### PR TITLE
Expand range of income types used in testmtr.py program

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -175,6 +175,13 @@ class Calculator(object):
     def current_year(self):
         return self.policy.current_year
 
+    MTR_VALID_INCOME_TYPES = ['e00200p', 'e00900p',
+                              'e00300', 'e00400',
+                              'e00600', 'e00650',
+                              'e01400', 'e01700',
+                              'e02000', 'e02400',
+                              'e22250', 'e23250']
+
     def mtr(self, income_type_str='e00200p',
             wrt_full_compensation=True):
         """
@@ -211,21 +218,21 @@ class Calculator(object):
         Notes
         -----
         Valid income_type_str values are:
-        'e00200p', taxpayer wage/salary earnings (which is the default value);
-        'e00900p', taxpayer (Schedule C) self-employment income;
+        'e00200p', taxpayer wage/salary earnings (also included in e00200);
+        'e00900p', taxpayer Schedule C self-employment income (also in e00900);
         'e00300',  taxable interest income;
+        'e00400',  federally-tax-exempt interest income;
+        'e00600',  all dividends included in AGI
+        'e00650',  qualified dividends (also included in e00600)
+        'e01400',  federally-taxable IRA distribution;
+        'e01700',  federally-taxable pension benefits;
+        'e02000',  Schedule E net income/loss
+        'e02400',  all social security (OASDI) benefits;
+        'e22250',  short-term capital gains;
         'e23250',  long-term capital gains;
-        'e01700',  federally-taxable pension benefits; and
-        'e02400',  social security (OASDI) benefits.
         """
-        mtr_valid_income_types = ['e00200p', 'e00900p',
-                                  'e00300', 'e23250',
-                                  'e01700', 'e02400',
-                                  'e00400', 'e00600',
-                                  'e00650', 'e22250',
-                                  'e01400', 'e02000']
         # check validity of income_type_str parameter
-        if income_type_str not in mtr_valid_income_types:
+        if income_type_str not in Calculator.MTR_VALID_INCOME_TYPES:
             msg = 'mtr income_type_str="{}" is not valid'
             raise ValueError(msg.format(income_type_str))
         # specify value for finite_diff parameter

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -251,6 +251,8 @@ class Calculator(object):
             earnings_type = self.records.e00200
         elif income_type_str == 'e00900p':
             seincome_type = self.records.e00900
+        elif income_type_str == 'e00650':
+            divincome_type = self.records.e00600
         # calculate base level of taxes
         self.calc_all()
         fica_base = copy.deepcopy(self.records._fica)
@@ -262,6 +264,8 @@ class Calculator(object):
             self.records.e00200 = earnings_type + finite_diff
         elif income_type_str == 'e00900p':
             self.records.e00900 = seincome_type + finite_diff
+        elif income_type_str == 'e00650':
+            self.records.e00600 = divincome_type + finite_diff
         self.calc_all()
         fica_up = copy.deepcopy(self.records._fica)
         iitax_up = copy.deepcopy(self.records._iitax)
@@ -276,6 +280,8 @@ class Calculator(object):
             self.records.e00200 = earnings_type
         elif income_type_str == 'e00900p':
             self.records.e00900 = seincome_type
+        elif income_type_str == 'e00650':
+            self.records.e00600 = divincome_type
         self.calc_all()
         # specify optional adjustment for employer (er) OASDI+HI payroll taxes
         if wrt_full_compensation and income_type_str == 'e00200p':

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -183,6 +183,7 @@ class Calculator(object):
                               'e22250', 'e23250']
 
     def mtr(self, income_type_str='e00200p',
+            negative_finite_diff=False,
             wrt_full_compensation=True):
         """
         Calculates the marginal FICA, individual income, and combined
@@ -203,6 +204,11 @@ class Calculator(object):
         income_type_str: string
             specifies type of income that is increased to compute the
             marginal tax rates.  See Notes for list of valid income types.
+
+        negative_finite_diff: boolean
+            specifies whether or not marginal tax rates are computed by
+            subtracting (rather than adding) a small finite_diff amount
+            to the specified income type.
 
         wrt_full_compensation: boolean
             specifies whether or not marginal tax rates on earned income
@@ -237,6 +243,8 @@ class Calculator(object):
             raise ValueError(msg.format(income_type_str))
         # specify value for finite_diff parameter
         finite_diff = 0.01  # a one-cent difference
+        if negative_finite_diff:
+            finite_diff *= -1.0
         # extract income_type array(s) from embedded records object
         income_type = getattr(self.records, income_type_str)
         if income_type_str == 'e00200p':

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -235,7 +235,7 @@ class Calculator(object):
         'e02000',  Schedule E net income/loss
         'e02400',  all social security (OASDI) benefits;
         'e22250',  short-term capital gains;
-        'e23250',  long-term capital gains;
+        'e23250',  long-term capital gains.
         """
         # check validity of income_type_str parameter
         if income_type_str not in Calculator.MTR_VALID_INCOME_TYPES:

--- a/testmtr.py
+++ b/testmtr.py
@@ -41,9 +41,6 @@ def run():
     # create a Calculator object using clp policy and puf records
     calc = Calculator(policy=clp, records=puf)
 
-    # compute marginal tax rate (mtr) histograms for each mtr income type
-    mtr_income_types = ['e00200p', 'e00900p',
-                        'e00300', 'e01700', 'e02400', 'e23250']
     # . . . specify FICA mtr histogram bin boundaries (or edges):
     fica_bin_edges = [0.0, 0.02, 0.04, 0.06, 0.08,
                       0.10, 0.12, 0.14, 0.16, 0.18, 1.0]
@@ -62,7 +59,8 @@ def run():
     sys.stdout.write('IIT mtr histogram bin edges:\n')
     sys.stdout.write('     {}\n'.format(iit_bin_edges))
     inctype_header = 'FICA and IIT mtr histogram bin counts for'
-    for inctype in mtr_income_types:
+    # compute marginal tax rate (mtr) histograms for each mtr income type
+    for inctype in Calculator.MTR_VALID_INCOME_TYPES:
         (mtr_fica, mtr_iit, _) = calc.mtr(income_type_str=inctype,
                                           wrt_full_compensation=False)
         sys.stdout.write('{} {}:\n'.format(inctype_header, inctype))

--- a/testmtr.py
+++ b/testmtr.py
@@ -23,6 +23,7 @@ from taxcalc import Policy, Records, Calculator
 
 
 TAX_YEAR = 2013
+NEG_DIFF = False  # set True if want to subtract (rather than add) small amount
 
 
 def run():
@@ -30,6 +31,10 @@ def run():
     Compute histograms for each marginal tax rate income type using
     sample input from the 'puf.csv' file and writing output to stdout.
     """
+    if NEG_DIFF:
+        sys.stdout.write('MTR computed using NEGATIVE finite_diff.\n')
+    else:
+        sys.stdout.write('MTR computed using POSITIVE finite_diff.\n')
     # create a Policy object (clp) containing current-law policy parameters
     clp = Policy()
     clp.set_year(TAX_YEAR)
@@ -62,6 +67,7 @@ def run():
     # compute marginal tax rate (mtr) histograms for each mtr income type
     for inctype in Calculator.MTR_VALID_INCOME_TYPES:
         (mtr_fica, mtr_iit, _) = calc.mtr(income_type_str=inctype,
+                                          negative_finite_diff=NEG_DIFF,
                                           wrt_full_compensation=False)
         sys.stdout.write('{} {}:\n'.format(inctype_header, inctype))
         write_mtr_bin_counts(mtr_fica, fica_bin_edges, recid)


### PR DESCRIPTION
This pull request makes changes to the Calculator mtr() method and to the testmtr.py program to acheive several objectives:
(1) The testmtr.py program now tests all twelve income types handled by the mtr() method.
(2) The mtr() method has been revised to have a new negative_finite_diff parameter, whose default value is False.
(3) The testmtr.py program has been revised to easily switch between using a positive or negative finite_diff when calling the mtr() method.

None of these logic revisions causes any changes in Tax-Calculator results; the only difference is that testmtr.py results now include mtr histograms for more income types.

cc  @MattHJensen  @feenberg  @GoFroggyRun  @Amy-Xu 