### PR TITLE
Added real estate taxes paid deduction haircut to the benefit surtax

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -403,8 +403,8 @@
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "cpi_inflated": true,
-        "col_label": ["Medical", "AllTaxPaid", "Casualty", "Miscellaneous", "Interest", "Charity"],        
-        "value":    [[true, 	   true,           true,          true,           true,      true]]
+        "col_label": ["Medical", "State & Local", "Real Estate", "Casualty", "Miscellaneous", "Interest", "Charity"],        
+        "value":    [[true, 	   true,           true,          true,          true,           true,      true]]
     },
      "_EITC_rt":{
         "long_name": "Earned income credit rate",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1702,16 +1702,18 @@ def BenefitSurtax(calc):
         # hard code the reform
         nobenefits_calc.policy.ID_Medical_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[0])
-        nobenefits_calc.policy.ID_AllTaxPaid_HC = \
+        nobenefits_calc.policy.ID_StateLocalTax_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[1])
-        nobenefits_calc.policy.ID_casualty_HC = \
+        nobenefits_calc.policy.ID_RealEstate_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[2])
-        nobenefits_calc.policy.ID_Miscellaneous_HC = \
+        nobenefits_calc.policy.ID_casualty_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[3])
-        nobenefits_calc.policy.ID_InterestPaid_HC = \
+        nobenefits_calc.policy.ID_Miscellaneous_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[4])
-        nobenefits_calc.policy.ID_Charity_HC = \
+        nobenefits_calc.policy.ID_InterestPaid_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[5])
+        nobenefits_calc.policy.ID_Charity_HC = \
+            int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[6])
 
         nobenefits_calc.calc_one_year()
 


### PR DESCRIPTION
As in previous PR #478, we separated the previous general state and local taxes paid into State & Local and Real Estate taxes paid. We need make the corresponding change to benefit surtax as well. In this PR, added one more element to the switch parameter and adjusted `BenefitSurtax()` function as well.

Could you review? @MattHJensen 