### PR TITLE
Personal refundable credit phaseout

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -958,7 +958,7 @@
     },
     "_ID_prt":{
         "long_name": "Itemized deduction phaseout rate (Pease)",
-	    "description": "Taxpayers will not be eligible to deduct the full amount of itemized deduction if their AGI is above the phaseout start. The deductible portion would be decreased at this rate for each dollar exceeding the start.",
+	"description": "Taxpayers will not be eligible to deduct the full amount of itemized deduction if their AGI is above the phaseout start. The deductible portion would be decreased at this rate for each dollar exceeding the start.",
         "irs_ref": "Schedule A, line 29, instructions. ",
         "notes": "This phaseout rate cannot be lower than 0.03 for each dollar, due to limited data on non-itemizers.",
         "start_year": 2013,
@@ -1410,7 +1410,7 @@
     },
         "_II_credit":{
         "long_name": "Personal refundable credit",
-	"description": "",
+	"description": "This credit amount is fully refundable, phased out based on taxable income. ",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -1423,7 +1423,7 @@
      },
         "_II_credit_ps":{
         "long_name": "Personal refundable credit phaseout start",
-	"description": "",
+	"description": "The Personal Refundable credit amount will be reduced for taxpayers with taxable income higher than this level.",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -1436,7 +1436,7 @@
      },
         "_II_credit_prt":{
         "long_name": "Personal refundable credit phaseout rate",
-	"description": "",
+	"description": "The Personal Refundable credit amount will be reduced at this rate for each dollor of taxable income exceeding the thresholds.",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -517,8 +517,8 @@ def Personal_Credit(c00100, MARS, II_credit, II_credit_ps, II_credit_prt):
     _personal_credit = II_credit[MARS - 1]
 
     # phaseout using AGI
-    if c00100 > II_credit_ps[MARS - 1]:
-        credit_phaseout = II_credit_prt * (c00100 - II_credit_ps[MARS - 1])
+    if c04500 > II_credit_ps[MARS - 1]:
+        credit_phaseout = II_credit_prt * (c04500 - II_credit_ps[MARS - 1])
     else:
         credit_phaseout = 0.0
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -580,7 +580,7 @@ def Personal_Credit(c04500, MARS, II_credit, II_credit_ps, II_credit_prt):
     # full amount as defined in the parameter
     _personal_credit = II_credit[MARS - 1]
 
-    # phaseout using AGI
+    # phaseout using taxable income
     if c04500 > II_credit_ps[MARS - 1]:
         credit_phaseout = II_credit_prt * (c04500 - II_credit_ps[MARS - 1])
     else:

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -512,22 +512,6 @@ def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
 
 
 @iterate_jit(nopython=True, puf=False)
-def Personal_Credit(c00100, MARS, II_credit, II_credit_ps, II_credit_prt):
-    # full amount as defined in the parameter
-    _personal_credit = II_credit[MARS - 1]
-
-    # phaseout using AGI
-    if c04500 > II_credit_ps[MARS - 1]:
-        credit_phaseout = II_credit_prt * (c04500 - II_credit_ps[MARS - 1])
-    else:
-        credit_phaseout = 0.0
-
-    _personal_credit = _personal_credit - credit_phaseout
-
-    return _personal_credit
-
-
-@iterate_jit(nopython=True, puf=False)
 def TaxInc(c00100, c04470, c04100, _standard, e37717, c21060, c21040,
            e04470, c04200, c04500, c04600, x04500,
            e04805, t04470, f6251, _exact, _feided, c04800, MARS,
@@ -589,6 +573,22 @@ def TaxInc(c00100, c04470, c04100, _standard, e37717, c21060, c21040,
     return (c04470, _othded, c04100,
             c04500, c04800, c60000, _amtstd, _taxinc,
             _feitax, _oldfei)
+
+
+@iterate_jit(nopython=True, puf=False)
+def Personal_Credit(c04500, MARS, II_credit, II_credit_ps, II_credit_prt):
+    # full amount as defined in the parameter
+    _personal_credit = II_credit[MARS - 1]
+
+    # phaseout using AGI
+    if c04500 > II_credit_ps[MARS - 1]:
+        credit_phaseout = II_credit_prt * (c04500 - II_credit_ps[MARS - 1])
+    else:
+        credit_phaseout = 0.0
+
+    _personal_credit = _personal_credit - credit_phaseout
+
+    return _personal_credit
 
 
 @iterate_jit(nopython=True)


### PR DESCRIPTION
In this PR, taxable income replaced AGI as the base of phaseout for this refundable credit.

@MattHJensen Could you review?