### PR TITLE
Add mtrinc and blowup options to inctax.py program

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -17,6 +17,7 @@ def main():
     """
     # parse command-line arguments:
     parser = argparse.ArgumentParser(
+        prog='python inctax.py',
         description=('Writes to a file the federal income tax OUTPUT for the '
                      'tax filing units specified in the INPUT file with the '
                      'OUTPUT computed from the INPUT for the TAXYEAR using '
@@ -53,6 +54,20 @@ def main():
                               '//-comments. No REFORM filename implies use '
                               'of current-law policy.'),
                         default=None)
+    parser.add_argument('--mtrinc',
+                        help=('MTRINC is name of income type for which '
+                              'marginal tax rates are computed. No MTRINC '
+                              'implies using taxpayer earnings as the income '
+                              'type for which to compute marginal tax rates.'),
+                        default='e00200p')
+    parser.add_argument('--blowup',
+                        help=('optional flag that causes INPUT variables to '
+                              'be aged using default blowup factors from the '
+                              'year of the INPUT data to the TAXYEAR.  No '
+                              '--blowup option implies INPUT data are not '
+                              'adjusted in any way.'),
+                        default=False,
+                        action="store_true")
     parser.add_argument('INPUT',
                         help=('INPUT is name of required CSV file that '
                               'contains a subset of IRS-SOI PUF variables. '
@@ -70,8 +85,9 @@ def main():
     # instantiate IncometaxIO object and do tax calculations
     inctax = IncomeTaxIO(input_filename=args.INPUT,
                          tax_year=args.TAXYEAR,
-                         reform_filename=args.reform)
-    inctax.calculate()
+                         reform_filename=args.reform,
+                         blowup_input_data=args.blowup)
+    inctax.calculate(mtr_inctype=args.mtrinc)
     # return no-error exit code
     return 0
 # end of main function code

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -99,7 +99,7 @@ class IncomeTaxIO(object):
         # read input file contents into Records object
         # (note that recs does not include the IRS-SOI-PUF aggregate record)
         recs = Records(data=input_filename, consider_imputations=True)
-        if blowup_input_data == False:
+        if blowup_input_data is False:
             # prepare Records object for sync_years=False in Calculator ctor
             recs.set_current_year(tax_year)
         # create Calculator object

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -32,6 +32,9 @@ class IncomeTaxIO(object):
     reform_filename: string or None
         name of optional REFORM file with None implying current-law policy.
 
+    blowup_input_data: boolean
+        whether or not to age record data from data year to tax_year.
+
     Raises
     ------
     ValueError:
@@ -47,7 +50,8 @@ class IncomeTaxIO(object):
     def __init__(self,
                  input_filename,
                  tax_year,
-                 reform_filename):
+                 reform_filename,
+                 blowup_input_data):
         """
         IncomeTaxIO class constructor.
         """
@@ -95,10 +99,12 @@ class IncomeTaxIO(object):
         # read input file contents into Records object
         # (note that recs does not include the IRS-SOI-PUF aggregate record)
         recs = Records(data=input_filename, consider_imputations=True)
-        # prepare Records object for sync_years=False in Calculator ctor
-        recs.set_current_year(policy.current_year)
-        # create Calculator object without doing year synchronization
-        self._calc = Calculator(policy=policy, records=recs, sync_years=False)
+        if blowup_input_data == False:
+            # prepare Records object for sync_years=False in Calculator ctor
+            recs.set_current_year(tax_year)
+        # create Calculator object
+        self._calc = Calculator(policy=policy, records=recs,
+                                sync_years=blowup_input_data)
 
     def tax_year(self):
         """
@@ -106,12 +112,14 @@ class IncomeTaxIO(object):
         """
         return self._calc.policy.current_year
 
-    def calculate(self, write_output_file=True):
+    def calculate(self, mtr_inctype='e00200p', write_output_file=True):
         """
         Calculate taxes for all INPUT lines and write OUTPUT to file.
 
         Parameters
         ----------
+        mtr_inctype: string
+
         write_output_file: boolean
 
         Returns
@@ -120,7 +128,8 @@ class IncomeTaxIO(object):
         """
         output = {}  # dictionary indexed by Records index for filing unit
         self._calc.calc_all()
-        (mtr_fica, mtr_iitax, _) = self._calc.mtr(wrt_full_compensation=False)
+        (mtr_fica, mtr_iitax, _) = self._calc.mtr(income_type_str=mtr_inctype,
+                                                  wrt_full_compensation=False)
         for idx in range(0, self._calc.records.dim):
             ovar = SimpleTaxIO.extract_output(self._calc.records, idx)
             ovar[7] = 100.0 * mtr_iitax[idx]

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -3,8 +3,8 @@ Tests for Tax-Calculator IncomeTaxIO class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 test_incometaxio.py
-# pylint --disable=locally-disabled --extension-pkg-whitelist=numpy \
-#        test_incometaxio.py
+# pylint --disable=locally-disabled incometaxio.py
+# (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 import os
 import sys

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -24,7 +24,8 @@ def test_1():
     taxyear = 2020
     inctax = IncomeTaxIO(input_filename=FAUX_PUF_CSV,
                          tax_year=taxyear,
-                         reform_filename=None)
+                         reform_filename=None,
+                         blowup_input_data=False)
     assert inctax.tax_year() == taxyear
 
 
@@ -35,6 +36,7 @@ def test_2():
     taxyear = 2020
     inctax = IncomeTaxIO(input_filename=FAUX_PUF_CSV,
                          tax_year=taxyear,
-                         reform_filename=None)
+                         reform_filename=None,
+                         blowup_input_data=False)
     inctax.calculate(write_output_file=False)
     assert inctax.tax_year() == taxyear


### PR DESCRIPTION
Enhancements allow control from the command-line over the type of
income for which marginal tax rates are computed and over whether or
not the input variables are aged from the input data year to the
inctax.py TAXYEAR.  Using neither of these two new options results in
the exact same inctax.py behavior and results as before these changes.