### PR TITLE
Set the MARS-derived values of _num and _sep variables in records.py

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -89,7 +89,6 @@ class Calculator(object):
 
     def calc_one_year(self):
         EI_FICA(self.policy, self.records)
-        FilingStatus(self.policy, self.records)
         Adj(self.policy, self.records)
         CapGains(self.policy, self.records)
         SSBenefits(self.policy, self.records)

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -8,16 +8,6 @@ import copy
 
 
 @iterate_jit(nopython=True)
-def FilingStatus(MARS):
-    if MARS == 3 or MARS == 6:
-        _sep = 2
-    else:
-        _sep = 1
-
-    return _sep
-
-
-@iterate_jit(nopython=True)
 def EI_FICA(SS_Earnings_c, e00200, e00200p, e00200s,
             e11055, e00250, e30100, FICA_ss_trt, FICA_mc_trt,
             e00900p, e00900s, e02100p, e02100s):
@@ -1231,11 +1221,9 @@ def NumDep(EICYB1, EICYB2, EICYB3, EIC, c00100, c01000, e00400, MARS, EITC_ps,
 
 @iterate_jit(nopython=True)
 def ChildTaxCredit(n24, MARS, CTC_c, c00100, _feided, CTC_ps, _exact,
-                   c11070, c07220, _num, _precrd, _nctcr, CTC_prt):
+                   c11070, c07220, _precrd, _nctcr, CTC_prt):
 
     # Child Tax Credit
-    if MARS == 2:
-        _num = 2.
 
     _nctcr = n24
 
@@ -1254,7 +1242,7 @@ def ChildTaxCredit(n24, MARS, CTC_c, c00100, _feided, CTC_ps, _exact,
     # TODO get rid of this type declaration
     _precrd = float(_precrd)
 
-    return (c11070, c07220, _num, _nctcr, _precrd, _ctcagi)
+    return (c11070, c07220, _nctcr, _precrd, _ctcagi)
 
 # def HopeCredit():
     # W/o congressional action, Hope Credit will replace
@@ -1374,7 +1362,7 @@ def RefAmOpp(_cmp, c87521, _num, c00100, EDCRAGE, c87668):
 
         c87521 : American Opportunity Credit
 
-        _num : filing status, number of people filing jointly
+        _num : number of people filing jointly
 
         EDCRAGE : Education credit age from CPS: NEED TO BE CONFIRMED!!!!!!
 

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -172,7 +172,7 @@ class Records(object):
         '_ywossbe', '_ywossbc', '_prexmp', 'c17750',
         '_statax', 'c37703', 'c20500', 'c20750', 'c19200',
         'c19700', '_nonlimited', '_limitratio', '_phase2_i',
-        '_fica', 'c03260', 'c11055', 'c15100', '_numextra',
+        '_fica', 'c03260', 'c11055', 'c15100', '_numextra', '_num',
         '_txpyers', 'c15200', '_othded', 'c04100', 'c04200',
         'c04500', '_amtstd', '_oldfei', 'c05200', '_cglong',
         '_noncg', '_hasgain', '_dwks9', '_dwks5', '_dwks12',
@@ -524,8 +524,11 @@ class Records(object):
         Records.ZEROED_VARS = Records.CALCULATED_VARS | Records.UNREAD_VARS
         for varname in Records.ZEROED_VARS:
             setattr(self, varname, np.zeros((self.dim,)))
-        # create variables that are not read in from input file
-        self._num = np.ones((self.dim,))  # TODO: why is this done this way?
+        # create variables that are derived from MARS
+        self._num = np.where(self.MARS == 2,
+                             2., 1.)
+        self._sep = np.where(np.logical_or(self.MARS == 3, self.MARS == 6),
+                             2., 1.)
         self.SOIYR = np.repeat(Records.PUF_YEAR, self.dim)  # TODO: eliminate
 
     def _read_weights(self, weights):


### PR DESCRIPTION
Setting _sep in records.py eliminates the need for the FilingStatus function.
Setting all values of _num in records.py eliminates the need to set _num in the functions.py file.

These changes move toward the vision in issue #436 (where Tax-Calculator code only computes taxes and taxdata code creates data) by moving code that sets input data out of the functions.py file and into the records.py file, from where it might be moved to the taxdata repo in the future.