### PR TITLE
Streamline Calculator and Records logic

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -31,7 +31,7 @@ def add_df(alldfs, df):
 class Calculator(object):
 
     def __init__(self, policy=None, records=None,
-                 sync_years=True, behavior=None, growth=None, **kwargs):
+                 sync_years=True, behavior=None, growth=None):
 
         if isinstance(policy, Policy):
             self._policy = policy
@@ -56,11 +56,8 @@ class Calculator(object):
 
         if isinstance(records, Records):
             self._records = records
-        elif isinstance(records, str):
-            self._records = Records.from_file(records, **kwargs)
         else:
-            msg = 'must specify records as a file path or Records object'
-            raise ValueError(msg)
+            raise ValueError('must specify records as a Records object')
 
         if sync_years and self._records.current_year == Records.PUF_YEAR:
             print("You loaded data for " +

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -3,8 +3,9 @@ Tax-Calculator income tax input-output class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 incometaxio.py
-# pylint --disable=locally-disabled --extension-pkg-whitelist=numpy \
-#        incometaxio.py
+# pylint --disable=locally-disabled incometaxio.py
+# (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
+
 
 import os
 import sys

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -4,6 +4,7 @@ Tax-Calculator federal tax policy Policy class.
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 policy.py
 # pylint --disable=locally-disabled --extension-pkg-whitelist=numpy policy.py
+# (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 
 import os

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -73,10 +73,6 @@ class Records(object):
     BLOWUP_FACTORS_FILENAME = "StageIFactors.csv"
     BLOWUP_FACTORS_PATH = os.path.join(CUR_PATH, BLOWUP_FACTORS_FILENAME)
 
-    @classmethod
-    def from_file(cls, path, **kwargs):
-        return cls(path, **kwargs)
-
     # pairs of 'name of attribute', 'column name' - often the same
     # NOTE: second name in each pair is what Records.__init__() expects
     # if data parameter is a Pandas DataFrame rather than a CSV filename.
@@ -378,9 +374,7 @@ class Records(object):
                  blowup_factors=BLOWUP_FACTORS_PATH,
                  weights=WEIGHTS_PATH,
                  start_year=None,
-                 consider_imputations=True,
-                 **kwargs):
-
+                 consider_imputations=True):
         """
         Records class constructor
         """

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -3,8 +3,8 @@ Tax-Calculator simple tax input-output class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 simpletaxio.py
-# pylint --disable=locally-disabled --extension-pkg-whitelist=numpy \
-#        simpletaxio.py
+# pylint --disable=locally-disabled simpletaxio.py
+# (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 import os
 import sys

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -145,17 +145,6 @@ def test_make_Calculator_deepcopy():
     assert isinstance(calc2, Calculator)
 
 
-def test_make_Calculator_files_to_ctor(policyfile):
-    with open(policyfile.name) as pfile:
-        policy = json.load(pfile)
-    ppo = Policy(parameter_dict=policy, start_year=1991,
-                 num_years=len(IRATES), inflation_rates=IRATES,
-                 wage_growth_rates=WRATES)
-    calc = Calculator(policy=ppo, records=TAX_DTA_PATH,
-                      start_year=1991, inflation_rates=IRATES)
-    assert calc
-
-
 def test_make_Calculator_with_policy_reform():
     # create a Policy object and apply a policy reform
     policy2 = Policy()
@@ -212,8 +201,7 @@ def test_make_Calculator_with_reform_after_start_year():
     reform[2016]['_II_em'] = [6000]
     reform[2016]['_II_em_cpi'] = False
     parm.implement_reform(reform)
-    tax_dta = pd.read_csv(TAX_DTA_PATH, compression='gzip')
-    recs = Records(data=tax_dta, weights=WEIGHTS, start_year=2009)
+    recs = Records(data=TAX_DTA, weights=WEIGHTS, start_year=2009)
     calc = Calculator(policy=parm, records=recs)
     # compare actual and expected parameter values over all years
     exp_STD_Aged = np.array([[1500, 1200, 1200, 1500, 1500, 1200],
@@ -240,8 +228,8 @@ def test_make_Calculator_user_mods_with_cpi_flags(policyfile):
     ppo = Policy(parameter_dict=policy, start_year=1991,
                  num_years=len(IRATES), inflation_rates=IRATES,
                  wage_growth_rates=WRATES)
-    calc = Calculator(policy=ppo, records=TAX_DTA_PATH, start_year=1991,
-                      inflation_rates=IRATES)
+    rec = Records(data=TAX_DTA)
+    calc = Calculator(policy=ppo, records=rec)
     user_mods = {1991: {"_almdep": [7150, 7250, 7400],
                         "_almdep_cpi": True,
                         "_almsep": [40400, 41050],
@@ -249,7 +237,7 @@ def test_make_Calculator_user_mods_with_cpi_flags(policyfile):
                         "_rt5": [0.33],
                         "_rt7": [0.396]}}
     calc.policy.implement_reform(user_mods)
-
+    # compare actual and expected values
     inf_rates = [IRATES[1991 + i] for i in range(0, 12)]
     exp_almdep = Policy.expand_array(np.array([7150, 7250, 7400]),
                                      inflate=True,
@@ -347,8 +335,7 @@ def test_make_Calculator_increment_years_first():
     reform[2016]['_II_em_cpi'] = False
     policy.implement_reform(reform)
     # create Records object by reading 1991 data and saying it is 2009 data
-    tax_dta = pd.read_csv(TAX_DTA_PATH, compression='gzip')
-    puf = Records(tax_dta, weights=WEIGHTS, start_year=2009)
+    puf = Records(TAX_DTA, weights=WEIGHTS, start_year=2009)
     # create Calculator object with Policy object as modified by reform
     calc = Calculator(policy=policy, records=puf)
     # compare expected policy parameter values with those embedded in calc

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -35,13 +35,6 @@ def test_create_records_with_wrong_start_year():
     # against accidentally specifying wrong start_year
 
 
-def test_create_records_from_file():
-    recs = Records.from_file(TAX_DTA_PATH, weigths=WEIGHTS,
-                             start_year=Records.PUF_YEAR)
-    assert recs
-    assert hasattr(recs, '_numextra') == True
-
-
 def test_blow_up():
     tax_dta = pd.read_csv(TAX_DTA_PATH, compression='gzip')
     extra_years = Records.PUF_YEAR - 1991


### PR DESCRIPTION
These changes simply remove vestigial code that is no longer called by Tax-Calculator or TaxBrain.