### PR TITLE
Earning split issue fixed

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -739,7 +739,7 @@ class Records(object):
                          self.wage_head + self.wage_spouse,
                          0)
         self._earning_split = np.where(total != 0,
-                                       self.wage_head / total, 1)
+                                       (self.wage_head * 1.0) / total, 1.0)
         self.e00200p = self._earning_split * self.e00200
         self.e00200s = (1 - self._earning_split) * self.e00200
 


### PR DESCRIPTION
This PR deals with issue #469 . The `_earning_split` variable was previously of integer type so that the earning split functionality was correctly implemented in the calculator. By multiplying a constant of float type, we are now doing the division in the right way. See the table for some simple verification:

|Observation|Earning Split Value|
|-----|------|
|0|    1.000000|
|1  |  1.000000|
|2  |  1.000000|
|3 |   0.619925|
|4  |  1.000000|
|5  |  0.619925|
|6 |   1.000000|
|7    |0.022172|
|8  |  0.741935|
|9 |   1.000000|

@MattHJensen @martinholmer Please take a look. 