### PR TITLE
Revise CODING-STYLE CHECKS comment to add pylint numpy option

### DIFF
--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -3,7 +3,8 @@ Tax-Calculator income tax input-output class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 incometaxio.py
-# pylint --disable=locally-disabled incometaxio.py
+# pylint --disable=locally-disabled --extension-pkg-whitelist=numpy \
+#        incometaxio.py
 
 import os
 import sys

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -3,7 +3,7 @@ Tax-Calculator federal tax policy Policy class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 policy.py
-# pylint --disable=locally-disabled policy.py
+# pylint --disable=locally-disabled --extension-pkg-whitelist=numpy policy.py
 
 
 import os
@@ -208,7 +208,7 @@ class Policy(ParametersBase):
                     raise ValueError(msg.format(skey))
                 else:
                     year = int(skey)
-                rdict[year] = (np.array(val)  # pylint: disable=no-member
+                rdict[year] = (np.array(val)
                                if isinstance(val, list) else val)
             reform_pkey_param[pkey] = rdict
         # convert reform_pkey_param dictionary to reform_pkey_year dictionary

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -3,7 +3,8 @@ Tax-Calculator simple tax input-output class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 simpletaxio.py
-# pylint --disable=locally-disabled simpletaxio.py
+# pylint --disable=locally-disabled --extension-pkg-whitelist=numpy \
+#        simpletaxio.py
 
 import os
 import sys

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -3,7 +3,8 @@ Tests for Tax-Calculator IncomeTaxIO class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 test_incometaxio.py
-# pylint --disable=locally-disabled test_incometaxio.py
+# pylint --disable=locally-disabled --extension-pkg-whitelist=numpy \
+#        test_incometaxio.py
 
 import os
 import sys

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -3,7 +3,8 @@ Tests for Tax-Calculator SimpleTaxIO class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 test_simpletaxio.py
-# pylint --disable=locally-disabled test_simpletaxio.py
+# pylint --disable=locally-disabled --extension-pkg-whitelist=numpy \
+#        test_simpletaxio.py
 
 import os
 import sys


### PR DESCRIPTION
Adding the pylint option "--extension-pkg-whitelist=numpy" eliminates
most false-positive warnings about missing numpy members.  This option
is available in pylint 1.4+ versions, which includes the 1.4.2 version
which was installed when running "conda install pylint" at the time of
this check-in.  This pull request contains changes only in comments;
no code has been changed.