### PR TITLE
Added epsilon to weighted_share_of_total function for diff tables

### DIFF
--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -15,6 +15,7 @@ from pandas.util.testing import assert_series_equal
 from numba import jit, vectorize, guvectorize
 from taxcalc import *
 from csv_to_ascii import ascii_output
+from taxcalc.utils import EPSILON
 
 # use 1991 PUF-like data to emulate current PUF, which is private
 TAX_DTA_PATH = os.path.join(CUR_PATH, '../../tax_all1991_puf.gz')
@@ -226,7 +227,7 @@ def test_weighted_share_of_total():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
     diffs = grped.apply(weighted_share_of_total, 'tax_diff', 42.0)
-    exp = Series(data=[16.0 / (42. + 1e-3), 26.0 / (42.0 + 1e-3)],
+    exp = Series(data=[16.0 / (42. + EPSILON), 26.0 / (42.0 + EPSILON)],
                  index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -226,7 +226,8 @@ def test_weighted_share_of_total():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
     diffs = grped.apply(weighted_share_of_total, 'tax_diff', 42.0)
-    exp = Series(data=[16.0 / 42., 26.0 / 42.0], index=['a', 'b'])
+    exp = Series(data=[16.0 / (42. + 1e-3), 26.0 / (42.0 + 1e-3)],
+                 index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -396,6 +396,10 @@ def create_difference_table(calc1, calc2, groupby,
     res1 = results(calc1)
     res2 = results(calc2)
 
+    baseline_income_measure = income_measure + '_baseline'
+    res2[baseline_income_measure] = res1[income_measure]
+    income_measure = baseline_income_measure
+
     if groupby == "weighted_deciles":
         df = add_weighted_decile_bins(res2, income_measure=income_measure)
     elif groupby == "small_income_bins":

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -377,15 +377,21 @@ def create_difference_table(calc1, calc2, groupby,
     Gets results given by the two different tax calculators and outputs
         a table that compares the differing results.
         The table is sorted according the the groupby input.
+        Notice that you always needs to run calc_all() for each year
+        before generating diffs table from this function. You can check
+        what year your calculator is using the current_year attribute
+        of your calculator. (usage: calc1.current_year)
 
     Parameters
     ----------
-    calc1, the first Calculator object
-    calc2, the other Calculator object
-    groupby, String object
+    calc1: the baseline Calculator on year t
+    calc2: the reform Calculator on year t
+    groupby: String
         options for input: 'weighted_deciles', 'small_income_bins',
         'large_income_bins', 'webapp_income_bins'
         determines how the columns in the resulting DataFrame are sorted
+    income_measure: String
+        specifies the income type for row label classifer
 
 
     Returns

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -41,6 +41,7 @@ SMALL_INCOME_BINS = [-1e14, 0, 4999, 9999, 14999, 19999, 24999, 29999, 39999,
 
 WEBAPP_INCOME_BINS = [-1e14, 0, 9999, 19999, 29999, 39999, 49999, 74999, 99999,
                       199999, 499999, 1000000, 1e14]
+EPSILON = 1e-3
 
 
 def extract_array(f):
@@ -95,7 +96,7 @@ def weighted_perc_dec(agg, col_name):
 
 
 def weighted_share_of_total(agg, col_name, total):
-    return float(weighted_sum(agg, col_name)) / float(total)
+    return float(weighted_sum(agg, col_name)) / (float(total) + EPSILON)
 
 
 def add_weighted_decile_bins(df, income_measure='_expanded_income'):
@@ -394,6 +395,7 @@ def create_difference_table(calc1, calc2, groupby,
 
     res1 = results(calc1)
     res2 = results(calc2)
+
     if groupby == "weighted_deciles":
         df = add_weighted_decile_bins(res2, income_measure=income_measure)
     elif groupby == "small_income_bins":


### PR DESCRIPTION
This is similar to what we have in drop q, just to make sure that even when the tax liabilities aren't big enough, diff tables can still be generated.

@MattHJensen Have a few questions for this function:
- Is calc1 in the create_difference_table always the baseline? Is there any scenario where users want to compare diffs between two reform plans?

- In either case, which calculator should row label classifier come from, calc1 or calc2?

- Do we need to add any docs to let users know that if they ever want to see the diff in the reform year, they need to do increment_year accordingly and then calc_call()?

@talumbau just a heads up, Matt wants to have this merged before tomorrow's release. I should be able to have things fixed quickly after knowing what to do with the issues above. I'll let you know when I finish everything. Thanks!