### PR TITLE
Update contents of six .taxdiffs files following recent mtr() change

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -273,10 +273,8 @@ class Calculator(object):
         delta_combined_taxes_up = _combined_taxes_up - _combined_taxes_base
 
         # Calculate the tax change with a marginal decrease in income.
-        setattr(self.records, income_type_string,
-                income_type - finite_diff)
-        setattr(self.records, 'e00200',
-                earnings_type - finite_diff)
+        setattr(self.records, income_type_string, income_type - finite_diff)
+        setattr(self.records, 'e00200', earnings_type - finite_diff)
         self.calc_all()
 
         _ospctax_down = copy.deepcopy(self.records._ospctax)

--- a/taxcalc/validation/a13.taxdiffs
+++ b/taxcalc/validation/a13.taxdiffs
@@ -1,5 +1,4 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7     58     32    -15.00 [305]
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9     13      0      0.90 [2158]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    217     54    -27.75 [15248]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19    209    209     -0.01 [36]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 25    115    115      0.01 [2574]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 26      2      0  -2900.00 [95197]

--- a/taxcalc/validation/a14.taxdiffs
+++ b/taxcalc/validation/a14.taxdiffs
@@ -1,5 +1,4 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7     68     41    -15.00 [7760]
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9     10      0      0.90 [19502]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    235     63    -27.75 [33059]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19    175    175     -0.01 [5713]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 22      1      1     -0.01 [85601]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 23      1      1      0.01 [85601]

--- a/taxcalc/validation/b13.taxdiffs
+++ b/taxcalc/validation/b13.taxdiffs
@@ -1,5 +1,4 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7     76     45    -18.50 [11768]
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      9      0      0.90 [11809]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    207     58    -27.75 [88755]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17     59      0  68000.00 [30152]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18     59      0 -19140.00 [78456]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19    227    168  -1978.50 [78456]

--- a/taxcalc/validation/b14.taxdiffs
+++ b/taxcalc/validation/b14.taxdiffs
@@ -1,5 +1,4 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7     51     33     15.00 [2924]
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      4      0      0.90 [22073]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    175     54    -22.08 [51136]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17     50      0  54800.00 [95002]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18     49      0 -19850.00 [16233]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19    151    102  -2070.00 [16233]

--- a/taxcalc/validation/c13.taxdiffs
+++ b/taxcalc/validation/c13.taxdiffs
@@ -1,7 +1,5 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    352     49    -18.50 [11610]
-      #big_vardiffs_with_big_inctax_diff=              277
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      6      0      0.90 [6453]
-      #big_vardiffs_with_big_inctax_diff=                1
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    490     61    -27.75 [33442]
+      #big_vardiffs_with_big_inctax_diff=              283
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17    181      0  74000.00 [48834]
       #big_vardiffs_with_big_inctax_diff=               68
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18    180      0 -17112.50 [20907]

--- a/taxcalc/validation/c14.taxdiffs
+++ b/taxcalc/validation/c14.taxdiffs
@@ -1,7 +1,5 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    356     42     15.00 [9977]
-      #big_vardiffs_with_big_inctax_diff=              297
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      8      0      0.90 [1527]
-      #big_vardiffs_with_big_inctax_diff=                2
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    494     62    -22.08 [25488]
+      #big_vardiffs_with_big_inctax_diff=              308
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17    192      0  69000.00 [83852]
       #big_vardiffs_with_big_inctax_diff=               68
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18    192      0 -22600.00 [54933]


### PR DESCRIPTION
Recent changes in Calculator mtr() method --- see pull request #422 --- cause minor changes in mtr output (ovar[7] and ovar[9]) generated by the validation/tests script.