### PR TITLE
Drop variable name aliases

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -180,7 +180,7 @@ class Calculator(object):
                               'e00600', 'e00650',
                               'e01400', 'e01700',
                               'e02000', 'e02400',
-                              'e22250', 'e23250']
+                              'p22250', 'p23250']
 
     def mtr(self, income_type_str='e00200p',
             negative_finite_diff=False,
@@ -234,8 +234,8 @@ class Calculator(object):
         'e01700',  federally-taxable pension benefits;
         'e02000',  Schedule E net income/loss
         'e02400',  all social security (OASDI) benefits;
-        'e22250',  short-term capital gains;
-        'e23250',  long-term capital gains.
+        'p22250',  short-term capital gains;
+        'p23250',  long-term capital gains.
         """
         # check validity of income_type_str parameter
         if income_type_str not in Calculator.MTR_VALID_INCOME_TYPES:

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1262,7 +1262,7 @@ def ChildTaxCredit(n24, MARS, CTC_c, c00100, _feided, CTC_ps, _exact,
 
 
 @iterate_jit(nopython=True, puf=True)
-def AmOppCr(_cmp, e87482, e87487, e87492, e87497, e87521, puf):
+def AmOppCr(_cmp, p87482, e87487, e87492, e87497, p87521, puf):
     """American Opportunity Credit 2009+; Form 8863"""
 
     """
@@ -1272,7 +1272,7 @@ def AmOppCr(_cmp, e87482, e87487, e87492, e87497, e87521, puf):
     """
 
     # Expense should not exceed the cap of $4000.
-    c87482 = max(0., min(e87482, 4000.))
+    c87482 = max(0., min(p87482, 4000.))
     c87487 = max(0., min(e87487, 4000.))
     c87492 = max(0., min(e87492, 4000.))
     c87497 = max(0., min(e87497, 4000.))
@@ -1303,7 +1303,7 @@ def AmOppCr(_cmp, e87482, e87487, e87492, e87497, e87521, puf):
     c87521 = c87483 + c87488 + c87493 + c87498
 
     if puf:
-        c87521 = e87521
+        c87521 = p87521
 
     return (c87482, c87487, c87492, c87497, c87483, c87488, c87493, c87498,
             c87521)

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -421,7 +421,7 @@ def AMED(_fica, e00200, MARS, AMED_thd, _sey, AMED_trt,
 
 
 @iterate_jit(nopython=True, puf=True)
-def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
+def StdDed(DSI, _earned, STD, p04470, e00100, e60000,
            MARS, MIDR, e15360, AGEP, AGES, PBI, SBI, _exact, e04200,
            STD_Aged, _txpyers, f6251, _numextra, puf):
 
@@ -495,7 +495,7 @@ def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
 
     # ??
     x04500 = 0.
-    if f6251 == 0 and e04470 == 0:
+    if f6251 == 0 and p04470 == 0:
         x04500 = e00100 - e60000
 
     # Calculate the extra deduction for aged and blind
@@ -523,7 +523,7 @@ def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
 
 @iterate_jit(nopython=True, puf=False)
 def TaxInc(c00100, c04470, _standard, e37717, c21060, c21040,
-           e04470, c04200, c04500, c04600, x04500,
+           p04470, c04200, c04500, c04600, x04500,
            e04805, t04470, f6251, _exact, _feided, c04800, MARS,
            II_rt1, II_rt2, II_rt3, II_rt4,
            II_rt5, II_rt6, II_rt7, II_brk1, II_brk2, II_brk3,
@@ -539,7 +539,7 @@ def TaxInc(c00100, c04470, _standard, e37717, c21060, c21040,
     #    c04470 = 0.
 
     # if FDED == 1:
-    #    _othded = e04470 - c04470
+    #    _othded = p04470 - c04470
     #    c04100 = 0.
     #    c04200 = 0.
     #    _standard = 0.
@@ -835,10 +835,10 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, p23250, e01100, e58990,
 
 @iterate_jit(nopython=True, puf=True)
 def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
-         e60300, e60860, e60100, e60840, e60630, e60550, FDED, e62740,
+         e60300, e60860, p60100, e60840, e60630, e60550, FDED, e62740,
          e60720, e60430, e60500, e60340, e60680, e60600, e60405, e24516,
          e60440, e60420, e60410, e61400, e60660, e60480, c21060, e62720,
-         e62000, e60250, _cmp, _standard, e04470, e17500, c04600, c05200,
+         e62000, e60250, _cmp, _standard, p04470, e17500, c04600, c05200,
          f6251, e62100, e21040, e20800, c00100, _statax, e60000, t04470,
          c04470, c17000, e18500, c20800, c21040, NIIT, e62730, e04805,
          DOBYR, FLPDYR, DOBMD, SDOBYR, SDOBMD, SFOBYR, c02700, AGERANGE,
@@ -904,12 +904,12 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517, e37717,
         _addamt = 0
 
     if _cmp == 1:
-        c62100 = (_addamt + e60300 + e60860 + e60100 + e60840 + e60630 +
+        c62100 = (_addamt + e60300 + e60860 + p60100 + e60840 + e60630 +
                   e60550 + e60720 + e60430 + e60500 + e60340 + e60680 +
                   e60600 + e60405 + e60440 + e60420 + e60410 + e61400 +
                   e60660 - c60260 - e60480 - e62000 + c60000 - e60250)
 
-    if (puf and ((_standard == 0 or (_exact == 1 and e04470 > 0)))):
+    if (puf and ((_standard == 0 or (_exact == 1 and p04470 > 0)))):
         if f6251 == 1:
             _cmbtp = _cmbtp_itemizer
         else:
@@ -1158,7 +1158,7 @@ def ExpEarnedInc(_exact, c00100, CDCC_ps, CDCC_crt,
 @iterate_jit(nopython=True, puf=True)
 def NumDep(EICYB1, EICYB2, EICYB3, EIC, c00100, c01000, e00400, MARS, EITC_ps,
            EITC_ps_MarriedJ, EITC_rt, c59560, EITC_c, EITC_prt, e83080, e00300,
-           e00600, e01000, e40223, e25360, e25430, e25470, e25400, e25500,
+           e00600, e01000, e40223, e25360, e25430, p25470, e25400, e25500,
            e26210, e26340, e27200, e26205, e26320, EITC_InvestIncome_c, _cmp,
            SOIYR, DOBYR, SDOBYR, _agep, _ages, _earned, c59660, _exact, e59560,
            _numextra, puf):
@@ -1197,7 +1197,7 @@ def NumDep(EICYB1, EICYB2, EICYB3, EIC, c00100, c01000, e00400, MARS, EITC_ps,
         _val_rtbase = EITC_rt[_ieic] * 100
         _val_rtless = EITC_prt[_ieic] * 100
         _dy = (e00400 + e83080 + e00300 + e00600 + max(0., max(0., c01000) -
-               max(0., e40223)) + max(0., max(0., e25360) - e25430 - e25470 -
+               max(0., e40223)) + max(0., max(0., e25360) - e25430 - p25470 -
                e25400 - e25500) + max(0., e26210 + e26340 + e27200 -
                e26205 - e26320))
     else:
@@ -1557,7 +1557,7 @@ def F5405(pm, rc):
 @iterate_jit(nopython=True, puf=True)
 def C1040(e07400, e07180, e07200, c07220, c07230, e07250, c07300, c07240,
           e07600, e07260, c07970, e07300, x07400, e09720, c07600,
-          e07500, e07700, e08000, e07240, e08001, e07960, e07970,
+          e07500, e07700, p08000, e07240, e08001, e07960, e07970,
           SOIYR, e07980, c05800, e08800, e09900, e09400, e09800,
           e10000, e10100, e09700, e10050, e10075, e09805, e09710,
           c59660, c07180, c59680, NIIT, _amed, puf):
@@ -1567,7 +1567,7 @@ def C1040(e07400, e07180, e07200, c07220, c07230, e07250, c07300, c07240,
     x07400 = e07400
 
     c07100 = (c07180 + e07200 + c07600 + c07300 + x07400 + e07980 + c07220 +
-              e07500 + e08000)
+              e07500 + p08000)
 
     y07100 = c07100
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -130,7 +130,7 @@ def Adj(e35300_0, e35600_0, e35910_0, e03150, e03210, e03600, e03260, c03260,
 
 
 @iterate_jit(nopython=True)
-def CapGains(e23250, e22250, e23660, _sep, _feided, FEI_ec_c, ALD_Interest_ec,
+def CapGains(p23250, p22250, e23660, _sep, _feided, FEI_ec_c, ALD_Interest_ec,
              ALD_StudentLoan_HC, f2555, e00200, e00300, e00600, e00700, e00800,
              e00900, e01100, e01200, e01400, e01700, e02000, e02100,
              e02300, e02600, e02610, e02800, e02540, e00400, e02400,
@@ -139,7 +139,7 @@ def CapGains(e23250, e22250, e23660, _sep, _feided, FEI_ec_c, ALD_Interest_ec,
     # Capital Gains
 
     # Net capital gain (long term + short term) before exclusion
-    c23650 = e23250 + e22250 + e23660
+    c23650 = p23250 + p22250 + e23660
 
     # Limitation for capital loss
     c01000 = max(-3000 / _sep, c23650)
@@ -602,14 +602,14 @@ def XYZD(_taxinc, c04800, MARS, II_rt1, II_rt2, II_rt3, II_rt4, II_rt5, II_rt6,
 
 
 @iterate_jit(nopython=True)
-def NonGain(c23650, e23250, e01100):
-    _cglong = min(c23650, e23250) + e01100
+def NonGain(c23650, p23250, e01100):
+    _cglong = min(c23650, p23250) + e01100
     _noncg = 0
     return (_cglong, _noncg)
 
 
 @iterate_jit(nopython=True)
-def TaxGains(e00650, c01000, c04800, e01000, c23650, e23250, e01100, e58990,
+def TaxGains(e00650, c01000, c04800, e01000, c23650, p23250, e01100, e58990,
              e58980, e24515, e24518, MARS, _taxinc, _xyztax, _feided,
              _feitax, _cmp, e59410, e59420, e59440, e59470, e59400,
              e83200_0, e10105, e74400, II_rt1, II_rt2, II_rt3, II_rt4,
@@ -620,7 +620,7 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, e23250, e01100, e58990,
     c00650 = e00650
     _addtax = 0.
 
-    if c01000 > 0 or c23650 > 0. or e23250 > 0. or e01100 > 0. or e00650 > 0.:
+    if c01000 > 0 or c23650 > 0. or p23250 > 0. or e01100 > 0. or e00650 > 0.:
         _hasgain = 1.
     else:
         _hasgain = 0.
@@ -634,7 +634,7 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, e23250, e01100, e58990,
         if e01100 > 0.:
             c24510 = float(e01100)
         else:
-            c24510 = max(0., min(c23650, e23250)) + e01100
+            c24510 = max(0., min(c23650, p23250)) + e01100
 
         _dwks9 = max(0, c24510 - min(e58990, e58980))
         c24516 = c24505 + _dwks9
@@ -689,7 +689,7 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, e23250, e01100, e58990,
         _dwks9 = 0.
         c24505 = 0.
         c24510 = 0.
-        c24516 = max(0., min(e23250, c23650)) + e01100
+        c24516 = max(0., min(p23250, c23650)) + e01100
 
         _dwks12 = 0.
         c24517 = 0.

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -258,8 +258,8 @@ class Records(object):
              ('e62740', 'e62740'),
              ('p65300', 'p65300'),
              ('p65400', 'p65400'),
-             ('e87482', 'p87482'),
-             ('e87521', 'p87521'),
+             ('p87482', 'p87482'),
+             ('p87521', 'p87521'),
              ('e68000', 'e68000'),
              ('e82200', 'e82200'),
              ('t27800', 't27800'),
@@ -616,7 +616,7 @@ class Records(object):
         times_equal(self.p27895, self.BF.ATXPY[year])
         times_equal(self.e87530, self.BF.ATXPY[year])
         times_equal(self.e87550, self.BF.ATXPY[year])
-        times_equal(self.e87521, self.BF.ATXPY[year])
+        times_equal(self.p87521, self.BF.ATXPY[year])
         times_equal(self.RECID, 1.)
         times_equal(self.s006, 1.)
         times_equal(self.s008, 1.)

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -647,12 +647,6 @@ class Records(object):
         for name in Records.ZEROED_NAMES:
             setattr(self, name, np.zeros((self.dim,)))
         self._num = np.ones((self.dim,))
-        # specify eNNNNN aliases for several pNNNNN and sNNNNN variables
-        self.e04470 = self.p04470
-        self.e25470 = self.p25470
-        self.e08000 = self.p08000
-        self.e60100 = self.p60100
-        self.e27860 = self.s27860
         # specify SOIYR
         self.SOIYR = np.repeat(Records.PUF_YEAR, self.dim)
 
@@ -737,13 +731,13 @@ class Records(object):
                                                  self.e02400 > 0))),
                                   self._txpyers,
                                   np.where(np.logical_and(self.FDED == 2,
-                                           self.e04470 >
+                                           self.p04470 >
                                            std_2009[self.MARS - 1]),
                                            np.where(self.MARS != 2,
-                                           (self.e04470 -
+                                           (self.p04470 -
                                             std_2009[self.MARS - 1]) /
                                            std_aged_2009[0],
-                                           (self.e04470 -
+                                           (self.p04470 -
                                             std_2009[self.MARS - 1]) /
                                            std_aged_2009[1]), 0))
 
@@ -801,7 +795,7 @@ class Records(object):
                     float64, float64)])
 def imputed_cmbtp_itemizer(e17500, e00100, e18400,
                            e62100, e00700,
-                           e04470, e21040,
+                           p04470, e21040,
                            e18500, e20800):
     """
     Calculates _cmbtp_itemizer values
@@ -810,5 +804,5 @@ def imputed_cmbtp_itemizer(e17500, e00100, e18400,
     medical_limited = max(0., e17500 - max(0., e00100) * 0.075)
     medical_adjustment = min(medical_limited, 0.025 * max(0., e00100))
     state_adjustment = max(0, e18400)
-    return (e62100 - medical_adjustment + e00700 + e04470 + e21040 -
+    return (e62100 - medical_adjustment + e00700 + p04470 + e21040 -
             state_adjustment - e00100 - e18500 - e20800)

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -648,9 +648,7 @@ class Records(object):
             setattr(self, name, np.zeros((self.dim,)))
         self._num = np.ones((self.dim,))
         # specify eNNNNN aliases for several pNNNNN and sNNNNN variables
-        self.e22250 = self.p22250
         self.e04470 = self.p04470
-        self.e23250 = self.p23250
         self.e25470 = self.p25470
         self.e08000 = self.p08000
         self.e60100 = self.p60100

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -54,7 +54,7 @@ def test_imputation_of_cmbtp_itemizer():
     e18400 = np.array([25., 34., 10.])
     e62100 = np.array([75., 12.4, 84.])
     e00700 = np.array([43.3, 34.1, 3.4])
-    e04470 = np.array([21.2, 12., 13.1])
+    p04470 = np.array([21.2, 12., 13.1])
     e21040 = np.array([45.9, 3., 45.])
     e18500 = np.array([33.1, 18.2, 39.])
     e20800 = np.array([0.9, 32., 52.1])
@@ -64,12 +64,12 @@ def test_imputation_of_cmbtp_itemizer():
     x = max(0., e17500 - max(0., e00100) * 0.075) = [17., 3.7925, 0.]
     medical_adjustment = min(x, 0.025 * max(0.,e00100)) = [-1., -.2025, 0.]
     state_adjustment = max(0, e18400) = [42., 34., 49.]
-    _cmbtp_itemizer = (e62100 - medical_adjustment + e00700 + e04470 + e21040
+    _cmbtp_itemizer = (e62100 - medical_adjustment + e00700 + p04470 + e21040
                        - z - e00100 - e18500 - e20800)
                     = [68.4, -31.0025 ,-84.7]
     """
     test_itemizer = imputed_cmbtp_itemizer(e17500, e00100, e18400,
-                                           e62100, e00700, e04470,
+                                           e62100, e00700, p04470,
                                            e21040, e18500, e20800)
     assert np.allclose(cmbtp_itemizer, test_itemizer)
 

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -46,9 +46,6 @@ def test_blow_up():
     # r.current_year == PUF_YEAR implies Calculator ctor will call r.blowup()
     calc = Calculator(policy=parms, records=recs)
     assert calc.current_year == parms_start_year
-    # have e aliases of p variables been maintained after several blowups?
-    assert calc.records.e23250.sum() == calc.records.p23250.sum()
-    assert calc.records.e22250.sum() == calc.records.p22250.sum()
 
 
 def test_imputation_of_cmbtp_itemizer():


### PR DESCRIPTION
This pull request is the first of several that will resolve issue #425.  This first #425 pull request also resolves issue #452.  The conversation for issue #425 proposed simply dropping the seven aliased variables, which were shown to not always work correctly by the development of the Calculator mtr() method (as reported in #452).

These code changes do not have any effect on the output generated by ```test.py``` or ```test_mtr.py``` or ```inctax.py``` or the ```validation/tests```, and all the ```py.tests``` continue to pass.

cc @MattHJensen @feenberg @Amy-Xu @GoFroggyRun 