### PR TITLE
Added haircut parameter for all taxes paid to state and local government

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -983,7 +983,7 @@
         "value":     [0.8]        
     },
     "_ID_StateLocalTax_HC":{
-        "long_name": "Deduction for state and local taxes haircut.",
+        "long_name": "State and local taxes (Income and Sales) deduction haircut.",
         "description": "This percentage reduces the state and local tax deduction." ,
         "irs_ref": "",
         "notes": "This parameter allows for the implementation of Option 51 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
@@ -995,11 +995,11 @@
         "col_label": "",
         "value": [0]
     },
-    "_ID_AllTaxPaid_HC":{
-        "long_name": "Deduction for all taxes paid at state and local level (Income, Sales, Real Estate, and Personal Property).",
-        "description": "This percentage reduces all taxes paid deduction." ,
+    "_ID_RealEstate_HC":{
+        "long_name": "Real estate taxes deduction haircut.",
+        "description": "This percentage reduces real estate taxes paid eligible to deduct in itemized deduction." ,
         "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction.",
+        "notes": "This parameter is currently used to eliminate real estate taxes paid itemized deduction.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -403,7 +403,7 @@
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "cpi_inflated": true,
-        "col_label": ["Medical", "StateLocal", "Casualty", "Miscellaneous", "Interest", "Charity"],        
+        "col_label": ["Medical", "AllTaxPaid", "Casualty", "Miscellaneous", "Interest", "Charity"],        
         "value":    [[true, 	   true,           true,          true,           true,      true]]
     },
      "_EITC_rt":{
@@ -987,6 +987,19 @@
         "description": "This percentage reduces the state and local tax deduction." ,
         "irs_ref": "",
         "notes": "This parameter allows for the implementation of Option 51 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0]
+    },
+    "_ID_AllTaxPaid_HC":{
+        "long_name": "Deduction for all taxes paid at state and local level (Income, Sales, Real Estate, and Personal Property).",
+        "description": "This percentage reduces all taxes paid deduction." ,
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -176,7 +176,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
             ID_Casualty_frt, ID_Casualty_HC, ID_Miscellaneous_frt,
             ID_Miscellaneous_HC, ID_Charity_crt_Cash, ID_Charity_crt_Asset,
             ID_prt, ID_crt, ID_StateLocalTax_HC, ID_Charity_frt,
-            ID_Charity_HC, ID_InterestPaid_HC, puf):
+            ID_Charity_HC, ID_InterestPaid_HC, ID_AllTaxPaid_HC, puf):
 
     """
     Itemized Deduction; Form 1040, Schedule A
@@ -254,7 +254,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
     c17000 = max(0, e17500 - c17750)
 
     # State and Local Income Tax, or Sales Tax
-    _statax = max(e18400, 0)
+    _statax = (1 - ID_StateLocalTax_HC) * max(e18400, 0)
     # _statax = max(e18450, max(e18400, e18425))
 
     # Other Taxes (including state and local)
@@ -298,7 +298,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
     # Gross Itemized Deductions
 
     c21060 = (e20900 + (1 - ID_Medical_HC) * c17000 +
-              (1 - ID_StateLocalTax_HC) * c18300 +
+              (1 - ID_AllTaxPaid_HC) * c18300 +
               (1 - ID_InterestPaid_HC) * c19200 +
               (1 - ID_Charity_HC) * c19700 +
               (1 - ID_Casualty_HC) * c20500 +
@@ -856,7 +856,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
          KT_c_Age, x62740, e62900, AMT_thd_MarriedS, _earned, e62600,
          AMT_em, AMT_prt, AMT_trt1, AMT_trt2, _cmbtp_itemizer,
          _cmbtp_standard, ID_StateLocalTax_HC, ID_Medical_HC,
-         ID_Miscellaneous_HC, puf):
+         ID_Miscellaneous_HC, ID_AllTaxPaid_HC, puf):
 
     # if e62720 != 0 and e24517 > 0:
     #    x62720 = e62720 - e24517
@@ -869,7 +869,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
     c60200 = min((1 - ID_Medical_HC) * c17000, 0.025 * _posagi)
     # if e60240 != 0 and e18300 > 0:
     #    x60240 = e60240 - e18300
-    c60240 = (1 - ID_StateLocalTax_HC) * c18300 + x60240
+    c60240 = (1 - ID_AllTaxPaid_HC) * c18300 + x60240
     # if e60220 != 0 and e20800 > 0:
     #    x60220 = e60220 - e20800
     c60220 = (1 - ID_Miscellaneous_HC) * c20800 + x60220
@@ -913,9 +913,9 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
             _cmbtp = _cmbtp_itemizer
         else:
             _cmbtp = 0.
+        taxes_paid = (1 - ID_StateLocalTax_HC) * max(0, e18400) + e18500
         c62100 = (c00100 - c04470 + max(0., min((1 - ID_Medical_HC) * c17000,
-                  0.025 * c00100)) +
-                  (1 - ID_StateLocalTax_HC) * (max(0, e18400) + e18500) -
+                  0.025 * c00100)) + (1 - ID_AllTaxPaid_HC) * taxes_paid -
                   c60260 + (1 - ID_Miscellaneous_HC) * c20800 - c21040)
         c62100 += _cmbtp
 
@@ -1702,7 +1702,7 @@ def BenefitSurtax(calc):
         # hard code the reform
         nobenefits_calc.policy.ID_Medical_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[0])
-        nobenefits_calc.policy.ID_StateLocalTax_HC = \
+        nobenefits_calc.policy.ID_AllTaxPaid_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[1])
         nobenefits_calc.policy.ID_casualty_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[2])

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -915,7 +915,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
             _cmbtp = 0.
         c62100 = (c00100 - c04470 + max(0., min((1 - ID_Medical_HC) * c17000,
                   0.025 * c00100)) +
-                  (1 - ID_StateLocalTax_HC) * max(0, e18400) + e18500 -
+                  (1 - ID_StateLocalTax_HC) * (max(0, e18400) + e18500) -
                   c60260 + (1 - ID_Miscellaneous_HC) * c20800 - c21040)
         c62100 += _cmbtp
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -176,7 +176,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
             ID_Casualty_frt, ID_Casualty_HC, ID_Miscellaneous_frt,
             ID_Miscellaneous_HC, ID_Charity_crt_Cash, ID_Charity_crt_Asset,
             ID_prt, ID_crt, ID_StateLocalTax_HC, ID_Charity_frt,
-            ID_Charity_HC, ID_InterestPaid_HC, ID_AllTaxPaid_HC, puf):
+            ID_Charity_HC, ID_InterestPaid_HC, ID_RealEstate_HC, puf):
 
     """
     Itemized Deduction; Form 1040, Schedule A
@@ -255,10 +255,10 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
 
     # State and Local Income Tax, or Sales Tax
     _statax = (1 - ID_StateLocalTax_HC) * max(e18400, 0)
-    # _statax = max(e18450, max(e18400, e18425))
 
     # Other Taxes (including state and local)
-    c18300 = _statax + e18500 + e18800 + e18900
+    real_estate = (1 - ID_RealEstate_HC) * e18500
+    c18300 = _statax + real_estate + e18800 + e18900
 
     # Casualty
     if e20500 > 0:
@@ -297,8 +297,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
 
     # Gross Itemized Deductions
 
-    c21060 = (e20900 + (1 - ID_Medical_HC) * c17000 +
-              (1 - ID_AllTaxPaid_HC) * c18300 +
+    c21060 = (e20900 + (1 - ID_Medical_HC) * c17000 + c18300 +
               (1 - ID_InterestPaid_HC) * c19200 +
               (1 - ID_Charity_HC) * c19700 +
               (1 - ID_Casualty_HC) * c20500 +
@@ -856,7 +855,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
          KT_c_Age, x62740, e62900, AMT_thd_MarriedS, _earned, e62600,
          AMT_em, AMT_prt, AMT_trt1, AMT_trt2, _cmbtp_itemizer,
          _cmbtp_standard, ID_StateLocalTax_HC, ID_Medical_HC,
-         ID_Miscellaneous_HC, ID_AllTaxPaid_HC, puf):
+         ID_Miscellaneous_HC, ID_RealEstate_HC, puf):
 
     # if e62720 != 0 and e24517 > 0:
     #    x62720 = e62720 - e24517
@@ -869,7 +868,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
     c60200 = min((1 - ID_Medical_HC) * c17000, 0.025 * _posagi)
     # if e60240 != 0 and e18300 > 0:
     #    x60240 = e60240 - e18300
-    c60240 = (1 - ID_AllTaxPaid_HC) * c18300 + x60240
+    c60240 = c18300 + x60240
     # if e60220 != 0 and e20800 > 0:
     #    x60220 = e60220 - e20800
     c60220 = (1 - ID_Miscellaneous_HC) * c20800 + x60220
@@ -913,9 +912,10 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
             _cmbtp = _cmbtp_itemizer
         else:
             _cmbtp = 0.
-        taxes_paid = (1 - ID_StateLocalTax_HC) * max(0, e18400) + e18500
+        real_estate = (1 - ID_RealEstate_HC) * e18500
+        income_sales = (1 - ID_StateLocalTax_HC) * max(0, e18400)
         c62100 = (c00100 - c04470 + max(0., min((1 - ID_Medical_HC) * c17000,
-                  0.025 * c00100)) + (1 - ID_AllTaxPaid_HC) * taxes_paid -
+                  0.025 * c00100)) + income_sales + real_estate -
                   c60260 + (1 - ID_Miscellaneous_HC) * c20800 - c21040)
         c62100 += _cmbtp
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -42,6 +42,7 @@ SMALL_INCOME_BINS = [-1e14, 0, 4999, 9999, 14999, 19999, 24999, 29999, 39999,
 WEBAPP_INCOME_BINS = [-1e14, 0, 9999, 19999, 29999, 39999, 49999, 74999, 99999,
                       199999, 499999, 1000000, 1e14]
 
+EPSILON = 1e-3
 
 def extract_array(f):
     """
@@ -95,7 +96,7 @@ def weighted_perc_dec(agg, col_name):
 
 
 def weighted_share_of_total(agg, col_name, total):
-    return float(weighted_sum(agg, col_name)) / float(total)
+    return float(weighted_sum(agg, col_name)) / (float(total) + EPSILON)
 
 
 def add_weighted_decile_bins(df, income_measure='_expanded_income'):

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -42,7 +42,6 @@ SMALL_INCOME_BINS = [-1e14, 0, 4999, 9999, 14999, 19999, 24999, 29999, 39999,
 WEBAPP_INCOME_BINS = [-1e14, 0, 9999, 19999, 29999, 39999, 49999, 74999, 99999,
                       199999, 499999, 1000000, 1e14]
 
-EPSILON = 1e-3
 
 def extract_array(f):
     """
@@ -96,7 +95,7 @@ def weighted_perc_dec(agg, col_name):
 
 
 def weighted_share_of_total(agg, col_name, total):
-    return float(weighted_sum(agg, col_name)) / (float(total) + EPSILON)
+    return float(weighted_sum(agg, col_name)) / float(total)
 
 
 def add_weighted_decile_bins(df, income_measure='_expanded_income'):


### PR DESCRIPTION
There are two issues involved in this PR:

- Current master version of state and local haircut parameter is not applied previously, in that it's applied to the combo of income taxes, sales taxes, real estate and personal property taxes under regular tax, but only to income taxes and sales taxes under AMT. We need to make this parameter applied consistently.

- The individual income tax (IIT) liabilities can change quite differently, depending on what variables this haircut parameter is applied to.
     - if applied to the combo of income taxes and sales taxes (e18400), real estate (e18500) and personal property taxes (e18800), the IIT change is about at 100 billion level on the out years. 
<img width="640" alt="screen shot 2015-11-19 at 11 04 27 am" src="https://cloud.githubusercontent.com/assets/10549597/11291072/7e7df0ec-8f0a-11e5-929a-75cec8ca9dc8.png">
     - however, if applied to just income and sales tax, the IIT change is only half of that size.
<img width="460" alt="screen shot 2015-11-19 at 12 00 58 pm" src="https://cloud.githubusercontent.com/assets/10549597/11291092/a532857c-8f0a-11e5-8a96-c818857144e2.png">


To solve the issues mentioned above, in this PR I added one more haircut parameter `ID_AllTaxPaid_HC`, to give users the option either repealing the combo deduction or just the income and sales taxes. If this parameter is set to one, then IIT change is the same as first table presented above. If `ID_StateLocalTax_HC` is set to one, then IIT change would be the second table.

@MattHJensen Could you review?