### PR TITLE
Marginal tax rate function bug fix

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -274,9 +274,9 @@ class Calculator(object):
 
         # Calculate the tax change with a marginal decrease in income.
         setattr(self.records, income_type_string,
-                income_type - 2 * finite_diff)
+                income_type - finite_diff)
         setattr(self.records, 'e00200',
-                earnings_type - 2 * finite_diff)
+                earnings_type - finite_diff)
         self.calc_all()
 
         _ospctax_down = copy.deepcopy(self.records._ospctax)
@@ -301,8 +301,8 @@ class Calculator(object):
 
         # Reset the income_type to its starting point to avoid
         # unintended consequences.
-        setattr(self.records, income_type_string, income_type + finite_diff)
-        setattr(self.records, 'e00200', earnings_type + finite_diff)
+        setattr(self.records, income_type_string, income_type)
+        setattr(self.records, 'e00200', earnings_type)
         self.calc_all()
 
         # Choose the more modest effect of either adding or subtracting income


### PR DESCRIPTION
Variable `earnings_type` saves the original `e00200` (Wage and Salaries) values and remains the same throughout the MTR calculation. But this variable was considered as the changed `e00200` attribute value in current master. Thus one extra dollar was deducted in the downside scenario and another extra dollar was added in the reset step. This PR fixed this issue. @MattHJensen Could you review?