### PR TITLE
[WIP] itemized deduction surtax and itemized deduction haircut consistency

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1730,3 +1730,4 @@ def BenefitSurtax(calc):
                                         0) * calc.policy.ID_BenefitSurtax_trt
 
         calc.records._iitax += calc.records._surtax
+        calc.records._combined += calc.records._surtax

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1706,7 +1706,7 @@ def BenefitSurtax(calc):
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[1])
         nobenefits_calc.policy.ID_RealEstate_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[2])
-        nobenefits_calc.policy.ID_casualty_HC = \
+        nobenefits_calc.policy.ID_Casualty_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[3])
         nobenefits_calc.policy.ID_Miscellaneous_HC = \
             int(nobenefits_calc.policy.ID_BenefitSurtax_Switch[4])

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -4,7 +4,7 @@ import json
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, "../../"))
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pandas as pd
 import tempfile
 import pytest
@@ -326,7 +326,7 @@ def test_ID_hc_vs_surtax():
     calc1.calc_all()
     calc2.calc_all()
 
-    assert_array_equal(calc1.records._combined, calc2.records._combined)
+    assert_array_almost_equal(calc1.records._combined, calc2.records._combined, decimal=2)
 
 
 def test_Calculator_create_difference_table():

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -298,6 +298,37 @@ def test_calculate_mtr():
     assert np.array_equal(mtr_FICA, mtr_IIT) == False
 
 
+def test_ID_hc_vs_surtax():
+    policy1 = Policy()
+    puf1 = Records(TAX_DTA, weights=WEIGHTS, start_year=2009)
+    calc1 = Calculator(policy=policy1, records=puf1)
+
+    policy2 = Policy()
+    puf2 = Records(TAX_DTA, weights=WEIGHTS, start_year=2009)
+    calc2 = Calculator(policy=policy2, records=puf2)
+
+    reform1 = {2013: {'_ID_Medical_HC': [1],
+                      '_ID_StateLocalTax_HC': [1],
+                      '_ID_RealEstate_HC': [1],
+                      '_ID_Casualty_HC': [1],
+                      '_ID_Miscellaneous_HC': [1],
+                      '_ID_InterestPaid_HC': [1],
+                      '_ID_Charity_HC': [1]
+                      }
+               }
+    reform2 = {2013: {'_ID_BenefitSurtax_crt': [0]
+                      }
+               }
+
+    policy1.implement_reform(reform1)
+    policy2.implement_reform(reform2)
+
+    calc1.calc_all()
+    calc2.calc_all()
+
+    assert_array_equal(calc1.records._combined, calc2.records._combined)
+
+
 def test_Calculator_create_difference_table():
     # create current-law Policy object and use to create Calculator calc1
     policy1 = Policy()


### PR DESCRIPTION
This PR adds a test to ensure that corresponding itemized deduction haircuts and an itemized deduction surtax produce consistent results per #488. 

It also attempts to fix the known inconsistency described in #487 in order to get the test to pass by adding the surtax to _combined as well as to _iitax. 

This is a major improvement over current master, but it is still not perfect. Currently _combined under the two scenarios are not almost_equal to two decimals for 0.0732779677577% of records. I am still exploring why these don't match.