### PR TITLE
Distribution table classifier

### DIFF
--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -350,6 +350,32 @@ def test_diff_table_sum_row():
                           tdiff2[non_digit_cols][-1:])
 
 
+def test_row_classifier():
+    # create a current-law Policy object and Calculator calc1
+    policy1 = Policy()
+    records1 = Records(data=TAX_DTA, weights=WEIGHTS, start_year=2009)
+    calc1 = Calculator(policy=policy1, records=records1)
+    calc1.calc_all()
+    calc1_s006 = create_distribution_table(calc1,
+                                           groupby="webapp_income_bins",
+                                           result_type="weighted_sum").s006
+
+    # create a policy-reform Policy object and Calculator calc2
+    reform = {2013: {"_ALD_StudentLoan_HC": [1]}}
+    policy2 = Policy()
+    policy2.implement_reform(reform)
+    records2 = Records(data=TAX_DTA, weights=WEIGHTS, start_year=2009)
+    calc2 = Calculator(policy=policy2, records=records2)
+    calc2.calc_all()
+    calc2_s006 = create_distribution_table(calc2,
+                                           groupby="webapp_income_bins",
+                                           result_type="weighted_sum",
+                                           baseline_calc=calc1).s006
+
+    # use weighted sum of weights in each cell to check classifer
+    npt.assert_array_equal(calc1_s006, calc2_s006)
+
+
 def test_expand_2D_already_filled():
 
     _II_brk2 = [[36000, 72250, 36500, 48600, 72500, 36250],

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -271,7 +271,8 @@ def weighted_avg_allcols(df, cols, income_measure='_expanded_income'):
 
 
 def create_distribution_table(calc, groupby, result_type,
-                              income_measure='_expanded_income'):
+                              income_measure='_expanded_income',
+                              baseline_calc=None):
     """
     Gets results given by the tax calculator, sorts them based on groupby, and
         manipulates them based on result_type. Returns these as a table
@@ -323,6 +324,15 @@ def create_distribution_table(calc, groupby, result_type,
 
     # weight of returns with positive Alternative Minimum Tax (AMT)
     res['num_returns_AMT'] = res['s006'].where(res['c09600'] > 0, 0)
+
+    if baseline_calc is not None:
+        if calc.current_year != baseline_calc.current_year:
+            msg = 'The baseline calculator is not on the same year as reform.'
+            raise ValueError(msg)
+        baseline_income_measure = income_measure + '_baseline'
+        res_base = results(baseline_calc)
+        res[baseline_income_measure] = res_base[income_measure]
+        income_measure = baseline_income_measure
 
     # sorts the data
     if groupby == "weighted_deciles":


### PR DESCRIPTION
This PR is replacing #440 which will be closed due to unexpected complications. In this PR, one more argument `baseline_calc` was added to function `create_distribution_table` in order to get the income measure from a baseline calculator. 

@talumbau The reason why we're doing this is that no matter what reform plans are passed in the calculator, we always want the row label classifiers to be the current law value. Even though many reforms won't change the AGI/Expanded Income values, some reforms (any plan involves haircut parameters) do change AGI and Expanded Income. Under these reforms, we should still group taxpayers using their original AGI/Expanded Income instead of the one under reform. 

So I added this `baseline_calc` to pass in the baseline data. I can definitely see this might increase the chance for users getting non-sense results, for example if they happen to pass in a non-baseline calculator or a baseline calculator not on the right year. I have only been able to add a check whether the current year attributes of two calculators are the same or not, but no clue how to check the 'baseline' part.

Anyways @MattHJensen Here're the results using the same reform `{2013:{"_ALD_StudentLoan_HC": [1]}}`. All the weights conform with master.

Baseline:
`create_distribution_table(calc1, groupby = "webapp_income_bins", result_type = "weighted_sum")`
<img width="668" alt="calc1_head" src="https://cloud.githubusercontent.com/assets/10549597/11017931/3896ef50-857f-11e5-9aaf-2403d4a0a9ef.png">
<img width="639" alt="calc1_tail" src="https://cloud.githubusercontent.com/assets/10549597/11017935/50737832-857f-11e5-8231-1ad8423e1f17.png">

Reform:
`create_distribution_table(calc2, groupby = "webapp_income_bins", result_type = "weighted_sum", baseline_calc=calc1)`
<img width="698" alt="calc2_tail" src="https://cloud.githubusercontent.com/assets/10549597/11017942/682bd9ec-857f-11e5-9187-e33992ebe5aa.png">

<img width="627" alt="calc2_head" src="https://cloud.githubusercontent.com/assets/10549597/11017938/5ea32e34-857f-11e5-9218-8b79f7a65e72.png">

Welcome any comments/suggestions! Thanks!
