### PR TITLE
[WIP] Streamline logic of Calculator class mtr() method

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -52,10 +52,10 @@ def behavior(calc_x, calc_y, update_income=update_income):
     """
 
     # Calculate marginal tax rates for plan x and plan y.
-    _, _, combined_mtr_x = calc_x.mtr('e00200p')
+    _, _, combined_mtr_x = calc_x.mtr()
     mtr_x = combined_mtr_x
 
-    _, _, combined_mtr_y = calc_y.mtr('e00200p')
+    _, _, combined_mtr_y = calc_y.mtr()
     mtr_y = combined_mtr_y
 
     # Calculate the percent change in after-tax rate.

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -216,17 +216,20 @@ class Calculator(object):
 
     def mtr(self, income_type_str='e00200p',
             finite_diff=0.01,
-            wrt_adjusted_income=True):
+            wrt_full_compensation=True):
         """
-        Calculates the marginal FICA, individual incom, and combined
-        tax rates for every tax filing unit.  The marginal tax rates
-        are approximated as the change in tax liability caused by a
-        small increase (the finite_diff) in income (specified by the
-        income_type_str) divided by that small increase in income.
-        If wrt_adjusted_income is true, then the marginal tax rates
-        are computed as the change in tax liability divided by the
-        change in total compensation caused by the small increase in
-        income.
+        Calculates the marginal FICA, individual income, and combined
+        tax rates for every tax filing unit.
+          The marginal tax rates are approximated as the change in tax
+        liability caused by a small increase (the finite_diff) in income
+        (specified by the income_type_str) divided by that small increase
+        in income, when wrt_full_compensation is false.
+          If wrt_full_compensation is true, then the marginal tax rates
+        are computed as the change in tax liability divided by the change
+        in total compensation caused by the small increase in income
+        (where the change in total compensation is the sum of the small
+        increase in income and any increase in the employer share of FICA
+        taxes caused by the small increase in income).
 
         Parameters
         ----------
@@ -238,9 +241,9 @@ class Calculator(object):
             specifies marginal amount to be added to income in order to
             calculate the marginal tax rate.
 
-        wrt_adjusted_income: boolean
+        wrt_full_compensation: boolean
             specifies whether or not marginal tax rates on earned income
-            are computed with respect to (wrt) changes in adjusted income
+            are computed with respect to (wrt) changes in total compensation
             that includes the employer share of OASDI+HI payroll taxes.
 
         Returns
@@ -286,7 +289,7 @@ class Calculator(object):
             self.records.e00200 = earnings_type
         self.calc_all()
         # specify optional adjustment for employer (er) OASDI+HI payroll taxes
-        if wrt_adjusted_income and income_type_str in mtr_ind_earnings_types:
+        if wrt_full_compensation and income_type_str in mtr_ind_earnings_types:
             adj = np.where(income_type <
                            self.policy.SS_Earnings_c,
                            0.5 * (self.policy.FICA_ss_trt +

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -114,7 +114,7 @@ class SimpleTaxIO(object):
                     self._output[lnum] = ovar
             if not no_marginal_tax_rates:
                 (mtr_fica, mtr_itax,
-                 _) = self._calc.mtr('e00200p', wrt_adjusted_income=False)
+                 _) = self._calc.mtr(wrt_full_compensation=False)
                 for idx in range(0, self._calc.records.dim):
                     indyr = cr_taxyr[idx]
                     if indyr == calcyr:

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -241,16 +241,10 @@ def test_Calculator_create_distribution_table():
 
 
 def test_calculate_mtr():
-    # Create a Policy object
     policy = Policy()
-
-    # Create a Records object
     puf = Records(TAX_DTA, weights=WEIGHTS, start_year=2009)
-
-    # Create a Calculator object
     calc = Calculator(policy=policy, records=puf)
-
-    (mtr_FICA, mtr_IIT, mtr) = calc.mtr('e00200p')
+    (mtr_FICA, mtr_IIT, mtr) = calc.mtr()
     assert type(mtr) == np.ndarray
     assert np.array_equal(mtr, mtr_FICA) == False
     assert np.array_equal(mtr_FICA, mtr_IIT) == False

--- a/taxcalc/validation/a13.taxdiffs
+++ b/taxcalc/validation/a13.taxdiffs
@@ -1,5 +1,6 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    193     14    -26.33 [23437]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7     38      7      6.25 [666]
       #big_vardiffs_with_big_inctax_diff=               30
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9     14      0      0.90 [2158]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19    377    377     -0.01 [147]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 25     58     58      0.01 [2574]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 27    203    173    315.75 [3776]

--- a/taxcalc/validation/a14.taxdiffs
+++ b/taxcalc/validation/a14.taxdiffs
@@ -1,5 +1,6 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    188     18    -27.75 [33059]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7     44      7      6.25 [15593]
       #big_vardiffs_with_big_inctax_diff=               36
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      7      0      0.90 [19502]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19    317    317     -0.01 [469]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 25     29     29      0.01 [89505]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 26      1      0   -700.00 [36539]

--- a/taxcalc/validation/b13.taxdiffs
+++ b/taxcalc/validation/b13.taxdiffs
@@ -1,5 +1,6 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    337     26    -18.50 [37304]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    179     18      6.25 [891]
       #big_vardiffs_with_big_inctax_diff=              161
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      7      0      0.90 [11809]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17      9      0 -26000.00 [59184]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18      9      0   9000.00 [59184]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19    679    670    903.75 [59184]

--- a/taxcalc/validation/b14.taxdiffs
+++ b/taxcalc/validation/b14.taxdiffs
@@ -1,5 +1,6 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    302     19    -22.08 [51136]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    163     14      6.25 [5658]
       #big_vardiffs_with_big_inctax_diff=              149
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      7      0      0.90 [10404]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17     11      0 -27750.00 [76434]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18     10      0 -10432.50 [95193]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19    654    644  -1043.25 [95193]

--- a/taxcalc/validation/c13.taxdiffs
+++ b/taxcalc/validation/c13.taxdiffs
@@ -1,5 +1,6 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    368     21    -27.75 [33442]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    194     16      6.25 [1742]
       #big_vardiffs_with_big_inctax_diff=              177
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      8      0      0.90 [6453]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17    149      0 -29900.00 [22228]
       #big_vardiffs_with_big_inctax_diff=                1
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18    148      0 -14900.00 [91655]

--- a/taxcalc/validation/c14.taxdiffs
+++ b/taxcalc/validation/c14.taxdiffs
@@ -1,5 +1,6 @@
-TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    317     21    -22.08 [25488]
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  7    162      7      6.25 [1172]
       #big_vardiffs_with_big_inctax_diff=              155
+TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9      6      0      0.90 [66327]
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17    159      0 -31900.00 [85540]
       #big_vardiffs_with_big_inctax_diff=                2
 TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18    159      0 -13400.00 [86672]


### PR DESCRIPTION
Change default finite_diff from one dollar to one cent and retain only the "up" calculations of marginal tax liabilities.  Also, revise the employer FICA adjustment logic in two ways: (1) make it can handle finite_diff values other than one dollar, and (2) fix problem with the calculation of the er_fica_adjustment variable, which previously used combined (not individual) earnings to determine whether over OASDI maximum taxable earnings level.

With regards to the marginal FICA tax rates in the new a13.taxdiffs file, see today's discussion under Issue #397.

@MattHJensen, can you check that I have revised the "employer FICA adjustment" logic correctly?
Also, check the long comment describing the rationale for this adjustment; I'm not sure I understand it well enough to have correctly described what is going on here.  Any alternative test you could suggest would be welcomed.