### PR TITLE
Tiny Enhancement of SIMTAX

### DIFF
--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -540,7 +540,7 @@ class SimpleTaxIO(object):
         recs.p22250[idx] = ivar[21]  # short-term capital gains (+/-)
         recs.p23250[idx] = ivar[22]  # long-term capital gains (+/-)
 
-    OVAR_NUM = 28
+    OVAR_NUM = 30
 
     @staticmethod
     def _extract_output(crecs, idx, ivar):
@@ -608,6 +608,8 @@ class SimpleTaxIO(object):
         # while TAXSIM ovar[28] explicitly excludes AMT liability, so
         # we have the following:
         ovar[28] = crecs.c05800[idx] - amt_liability
+        ovar[29] = 0.0  # test purpose, intermediate variable
+        ovar[30] = 0.0  # test purpose, intermediate variable
         return ovar
 
     def _write_output_file(self):
@@ -654,7 +656,9 @@ class SimpleTaxIO(object):
                 25: ' {:.2f}',
                 26: ' {:.2f}',
                 27: ' {:.2f}',
-                28: ' {:.2f}'}
+                28: ' {:.2f}',
+                29: ' {:.1f}',
+                30: ' {:.1f}'}
 
     @staticmethod
     def _write_output_line(output_dict, output_file):


### PR DESCRIPTION
While dealing with #438 , I found that having some intermediate variables printed out might be helpful in terms of debugging (please refer to the commit "debug strategy revealed" in that PR). And I was wondering can we add two extra optional variables in the output, namely [ovar29] and [ovar30]. Notice that I only kept one decimal point on purpose, hoping this would make them easier to be distinguished from the remaining 28 variables. 
@martinholmer What do you think? Does such enhancement make sense? Please take a look. 
(I was also thinking of incorporate such option into commend line, but my concern is that, in that case, the command might be a little bit tedious and most user might not be interested in such functionality)