### PR TITLE
AMT25PC Criteria Issue

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1020,7 +1020,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
     else:
         _amt20pc = 0.
 
-    if c62720 != 0:
+    if c62730 != 0:
         _amt25pc = max(0, _alminc - _ngamty - _line46)
     else:
         _amt25pc = 0.

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1020,7 +1020,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
     else:
         _amt20pc = 0.
 
-    if c62730 != 0:
+    if c62740 != 0:
         _amt25pc = max(0, _alminc - _ngamty - _line46)
     else:
         _amt25pc = 0.


### PR DESCRIPTION
In PR #484,  it seems like I messed up `c62720`, `c62730` and `c62740` for whatever stupid reason, and thus result in issue #503. The intended change should be `c62740 != 0`, where `c62740` stands for alternative minimum capital gain amount, as indicated in the 09 puf documentation. 
`c62740` is line 19 in Sch D and thus also line 38 in [Form 6251](https://www.irs.gov/pub/irs-pdf/f6251.pdf). This criteria on AMT 25 percentage corresponds to the instruction on the form, which reads "If line 38 is zero or blank, skip lines 59 through 61 and go to line 62. Otherwise, go to line 59".
Please refer to the MTR output for this PR below:
```
ITs-MacBook-Air:tax-calculator Sean.Wang$ git status
On branch MTR_on_LTCG
...
ITs-MacBook-Air:tax-calculator Sean.Wang$ python inctax.py --blowup --mtrinc e23250 puf.csv 2013
You loaded data for 2009.
Your data have been extrapolated to 2013.
ITs-MacBook-Air:tax-calculator Sean.Wang$ awk '$7>100&&$25==0{printf("%.2f\t%d\n",$7/100,$1);n++}END{print n}' puf-13.out-inctax

```
The last blank line means that no significant MTR is reported, if I were not mistaken. 

@MattHJensen @martinholmer @feenberg Please take a look.