### PR TITLE
Add MUST_READ_VARS to Records read logic to avoid fatal errors

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -85,7 +85,7 @@ class Records(object):
     BLOWUP_FACTORS_FILENAME = "StageIFactors.csv"
     BLOWUP_FACTORS_PATH = os.path.join(CUR_PATH, BLOWUP_FACTORS_FILENAME)
 
-    # specify set of all Record variables that can be read by Tax-Calculator:
+    # specify set of all Record variables that MAY be read by Tax-Calculator:
     VALID_READ_VARS = set([
         'AGIR1', 'DSI', 'EFI', 'EIC', 'ELECT', 'FDED', 'FLPDYR', 'FLPDMO',
         'f2441', 'f3800', 'f6251', 'f8582', 'f8606', 'f8829', 'f8910', 'f8936',
@@ -120,6 +120,9 @@ class Records(object):
         'wage_head', 'wage_spouse', 'earnsplit',
         'age', 'agedp1', 'agedp2', 'agedp3', 'AGERANGE',
         's006', 's008', 's009', 'WSAMP', 'TXRT', 'filer', 'matched_weight'])
+
+    # specify set of all Record variables that MUST be read by Tax-Calculator:
+    MUST_READ_VARS = set(['RECID', 'FLPDYR', 'MARS'])
 
     # specify set of all Record variables that cannot be read in:
     CALCULATED_VARS = set([
@@ -511,6 +514,11 @@ class Records(object):
                 raise ValueError(msg.format(varname))
             Records.READ_VARS.add(varname)
             setattr(self, varname, tax_dta[varname].values)
+        # check that MUST_READ_VARS are all present in tax_dta
+        UNREAD_MUST_VARS = Records.MUST_READ_VARS - Records.READ_VARS
+        if len(UNREAD_MUST_VARS) > 0:
+            msg = 'Records data missing {} MUST_READ_VARS'
+            raise ValueError(msg.format(len(UNREAD_MUST_VARS)))
         # create variables that are set to all zeros
         Records.UNREAD_VARS = Records.VALID_READ_VARS - Records.READ_VARS
         Records.ZEROED_VARS = Records.CALCULATED_VARS | Records.UNREAD_VARS


### PR DESCRIPTION
The new MUST_READ_VARS set contains three variables that **must** be read by the Records class in order for the Tax-Calculator to avoid fatal Python errors.  The variables are RECID, FLPDYR, and MARS.

When the standard ```puf.csv``` file is reduced to just these three variables, the Tax-Calculator computes sensible results: tax liabilities are zero and marginal taxes rates are sensible for filing units without any income.  The following shows how this one-time test was conducted:
```
> awk -F, '{printf("%s,%s,%s\n",$215,$15,$27)}' ../tax-calculator-data/puf.csv > pufsmall.csv
> head pufsmall.csv 
RECID,FLPDYR,MARS
51940,2009,1
3452160,2009,1
3323870,2009,1
3455930,2009,2
3628610,2009,3
3340520,2009,2
3672510,2009,3
3649970,2009,2
3234000,2009,2
> python inctax.py --blowup pufsmall.csv 2013
You loaded data for 2009.
Your data have been extrapolated to 2013.
> head pufsmall-13.out-inctax
51940. 2013 0 0.00 0.00 0.00 -7.65 0.00 15.30 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3452160. 2013 0 0.00 0.00 0.00 -7.65 0.00 15.30 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3323870. 2013 0 0.00 0.00 0.00 -7.65 0.00 15.30 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3455930. 2013 0 0.00 0.00 0.00 -7.65 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3628610. 2013 0 0.00 0.00 0.00 0.00 0.00 15.30 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3340520. 2013 0 0.00 0.00 0.00 -7.65 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3672510. 2013 0 0.00 0.00 0.00 0.00 0.00 15.30 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3649970. 2013 0 0.00 0.00 0.00 -7.65 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3234000. 2013 0 0.00 0.00 0.00 -7.65 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
3484000. 2013 0 0.00 0.00 0.00 -7.65 0.00 15.30 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00
> cp pufsmall.csv puf.csv
> python testmtr.py
MTR computed using POSITIVE finite_diff.
You loaded data for 2009.
Your data have been extrapolated to 2013.
Total number of data records = 219814
FICA mtr histogram bin edges:
     [0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.12, 0.14, 0.16, 0.18, 1.0]
IIT mtr histogram bin edges:
     [-1.0, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0]
FICA and IIT mtr histogram bin counts for e00200p:
219814 :      0      0      0      0      0      0      0 219814      0      0
219814 :      0      0      0 215525   4289      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e00900p:
219814 :      0      0      0      0      0      0      0 219814      0      0
219814 :      0      0      0 215525   4289      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e00300:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e00400:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e00600:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e00650:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e01400:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e01700:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e02000:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for e02400:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for p22250:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
FICA and IIT mtr histogram bin counts for p23250:
219814 : 219814      0      0      0      0      0      0      0      0      0
219814 :      0      0      0      0 219814      0      0      0      0      0
>
```