### PR TITLE
Add FICA output for non-couple filing units in IncomeTaxIO class

### DIFF
--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -51,6 +51,7 @@ class IncomeTaxIO(object):
         """
         IncomeTaxIO class constructor.
         """
+        # pylint: disable=too-many-branches
         # check that input_filename ends with '.csv' or '.csv.gz'
         if input_filename.endswith('.csv'):
             inp_str = '{}-{}'.format(input_filename[:-4], str(tax_year)[2:])
@@ -119,12 +120,15 @@ class IncomeTaxIO(object):
         """
         output = {}  # dictionary indexed by Records index for filing unit
         self._calc.calc_all()
-        (_, mtr_iitax, _) = self._calc.mtr(wrt_full_compensation=False)
+        (mtr_fica, mtr_iitax, _) = self._calc.mtr(wrt_full_compensation=False)
         for idx in range(0, self._calc.records.dim):
             ovar = SimpleTaxIO.extract_output(self._calc.records, idx)
-            ovar[6] = 0.0  # no FICA tax liability calculated
-            ovar[7] = 100 * mtr_iitax[idx]
-            ovar[9] = 0.0  # no marginal FICA tax rate calculated
+            ovar[7] = 100.0 * mtr_iitax[idx]
+            if self._calc.records.MARS[idx] == 2:
+                ovar[6] = 0.0  # no FICA tax liability calculated for couples
+                ovar[9] = 0.0  # no marginal FICA tax rate for couples
+            else:
+                ovar[9] = 100.0 * mtr_fica[idx]
             output[idx] = ovar
         # write contents of output dictionary to OUTPUT file
         if write_output_file:


### PR DESCRIPTION
Filing units with MARS==2 continue to have zero OASDI payroll tax liability and zero marginal OASDI payroll tax rate in IncomeTaxIO class output.

These changes generate the following (new vs old) differences in ```python inctax.py puf.csv 2013``` output:
```
> tclsh taxdiffs.tcl new-puf-13.out-inctax old-puf-13.out-inctax 
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  6  90614      0 776326.80 [182234]
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  9 110549      0     15.30 [345216]
>
```
The above differences show that only payroll tax liability (ovar=6) and marginal payroll tax rate (ovar=9) are different and then for only some (MARS!=2) filing units.

These changes in IncomeTaxIO logic have no effect on any other Tax-Calculator logic or results.