### PR TITLE
Move read-JSON-reform-file capabilities to Policy class

### DIFF
--- a/taxcalc/parameters_base.py
+++ b/taxcalc/parameters_base.py
@@ -159,7 +159,7 @@ class ParametersBase(object):
             if num_values <= nyrs:
                 # val should be the single start_year value
                 rawval = getattr(ppo, name[1:])
-                if isinstance(rawval, np.core.ndarray):
+                if isinstance(rawval, np.ndarray):
                     val = rawval.tolist()
                 else:
                     val = rawval
@@ -361,11 +361,11 @@ class ParametersBase(object):
         If necessary, pad out additional years by increasing the last given
         year using the given inflation_rates list.
         """
-        if isinstance(x, np.core.ndarray):
+        if isinstance(x, np.ndarray):
             if len(x) >= num_years:
                 return x
             else:
-                ans = np.core.zeros(num_years, dtype='f8')
+                ans = np.zeros(num_years, dtype='f8')
                 ans[:len(x)] = x
                 if inflate:
                     extra = []
@@ -380,7 +380,7 @@ class ParametersBase(object):
 
                 ans[len(x):] = extra
                 return ans.astype(x.dtype, casting='unsafe')
-        return ParametersBase.expand_1D(np.core.array([x]),
+        return ParametersBase.expand_1D(np.array([x]),
                                         inflate,
                                         inflation_rates,
                                         num_years)
@@ -393,7 +393,7 @@ class ParametersBase(object):
         number of rows. For each expanded row, we inflate using the given
         inflation rates list.
         """
-        if isinstance(x, np.core.ndarray):
+        if isinstance(x, np.ndarray):
             # Look for -1s and create masks if present
             last_good_row = -1
             keep_user_data_mask = []
@@ -402,7 +402,7 @@ class ParametersBase(object):
             for row in x:
                 keep_user_data_mask.append([1 if i != -1 else 0 for i in row])
                 keep_calc_data_mask.append([0 if i != -1 else 1 for i in row])
-                if not np.core.any(row == -1):
+                if not np.any(row == -1):
                     last_good_row += 1
                 else:
                     has_nones = True
@@ -411,20 +411,19 @@ class ParametersBase(object):
             else:
                 if has_nones:
                     c = x[:last_good_row + 1]
-                    keep_user_data_mask = np.core.array(keep_user_data_mask)
-                    keep_calc_data_mask = np.core.array(keep_calc_data_mask)
+                    keep_user_data_mask = np.array(keep_user_data_mask)
+                    keep_calc_data_mask = np.array(keep_calc_data_mask)
 
                 else:
                     c = x
-                ans = np.core.zeros((num_years, c.shape[1]))
+                ans = np.zeros((num_years, c.shape[1]))
                 ans[:len(c), :] = c
                 if inflate:
                     extra = []
                     cur = c[-1]
                     for i in range(0, num_years - len(c)):
                         inf_idx = i + len(c) - 1
-                        cur = np.core.array(cur *
-                                            (1. + inflation_rates[inf_idx]))
+                        cur = np.array(cur * (1. + inflation_rates[inf_idx]))
                         extra.append(cur)
                 else:
                     extra = [c[-1, :] for i in
@@ -437,7 +436,7 @@ class ParametersBase(object):
                     user_vals = x * keep_user_data_mask
                     ans = ans + user_vals
                 return ans.astype(c.dtype, casting='unsafe')
-        return ParametersBase.expand_2D(np.core.array(x), inflate,
+        return ParametersBase.expand_2D(np.array(x), inflate,
                                         inflation_rates, num_years)
 
     @staticmethod
@@ -493,7 +492,7 @@ class ParametersBase(object):
         -------
         expanded numpy array
         """
-        x = np.core.array(ParametersBase.strip_Nones(x))
+        x = np.array(ParametersBase.strip_Nones(x))
         try:
             if len(x.shape) == 1:
                 return ParametersBase.expand_1D(x, inflate, inflation_rates,

--- a/taxcalc/parameters_base.py
+++ b/taxcalc/parameters_base.py
@@ -1,3 +1,6 @@
+"""
+OSPC Tax-Calculator abstract base parameters class.
+"""
 import os
 import json
 import numpy as np
@@ -44,57 +47,6 @@ class ParametersBase(object):
             return params
         else:
             return {name: data['value'] for name, data in params.items()}
-
-    # ----- begin private methods of ParametersBase class -----
-
-    @staticmethod
-    def _revised_default_data(params, start_year, nyrs, ppo):
-        """
-        Return revised default parameter data.
-
-        Parameters
-        ----------
-        params: dictionary of NAME:DATA pairs for each parameter
-            as defined in calling default_data staticmethod.
-
-        start_year: int
-            as defined in calling default_data staticmethod.
-
-        nyrs: int
-            as defined in calling default_data staticmethod.
-
-        ppo: Policy object
-            as defined in calling default_data staticmethod.
-
-        Returns
-        -------
-        params: dictionary of revised parameter data
-
-        Notes
-        -----
-        This staticmethod is called from default_data staticmethod in
-        order to reduce the complexity of the default_data staticmethod.
-        """
-        import numpy as np
-        start_year_str = '{}'.format(start_year)
-        for name, data in params.items():
-            data['start_year'] = start_year
-            values = data['value']
-            num_values = len(values)
-            if num_values <= nyrs:
-                # val should be the single start_year value
-                rawval = getattr(ppo, name[1:])
-                if isinstance(rawval, np.ndarray):
-                    val = rawval.tolist()
-                else:
-                    val = rawval
-                data['value'] = [val]
-                data['row_label'] = [start_year_str]
-            else:  # if num_values > nyrs
-                # val should extend beyond the start_year value
-                data['value'] = data['value'][(nyrs - 1):]
-                data['row_label'] = data['row_label'][(nyrs - 1):]
-        return params
 
     def __init__(self, *args, **kwargs):
         msg = 'Override __init__ and call self.initialize from it.'
@@ -168,6 +120,56 @@ class ParametersBase(object):
         for name in self._vals:
             arr = getattr(self, name)
             setattr(self, name[1:], arr[year_zero_indexed])
+
+    # ----- begin private methods of ParametersBase class -----
+
+    @staticmethod
+    def _revised_default_data(params, start_year, nyrs, ppo):
+        """
+        Return revised default parameter data.
+
+        Parameters
+        ----------
+        params: dictionary of NAME:DATA pairs for each parameter
+            as defined in calling default_data staticmethod.
+
+        start_year: int
+            as defined in calling default_data staticmethod.
+
+        nyrs: int
+            as defined in calling default_data staticmethod.
+
+        ppo: Policy object
+            as defined in calling default_data staticmethod.
+
+        Returns
+        -------
+        params: dictionary of revised parameter data
+
+        Notes
+        -----
+        This staticmethod is called from default_data staticmethod in
+        order to reduce the complexity of the default_data staticmethod.
+        """
+        start_year_str = '{}'.format(start_year)
+        for name, data in params.items():
+            data['start_year'] = start_year
+            values = data['value']
+            num_values = len(values)
+            if num_values <= nyrs:
+                # val should be the single start_year value
+                rawval = getattr(ppo, name[1:])
+                if isinstance(rawval, np.core.ndarray):
+                    val = rawval.tolist()
+                else:
+                    val = rawval
+                data['value'] = [val]
+                data['row_label'] = [start_year_str]
+            else:  # if num_values > nyrs
+                # val should extend beyond the start_year value
+                data['value'] = data['value'][(nyrs - 1):]
+                data['row_label'] = data['row_label'][(nyrs - 1):]
+        return params
 
     @classmethod
     def _params_dict_from_json_file(cls):
@@ -286,6 +288,10 @@ class ParametersBase(object):
         if year != self.current_year:
             msg = 'YEAR={} in year_mods is not equal to current_year={}'
             raise ValueError(msg.format(year, self.current_year))
+        # check that MODS is a dictionary
+        if not isinstance(year_mods[year], dict):
+            msg = 'mods in year_mods is not a dictionary'
+            raise ValueError(msg)
         # implement reform provisions included in the single YEAR:MODS pair
         num_years_to_expand = (self.start_year + self.num_years) - year
         if hasattr(self, '_inflation_rates'):
@@ -293,8 +299,8 @@ class ParametersBase(object):
                          for i in range(0, num_years_to_expand)]
         else:
             inf_rates = None
-        all_names = set(year_mods[year].keys())
-        used_names = set()  # set of used parameter names in year_mods dict
+        all_names = set(year_mods[year].keys())  # no duplicate keys in a dict
+        used_names = set()  # set of used parameter names in MODS dict
         for name, values in year_mods[year].items():
             # determine indexing status of parameter with name for year
             if name.endswith('_cpi'):
@@ -306,21 +312,13 @@ class ParametersBase(object):
                 raise ValueError(msg.format(name))
             name_plus_cpi = name + '_cpi'
             if name_plus_cpi in year_mods[year].keys():
+                used_names.add(name_plus_cpi)
                 indexed = year_mods[year].get(name_plus_cpi)
                 self._vals[name]['cpi_inflated'] = indexed  # remember status
-                if name_plus_cpi in used_names:
-                    msg = 'parameter {} used twice in year_mods for year {}'
-                    raise ValueError(msg.format(name_plus_cpi, year))
-                else:
-                    used_names.add(name_plus_cpi)
             else:
                 indexed = vals_indexed
             # set post-reform values of parameter with name
-            if name in used_names:
-                msg = 'parameter {} used twice in year_mods for year {}'
-                raise ValueError(msg.format(name, year))
-            else:
-                used_names.add(name)
+            used_names.add(name)
             cval = getattr(self, name, None)
             if cval is None:
                 msg = 'parameter {} in year_mods for year [] is unknown'
@@ -334,6 +332,7 @@ class ParametersBase(object):
         # parameter names ending in _cpi were handled above
         unused_names = all_names - used_names
         for name in unused_names:
+            used_names.add(name)
             pname = name[:-4]  # root parameter name
             if pname not in self._vals:
                 msg = 'root parameter name {} not in values dictionary'
@@ -350,16 +349,8 @@ class ParametersBase(object):
                                      inflation_rates=inf_rates,
                                      num_years=num_years_to_expand)
             cval[(year - self.start_year):] = nval
-            if name in used_names:
-                msg = 'parameter {} used twice in year_mods for year {}'
-                raise ValueError(msg.format(name, year))
-            else:
-                used_names.add(name)
-        # check that all names in year_mods[year] dictionary have been used
-        if len(used_names) != len(year_mods[year]):
-            msg = 'length of used_names={} != len(year_mods)={} for year {}'
-            raise ValueError(msg.format(len(used_names),
-                                        len(year_mods[year]), year))
+        # confirm that all names have been used
+        assert len(used_names) == len(all_names)
         # implement updated parameters for year
         self.set_year(year)
 
@@ -370,11 +361,11 @@ class ParametersBase(object):
         If necessary, pad out additional years by increasing the last given
         year using the given inflation_rates list.
         """
-        if isinstance(x, np.ndarray):
+        if isinstance(x, np.core.ndarray):
             if len(x) >= num_years:
                 return x
             else:
-                ans = np.zeros(num_years, dtype='f8')
+                ans = np.core.zeros(num_years, dtype='f8')
                 ans[:len(x)] = x
                 if inflate:
                     extra = []
@@ -389,7 +380,7 @@ class ParametersBase(object):
 
                 ans[len(x):] = extra
                 return ans.astype(x.dtype, casting='unsafe')
-        return ParametersBase.expand_1D(np.array([x]),
+        return ParametersBase.expand_1D(np.core.array([x]),
                                         inflate,
                                         inflation_rates,
                                         num_years)
@@ -402,7 +393,7 @@ class ParametersBase(object):
         number of rows. For each expanded row, we inflate using the given
         inflation rates list.
         """
-        if isinstance(x, np.ndarray):
+        if isinstance(x, np.core.ndarray):
             # Look for -1s and create masks if present
             last_good_row = -1
             keep_user_data_mask = []
@@ -411,7 +402,7 @@ class ParametersBase(object):
             for row in x:
                 keep_user_data_mask.append([1 if i != -1 else 0 for i in row])
                 keep_calc_data_mask.append([0 if i != -1 else 1 for i in row])
-                if not np.any(row == -1):
+                if not np.core.any(row == -1):
                     last_good_row += 1
                 else:
                     has_nones = True
@@ -420,19 +411,20 @@ class ParametersBase(object):
             else:
                 if has_nones:
                     c = x[:last_good_row + 1]
-                    keep_user_data_mask = np.array(keep_user_data_mask)
-                    keep_calc_data_mask = np.array(keep_calc_data_mask)
+                    keep_user_data_mask = np.core.array(keep_user_data_mask)
+                    keep_calc_data_mask = np.core.array(keep_calc_data_mask)
 
                 else:
                     c = x
-                ans = np.zeros((num_years, c.shape[1]))
+                ans = np.core.zeros((num_years, c.shape[1]))
                 ans[:len(c), :] = c
                 if inflate:
                     extra = []
                     cur = c[-1]
                     for i in range(0, num_years - len(c)):
                         inf_idx = i + len(c) - 1
-                        cur = np.array(cur * (1. + inflation_rates[inf_idx]))
+                        cur = np.core.array(cur *
+                                            (1. + inflation_rates[inf_idx]))
                         extra.append(cur)
                 else:
                     extra = [c[-1, :] for i in
@@ -445,8 +437,8 @@ class ParametersBase(object):
                     user_vals = x * keep_user_data_mask
                     ans = ans + user_vals
                 return ans.astype(c.dtype, casting='unsafe')
-        return ParametersBase.expand_2D(np.array(x), inflate, inflation_rates,
-                                        num_years)
+        return ParametersBase.expand_2D(np.core.array(x), inflate,
+                                        inflation_rates, num_years)
 
     @staticmethod
     def strip_Nones(x):
@@ -501,7 +493,7 @@ class ParametersBase(object):
         -------
         expanded numpy array
         """
-        x = np.array(ParametersBase.strip_Nones(x))
+        x = np.core.array(ParametersBase.strip_Nones(x))
         try:
             if len(x.shape) == 1:
                 return ParametersBase.expand_1D(x, inflate, inflation_rates,

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -163,8 +163,8 @@ class Policy(ParametersBase):
                     raise ValueError(msg.format(skey))
                 else:
                     year = int(skey)
-                rdict[year] = (np.core.array(val) if isinstance(val, list)
-                               else val)
+                rdict[year] = (np.array(val)  # pylint: disable=no-member
+                               if isinstance(val, list) else val)
             reform_pkey_param[pkey] = rdict
         # convert reform_pkey_param dictionary to reform_pkey_year dictionary
         return Policy._reform_pkey_year(reform_pkey_param)

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -54,38 +54,6 @@ REFORM_CONTENTS = """
      "2020": true   // values in future years indexed with this year as base
     }
 }
-
-// The JSON above is translated into the following Python dictionary with
-// calendar year as the primary key, which is the data structure required
-// as input to the Policy class implement_reform(reform) method.
-//   reform = {
-//       2015: {
-//           '_AMT_tthd': [200000]
-//       },
-//       2016: {
-//           '_EITC_c': [[ 900, 5000,  8000, 9000]],
-//           '_II_em': [6000],
-//           '_II_em_cpi': False,
-//           '_SS_Earnings_c': [300000]
-//       },
-//       2017: {
-//           '_AMT_tthd': [300000],
-//           '_AMT_em_cpi': False
-//       },
-//       2018: {
-//           '_II_em': [7500],
-//           '_II_em_cpi': True,
-//           '_SS_Earnings_c': [500000]
-//       },
-//       2019: {
-//           '_EITC_c': [[1200, 7000, 10000, 12000]]
-//       },
-//       2020: {
-//           '_II_em': [9000],
-//           '_SS_Earnings_c': [700000],
-//           '_AMT_em_cpi': True
-//       }
-//   }
 """
 
 

--- a/taxcalc/validation/README.md
+++ b/taxcalc/validation/README.md
@@ -199,8 +199,8 @@ filing units, have been used to generate Internet TAXSIM OUTPUT files
 that are stored in the out-taxsim.zip file.  The `tests` bash script
 automates the four-step validation process described above.  The
 `tests` script takes longer to execute (roughly nine or ten minutes)
-than the unit tests in the taxcalc/tests directory (roughly one
-minute).  But if the content of the six ?1?.taxdiffs files that are
+than the unit tests in the taxcalc/tests directory (roughly one or two
+minutes).  But if the content of the six ?1?.taxdiffs files that are
 under version control are not modified by a `tests` execution, this a
 more thorough confirmation that Tax-Calculator logic has not changed.
 


### PR DESCRIPTION
These capabilities were originally developed as part of the SimpleTaxIO class development, but logically belong in the Policy class.

@MattHJensen and T.J. @talumbau,  Can you review and comment or merge into master?