### PR TITLE
Add consider_imputations argument to Records class constructor

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -15,24 +15,30 @@ class Records(object):
     Parameters
     ----------
     data: string or Pandas DataFrame
-        string describes CSV file in which records data reside
-        DataFrame already contains records data
+        string describes CSV file in which records data reside;
+        DataFrame already contains records data;
         default value is the string 'puf.csv'
 
     blowup_factors: string or Pandas DataFrame
-        string describes CSV file in which blowup factors reside
-        DataFrame already contains blowup factors
+        string describes CSV file in which blowup factors reside;
+        DataFrame already contains blowup factors;
         default value is filename of the default blowup factors
 
     weights: string or Pandas DataFrame
-        string describes CSV file in which weights reside
-        DataFrame already contains weights
+        string describes CSV file in which weights reside;
+        DataFrame already contains weights;
         default value is filename of the default weights
 
     start_year: None or integer
-        None implies current_year is set to value of FLPDYR for first unit
-        integer implies current_year is set to start_year
+        None implies current_year is set to value of FLPDYR for first unit;
+        integer implies current_year is set to start_year;
         default value is None
+
+    consider_imputations: boolean
+        True implies that if current_year (see start_year above) equals
+        PUF_YEAR (see below), then call _impute_variables() method;
+        False implies never call _impute_variables() method;
+        default value is True
 
     Raises
     ------
@@ -371,6 +377,7 @@ class Records(object):
                  blowup_factors=BLOWUP_FACTORS_PATH,
                  weights=WEIGHTS_PATH,
                  start_year=None,
+                 consider_imputations=True,
                  **kwargs):
 
         """
@@ -387,7 +394,7 @@ class Records(object):
             msg = ('Records.constructor start_year is neither None nor '
                    'an integer')
             raise ValueError(msg)
-        if self._current_year == Records.PUF_YEAR:
+        if consider_imputations and self._current_year == Records.PUF_YEAR:
             self._impute_variables()
 
     @property

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -473,7 +473,9 @@ class SimpleTaxIO(object):
         dict_list = [zero_dict for _ in range(0, len(self._input))]
         # use dict_list to create a Pandas DataFrame and Records object
         recsdf = pd.DataFrame(dict_list, dtype='int64')
-        recs = Records(data=recsdf, start_year=2013)
+        recs = Records(data=recsdf,
+                       start_year=self._policy.start_year,
+                       consider_imputations=False)
         assert recs.dim == len(self._input)
         # specify input for each tax filing unit in Records object
         lnum = 0
@@ -481,10 +483,8 @@ class SimpleTaxIO(object):
             lnum += 1
             SimpleTaxIO._specify_input(recs, idx, self._input[lnum],
                                        emulate_taxsim_2441_logic)
-        # create Calculator object for 2013 containing all tax filing units
-        assert recs.current_year == 2013
-        assert self._policy.current_year == 2013
-        return Calculator(policy=self._policy, records=recs)
+        # create Calculator object containing all tax filing units
+        return Calculator(policy=self._policy, records=recs, sync_years=False)
 
     @staticmethod
     def _specify_input(recs, idx, ivar, emulate_taxsim_2441_logic):

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -473,8 +473,7 @@ class SimpleTaxIO(object):
         dict_list = [zero_dict for _ in range(0, len(self._input))]
         # use dict_list to create a Pandas DataFrame and Records object
         recsdf = pd.DataFrame(dict_list, dtype='int64')
-        recs = Records(data=recsdf,
-                       start_year=self._policy.start_year,
+        recs = Records(data=recsdf, start_year=self._policy.start_year,
                        consider_imputations=False)
         assert recs.dim == len(self._input)
         # specify input for each tax filing unit in Records object

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -207,7 +207,7 @@ class SimpleTaxIO(object):
     @staticmethod
     def extract_output(crecs, idx):
         """
-        Extracts tax output from crecs object for filing unit with idx.
+        Extracts tax output from crecs object for one tax filing unit.
 
         Parameters
         ----------
@@ -215,7 +215,7 @@ class SimpleTaxIO(object):
             Records object embedded in Calculator object.
 
         idx: integer
-            crecs object index of tax filing unit with specified idx.
+            crecs object index of the one tax filing unit.
 
         Returns
         -------


### PR DESCRIPTION
The default value of the new argument is True, which was the implied logic before the addition, so that all code that calls the Records class constructor will work exactly as before.  This new constructor argument has been added to make explicit whether or not to do the variable imputations.  The addition of this argument makes the Records class constructor argument consider_imputations analogous to the Calculator class constructor argument sync_years.

Also, use this new argument to streamline logic of SimpleTaxIO class.

@MattHJensen and @Amy-Xu,  Please review to confirm that this addition to the Records class constructor does not distrupt any existing uses of the Records class.