### PR TITLE
Added variables to current mtr function, replacing PR 492

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -222,9 +222,8 @@ class Calculator(object):
                                   'e00300', 'e23250',
                                   'e01700', 'e02400',
                                   'e00400', 'e00600',
-                                  'e00650', 'e01000',
-                                  'e01400', 'e01500',
-                                  'e02000']
+                                  'e00650', 'e22250',
+                                  'e01400', 'e02000']
         # check validity of income_type_str parameter
         if income_type_str not in mtr_valid_income_types:
             msg = 'mtr income_type_str="{}" is not valid'

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -220,7 +220,11 @@ class Calculator(object):
         """
         mtr_valid_income_types = ['e00200p', 'e00900p',
                                   'e00300', 'e23250',
-                                  'e01700', 'e02400']
+                                  'e01700', 'e02400',
+                                  'e00400', 'e00600',
+                                  'e00650', 'e01000',
+                                  'e01400', 'e01500',
+                                  'e02000']
         # check validity of income_type_str parameter
         if income_type_str not in mtr_valid_income_types:
             msg = 'mtr income_type_str="{}" is not valid'


### PR DESCRIPTION
After further discussion with Dan, Jason and Matt, it seems the best way to deal with mtr weights is leaving the decision to our users -- they could choose to use either the negative capital income directly or the absolute values. Even though this method doesn't seem to be very computationally efficient, it would be more tricky to include the weighting step in MTR function given how many assumptions need to be made.

As of now, the capital income part of this function is just to connect Tax-calculator with our macro model. I assume there would be a script in the macro repo calling this mtr function for each item of capital income and then manually weighted average these mtrs right afterward. @jdebacker @talumbau  Does this sound right. If so, let me know you need me to provide a more update script for this function. I would love to read the current script if needed.

@martinholmer Do you think we need to add more warnings/tests regarding the new capital income variables added in the list? I wasn't sure as it seems we've already had the most essential ones.

cc @MattHJensen 