### PR TITLE
[WIP]Short term solution for capital income MTR

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -276,13 +276,14 @@ class Calculator(object):
         return (mtr_fica, mtr_iit, mtr_combined)
 
     def capital_mtr(self):
-        capital_income_sources = ['e00300', 'e00400', 'e00600', 'e00650', 'e01000',
-                                  'e01400', 'e01500', 'e01700', 'e02000', 'e23250']
-        
+        capital_income_sources = ['e00300', 'e00400', 'e00600', 'e00650',
+                                  'e01000', 'e01400', 'e01500', 'e01700',
+                                  'e02000', 'e23250']
+
         length = len(self.records.s006)
         income_sum = np.zeros(length)
         originals = {}
-        
+
         # get the sum of all capital income and save the values for later use
         for capital_income in capital_income_sources:
             income_sum += getattr(self.records, capital_income)
@@ -295,7 +296,9 @@ class Calculator(object):
         finite_diff = 0.01  # a one-cent difference
         epsilon = 10e-20
         for capital_income in capital_income_sources:
-            income_up = originals[capital_income] * (1 + finite_diff/(income_sum + epsilon))
+            margin = finite_diff * originals[capital_income]/(income_sum +
+                                                              epsilon)
+            income_up = originals[capital_income] + margin
             setattr(self.records, capital_income, income_up)
 
         self.calc_all()
@@ -303,7 +306,7 @@ class Calculator(object):
 
         # delta of the results with margin added
         iitax_delta = iitax_up - iitax_base
-        
+
         # calculates mtrs
         mtr_iit = iitax_delta / finite_diff
 
@@ -311,7 +314,7 @@ class Calculator(object):
         for capital_income in capital_income_sources:
             setattr(self.records, capital_income, originals[capital_income])
         self.calc_all()
-        
+
         return mtr_iit
 
     def diagnostic_table(self, num_years=5):

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -289,9 +289,7 @@ class Calculator(object):
             originals[capital_income] = getattr(self.records, capital_income)
 
         self.calc_all()
-        fica_base = copy.deepcopy(self.records._fica)
         iitax_base = copy.deepcopy(self.records._iitax)
-        combined_taxes_base = iitax_base + fica_base
 
         # add the one-cent margin
         finite_diff = 0.01  # a one-cent difference   
@@ -300,19 +298,13 @@ class Calculator(object):
             setattr(self.records, capital_income, income_up)
 
         self.calc_all()
-        fica_up = copy.deepcopy(self.records._fica)
         iitax_up = copy.deepcopy(self.records._iitax)
-        combined_taxes_up = iitax_up + fica_up
 
         # delta of the results with margin added
-        fica_delta = fica_up - fica_base
         iitax_delta = iitax_up - iitax_base
-        combined_delta = combined_taxes_up - combined_taxes_base
         
         # calculates mtrs
-        mtr_fica = fica_delta / finite_diff
         mtr_iit = iitax_delta / finite_diff
-        mtr_combined = combined_delta / finite_diff
 
         # reset everything
         for capital_income in capital_income_sources:

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -296,8 +296,8 @@ class Calculator(object):
         finite_diff = 0.01  # a one-cent difference
         epsilon = 10e-20
         for capital_income in capital_income_sources:
-            margin = finite_diff * originals[capital_income]/(income_sum +
-                                                              epsilon)
+            margin = finite_diff * originals[capital_income] / (income_sum +
+                                                                epsilon)
             income_up = originals[capital_income] + margin
             setattr(self.records, capital_income, income_up)
 

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -292,9 +292,10 @@ class Calculator(object):
         iitax_base = copy.deepcopy(self.records._iitax)
 
         # add the one-cent margin
-        finite_diff = 0.01  # a one-cent difference   
+        finite_diff = 0.01  # a one-cent difference
+        epsilon = 10e-20
         for capital_income in capital_income_sources:
-            income_up = originals[capital_income] * (1 + finite_diff/income_sum)
+            income_up = originals[capital_income] * (1 + finite_diff/(income_sum + epsilon))
             setattr(self.records, capital_income, income_up)
 
         self.calc_all()
@@ -311,7 +312,7 @@ class Calculator(object):
             setattr(self.records, capital_income, originals[capital_income])
         self.calc_all()
         
-        return (mtr_fica, mtr_iit, mtr_combined)
+        return mtr_iit
 
     def diagnostic_table(self, num_years=5):
         table = []

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -296,8 +296,8 @@ class Calculator(object):
         # add the one-cent margin
         finite_diff = 0.01  # a one-cent difference   
         for capital_income in capital_income_sources:
-            income_up = originals[each_income] * (1 + finite_diff/income_sum)
-            setattr(self.records, income_up)
+            income_up = originals[capital_income] * (1 + finite_diff/income_sum)
+            setattr(self.records, capital_income, income_up)
 
         self.calc_all()
         fica_up = copy.deepcopy(self.records._fica)
@@ -312,11 +312,11 @@ class Calculator(object):
         # calculates mtrs
         mtr_fica = fica_delta / finite_diff
         mtr_iit = iitax_delta / finite_diff
-        mtr_combined = combined_delta / finite_diff * 1.0
+        mtr_combined = combined_delta / finite_diff
 
         # reset everything
         for capital_income in capital_income_sources:
-            setattr(self.records, originals[each_income])
+            setattr(self.records, capital_income, originals[capital_income])
         self.calc_all()
         
         return (mtr_fica, mtr_iit, mtr_combined)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -275,10 +275,11 @@ class Calculator(object):
         # return the three marginal tax rate arrays
         return (mtr_fica, mtr_iit, mtr_combined)
 
-    def capital_mtr(self):
-        capital_income_sources = ['e00300', 'e00400', 'e00600', 'e00650',
-                                  'e01000', 'e01400', 'e01500', 'e01700',
-                                  'e02000', 'e23250']
+    def capital_mtr(self,
+                    capital_income_sources=['e00300', 'e00400', 'e00600',
+                                            'e00650', 'e01000', 'e01400',
+                                            'e01500', 'e01700', 'e02000',
+                                            'e23250']):
 
         length = len(self.records.s006)
         income_sum = np.zeros(length)


### PR DESCRIPTION
A new function for capital income MTR is added in this PR due to the following two reasons.

- The one-cent margin needs to be weighted split among all capital income sources before calculation. This step is only needed for these capital income sources but not any other type of income.

- Not much validation needed at this point since we only calculate mtr based on a certain set of capital income sources.

This is still just a short-term solution, as it's easy to implement and relatively efficient computation wise, without messing up the original mtr function which is currently used by other team members for testing purposes. In long run, we need to combine the two mtr functions. 

@MattHJensen @martinholmer Could you take a look at this function? I haven't added any test yet, but will do once you're happy with the function.