### PR TITLE
update docs for substitution effect, income effect, and itemized deduction surtax switch. 

### DIFF
--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -1,7 +1,7 @@
 {   "_BE_inc":{
         "start_year": 2013,
         "long_name": "Income effect",
-        "description": "The taxpayer's taxable income changes according to the product of this parameter and the change in tax liability that would have occurred as a result of specified policy change in the absence of any behavioral response.",
+        "description": "Change in the demand for leisure (negative of labor supply) per penny of change in after tax income, evaluated at the PlanX level of income and deductions. That is, the work response to a lump sum tax.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0]

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -1,7 +1,7 @@
 {   "_BE_inc":{
         "start_year": 2013,
         "long_name": "Income effect",
-        "description": "The taxpayer's taxable income changes according to the product of this parameter and the change in tax liabilitiy that would have occured as a result of specified policy change in the abscence of any behavioral response.",
+        "description": "The taxpayer's taxable income changes according to the product of this parameter and the change in tax liability that would have occurred as a result of specified policy change in the absence of any behavioral response.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0]

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -1,7 +1,7 @@
 {   "_BE_inc":{
         "start_year": 2013,
         "long_name": "Income effect",
-        "description": "Change in the demand for leisure (negative of labor supply) per penny of change in after tax income, evaluated at the PlanX level of income and deductions. That is, the work response to a lump sum tax.",
+        "description": "Change in the demand for leisure (negative of labor supply) per penny of change in after tax income, evaluated at the pre-policy-change level of income and deductions. That is, the work response to a lump sum tax.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0]

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -1,7 +1,7 @@
 {   "_BE_inc":{
         "start_year": 2013,
         "long_name": "Income effect",
-        "description": "Behavior effect",
+        "description": "The taxpayer's taxable income changes according to the product of this parameter and the change in tax liabilitiy that would have occured as a result of specified policy change in the abscence of any behavioral response.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0]
@@ -9,7 +9,7 @@
     "_BE_sub":{
         "start_year": 2013,
         "long_name": "Substitution effect",
-        "description": "Behavior effect",
+        "description": "The taxpayer's taxable income changes according to the product of this parameter, the taxpayer's taxable income before the policy change, and the percent change in the after tax rate (1-MTR). ",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0]

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -394,8 +394,8 @@
                     [258250, 	309900,   154950,     284050, 		  309900,  154950]]
     },
     "_ID_BenefitSurtax_Switch":{
-        "long_name": "Switch for manipulating itemized deduction benefit surtax",
-	"description": "This parameter is specified by items and year. ",
+        "long_name": "Deductions subject to the surtax on itemized deduction benefits",
+	"description": "The surtax on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter. ",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,


### PR DESCRIPTION
I added descriptions for the:

income effect:

"The taxpayer's taxable income changes according to the product of this parameter and the change in tax liability that would have occurred as a result of specified policy change in the absence of any behavioral response."

and the substitution effect:

"The taxpayer's taxable income changes according to the product of this parameter, the taxpayer's taxable income before the policy change, and the percent change in the after tax rate (1-MTR)." 

I also changed the title of the long_name of ID_BenefitSurtax_switch to 

"The surtax on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter."

and I added a description of the ID_BenefitSurtax_switch:

"The surtax on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter."

I think it would be helpful to add a discussion of the elasticity of taxable income more generally, but for now I just wanted to state exactly what the parameters do. 

cc @feenberg, @martinholmer 

