### PR TITLE
calculate income effect w _combined instead of _iitax

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -65,8 +65,8 @@ def behavior(calc_x, calc_y, update_income=update_income):
     substitution_effect = (calc_y.behavior.BE_sub * pct_diff_atr *
                            (calc_x.records.c04800))
 
-    income_effect = calc_y.behavior.BE_inc * (calc_y.records._iitax -
-                                              calc_x.records._iitax)
+    income_effect = calc_y.behavior.BE_inc * (calc_y.records._combined -
+                                              calc_x.records._combined)
     calc_y_behavior = copy.deepcopy(calc_y)
 
     combined_behavioral_effect = income_effect + substitution_effect


### PR DESCRIPTION
As per #489, this pr calculates income effect with _combined instead of with _iitax. 

```
income_effect = calc_y.behavior.BE_inc * (calc_y.records._combined -
                                          calc_x.records._combined)
```