### PR TITLE
Minor changes in validation/tests script and docs/source/*.rst files

### DIFF
--- a/docs/source/about_ospc.rst
+++ b/docs/source/about_ospc.rst
@@ -20,7 +20,7 @@ Projects
 OSPC's first project is building tools to analyze the budgetary and
 broader economic impact of taxes. These models are completely
 transparent and freely available to researchers across the
-country. Additionally, an easy-to-use online interfaces will allow
+country. Additionally, an easy-to-use online interface will allow
 students, policymakers, journalists, and informed citizens to interact
 with the models and learn for themselves about the effects of
 policies.

--- a/docs/source/code.rst
+++ b/docs/source/code.rst
@@ -1,7 +1,7 @@
 Source Code
 ===========
 
-The Tax Calculator's core capabilities are in the Python package
+The Tax-Calculator's core capabilities are in the Python package
 called taxcalc, the source code for which is located in the
 tax-calculator/taxcalc directory.
 
@@ -39,16 +39,34 @@ Module taxcalc.functions
 .. automodule:: taxcalc.functions
     :members:
 
-Module taxcalc.parameters
--------------------------
+Module taxcalc.growth
+---------------------
 
-.. automodule:: taxcalc.parameters
+.. automodule:: taxcalc.growth
+    :members:
+
+Module taxcalc.parameters_base
+------------------------------
+
+.. automodule:: taxcalc.parameters_base
+    :members:
+
+Module taxcalc.policy
+---------------------
+
+.. automodule:: taxcalc.policy
     :members:
 
 Module taxcalc.records
 ----------------------
 
 .. automodule:: taxcalc.records
+    :members:
+
+Module taxcalc.simpletaxio
+----------------------
+
+.. automodule:: taxcalc.simpletaxio
     :members:
 
 Module taxcalc.utils

--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -1,17 +1,17 @@
 Contributors
 ============
 
-Many people have contributed to the Tax Calculator, and we hope this
+Many people have contributed to the Tax-Calculator, and we hope this
 list continues to grow.
 
-Origins of OSPC Tax Calculator
-------------------------------
+Origins of Tax-Calculator
+-------------------------
 
-The Tax Calculator is derived from taxcalc.sas, a program written by
+The Tax-Calculator is derived from taxcalc.sas, a program written by
 Dan Feenberg (`NBER`_) and Inna Shapiro (`NBER`_).
 
-Contributors to OSPC Tax Calculator
------------------------------------
+Contributors to Tax-Calculator
+------------------------------
 
 Contributors include the following individuals:
 

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -1,7 +1,7 @@
 Micro Data
 ==========
 
-The Tax Calculator simulates federal income taxes for each tax filing
+The Tax-Calculator simulates federal income taxes for each tax filing
 unit in a sample that is representative of the US population.
 
 Description

--- a/docs/source/disclaimer.rst
+++ b/docs/source/disclaimer.rst
@@ -1,7 +1,7 @@
 Disclaimer
 ==========
 
-The Tax Calculator is currently under development.  Users should be
+The Tax-Calculator is currently under development.  Users should be
 forewarned that the taxcalc API (application programming interface)
 could change significantly.  Additionally, the implementation is
 subject to wild change.  Therefore, there is NO GUARANTEE OF ACCURACY.
@@ -9,6 +9,6 @@ THE CODE SHOULD NOT CURRENTLY BE USED FOR PUBLICATIONS, JOURNAL
 ARTICLES, OR RESEARCH PURPOSES.  Essentially, you should assume the
 calculations are unreliable until we finish the code re-architecture
 and have checked the results against other existing tax simulation
-models.  The Tax Calculator will have released versions, which will be
+models.  The Tax-Calculator will have released versions, which will be
 checked against existing code prior to release.  Stay tuned for an
 upcoming release!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,11 +1,11 @@
-OSPC Tax Calculator 
-===================
+Tax-Calculator 
+==============
 
-The Tax Calculator simulates the US federal individual income tax
+The Tax-Calculator simulates the US federal individual income tax
 system.  In conjunction with micro data that represent the US
-population and a set of behavioral assumptions, the Tax Calculator can
+population and a set of behavioral assumptions, the Tax-Calculator can
 be used to conduct revenue scoring and distributional analyses of tax
-policies.  The Tax Calculator is written in Python, an interpreted
+policies.  The Tax-Calculator is written in Python, an interpreted
 language that can execute on Windows, Mac, or Linux.
 
 Contents

--- a/docs/source/make_local_change.rst
+++ b/docs/source/make_local_change.rst
@@ -20,7 +20,7 @@ local tax-calculator directory.
 
 **1. Navigate to the relevant file and open it.**
 
-From your tax calculator directory, the path to the file that defines
+From your tax-calculator directory, the path to the file that defines
 the tax parameters is:
 
 .. code-block:: python

--- a/docs/source/parameter_taxonomy.rst
+++ b/docs/source/parameter_taxonomy.rst
@@ -101,5 +101,5 @@ Examples
 
 
 .. [1] Currently, the abbreviation for haircuts is uppercase in the
-       Tax Calculator; we will be changing it to lowercase in the
+       Tax-Calculator; we will be changing it to lowercase in the
        future and will update this page accordingly.

--- a/taxcalc/validation/tests
+++ b/taxcalc/validation/tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Executes current-law validation TESTS by calling test bash script.
+# Executes current-law & reform validation TESTS by calling test bash script.
 # .... check number of command-line arguments
 if [[ "$#" -gt 1 ]]; then
     echo "ERROR: can specify at most one command-line argument"
@@ -18,7 +18,7 @@ if [[ "$#" -eq 1 ]]; then
     fi
 fi
 # .... execute validation tests in parallel
-echo "STARTING WITH CURLAW TESTS : `date`"
+echo "STARTING WITH VALIDATION TESTS : `date`"
 if [[ "$ALLTESTS" == true ]] ; then
     ./test a13 &
     ./test a14 &
@@ -30,9 +30,9 @@ fi
 ./test c13 &
 ./test c14 &
 wait
-echo "FINISHED WITH CURLAW TESTS : `date`"
+echo "FINISHED WITH VALIDATION TESTS : `date`"
 echo "TEST RESULTS: any lines (starting with M) between the STARTING... and"
-echo "              FINISHING... lines above indicate test failure caused by"
+echo "              FINISHED... lines above indicate test failure caused by"
 echo "              the actual ???.taxdiffs results being different from the"
-echo "              expected results.  No M... lines implies tests passed."
+echo "              expected results; no M... lines implies tests passed."
 exit 0


### PR DESCRIPTION
Fix typo in validation/tests echo statement.  Revisions in docs/source do two things: (a) separate identity of Tax-Calculator from that of OSPC, and (b) update documentation to reflect changes in the structure of the source code over the past month or so.