### PR TITLE
Add parameter to exclude taxable interest income from AGI

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1112,6 +1112,19 @@
         "col_label": "",
         "value":     [3]        
     },
+    "_ALD_Interest_HC":{
+        "long_name": "Interest income haircut",
+	"description": "This pencentage can be applied to limit the interest income included in AGI. ",
+        "irs_ref": "Form 1040, line 8a",
+        "notes": "The final taxable interest amount will be (1- Haircut) * Interest. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value":     [0]        
+    },
     "_ALD_StudentLoan_HC":{
         "long_name": "Adjustment for student loan interest haircut",
 	"description": "This pencentage can be applied to limit the student loan interest adjustment allowed. ",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1116,7 +1116,7 @@
         "long_name": "Interest income exclusion",
 	"description": "This pencentage can be applied to limit the interest income included in AGI. ",
         "irs_ref": "Form 1040, line 8a",
-        "notes": "The final taxable interest amount will be (1- Haircut) * Interest. ",
+        "notes": "The final taxable interest amount will be (1- exclusion) * Interest. Even though this portion of interest wouldn't be included in AGI, it still contributes to Net Investment Income Tax and Earned Income Tax Credit.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1112,8 +1112,8 @@
         "col_label": "",
         "value":     [3]        
     },
-    "_ALD_Interest_HC":{
-        "long_name": "Interest income haircut",
+    "_ALD_Interest_ec":{
+        "long_name": "Interest income exclusion",
 	"description": "This pencentage can be applied to limit the interest income included in AGI. ",
         "irs_ref": "Form 1040, line 8a",
         "notes": "The final taxable interest amount will be (1- Haircut) * Interest. ",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -90,7 +90,7 @@ def Adj(e35300_0, e35600_0, e35910_0, e03150, e03210, e03600, e03260,
 
 
 @iterate_jit(nopython=True)
-def CapGains(e23250, e22250, e23660, _sep, _feided, FEI_ec_c, ALD_Interest_HC,
+def CapGains(e23250, e22250, e23660, _sep, _feided, FEI_ec_c, ALD_Interest_ec,
              ALD_StudentLoan_HC, f2555, e00200, e00300, e00600, e00700, e00800,
              e00900, e01100, e01200, e01400, e01700, e02000, e02100,
              e02300, e02600, e02610, e02800, e02540, e00400, e02400,
@@ -108,7 +108,7 @@ def CapGains(e23250, e22250, e23660, _sep, _feided, FEI_ec_c, ALD_Interest_HC,
     c02700 = min(_feided, FEI_ec_c * f2555)
 
     #
-    _ymod1 = (e00200 + (1 - ALD_Interest_HC) * e00300 + e00600 + e00700 +
+    _ymod1 = (e00200 + (1 - ALD_Interest_ec) * e00300 + e00600 + e00700 +
               e00800 + e00900 + c01000 + e01100 + e01200 + e01400 + e01700 +
               e02000 + e02100 + e02300 + e02600 + e02610 + e02800 - e02540)
     _ymod2 = e00400 + (0.50 * e02400) - c02900

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -90,7 +90,7 @@ def Adj(e35300_0, e35600_0, e35910_0, e03150, e03210, e03600, e03260,
 
 
 @iterate_jit(nopython=True)
-def CapGains(e23250, e22250, e23660, _sep, _feided, FEI_ec_c,
+def CapGains(e23250, e22250, e23660, _sep, _feided, FEI_ec_c, ALD_Interest_HC,
              ALD_StudentLoan_HC, f2555, e00200, e00300, e00600, e00700, e00800,
              e00900, e01100, e01200, e01400, e01700, e02000, e02100,
              e02300, e02600, e02610, e02800, e02540, e00400, e02400,
@@ -108,9 +108,9 @@ def CapGains(e23250, e22250, e23660, _sep, _feided, FEI_ec_c,
     c02700 = min(_feided, FEI_ec_c * f2555)
 
     #
-    _ymod1 = (e00200 + e00300 + e00600 + e00700 + e00800 + e00900 + c01000 +
-              e01100 + e01200 + e01400 + e01700 + e02000 + e02100 + e02300 +
-              e02600 + e02610 + e02800 - e02540)
+    _ymod1 = (e00200 + (1 - ALD_Interest_HC) * e00300 + e00600 + e00700 +
+              e00800 + e00900 + c01000 + e01100 + e01200 + e01400 + e01700 +
+              e02000 + e02100 + e02300 + e02600 + e02610 + e02800 - e02540)
     _ymod2 = e00400 + (0.50 * e02400) - c02900
     _ymod3 = (1 - ALD_StudentLoan_HC) * e03210 + e03230 + e03240 + e02615
     _ymod = _ymod1 + _ymod2 + _ymod3


### PR DESCRIPTION
In this PR, one more haircut parameter is added for taxable interest income to exclude it from AGI and therefore regular tax. There're two relevant issues:

- Currently this parameter is named as `_ALD_Interest_HC`, which means above-the-line deduction haircut for interest income. But obviously interest income is not a deduction. On top of that, I'm not quite sure whether this is technically a haircut. Algebra is pretty simple for this parameter, but asking for naming advice. @MattHJensen @martinholmer @feenberg 

- @MattHJensen mentioned that all this kind of parameters would influence AGI amount. We want to maintain the AGI decile/bins the same as current law for easy comparison. To make sure our tables use the same set of AGI results, I'm going to create a new function calculating and storing current law AGI in a separate PR. Have not started to implement it yet. Welcome any comments/suggestions.