### PR TITLE
Revise FLPDYR logic along lines suggested by Dan Feenberg

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -26,7 +26,7 @@ class Records(object):
         default value is the string 'puf.csv'
         For details on how to use your own data with the Tax-Calculator,
         look at the test_Calculator_using_nonstd_input() function in the
-        tests/test_calculator.py file.
+        tests/test_calculate.py file.
 
     blowup_factors: string or Pandas DataFrame
         string describes CSV file in which blowup factors reside;
@@ -47,7 +47,7 @@ class Records(object):
               custom data's calendar year.  For details on how to
               use your own data with the Tax-Calculator, look at the
               test_Calculator_using_nonstd_input() function in the
-              tests/test_calculator.py file.
+              tests/test_calculate.py file.
 
     consider_imputations: boolean
         True implies that if current_year (see start_year above) equals
@@ -56,7 +56,7 @@ class Records(object):
         default value is True
         For details on how to use your own data with the Tax-Calculator,
         look at the test_Calculator_using_nonstd_input() function in the
-        tests/test_calculator.py file.
+        tests/test_calculate.py file.
 
     Raises
     ------

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -36,7 +36,7 @@ class Records(object):
         default value is filename of the default weights
 
     start_year: None or integer
-        None implies current_year is set to value of FLPDYR for first unit;
+        None implies current_year is set to PUF_YEAR (see below);
         integer implies current_year is set to start_year;
         default value is None
 
@@ -122,7 +122,7 @@ class Records(object):
         's006', 's008', 's009', 'WSAMP', 'TXRT', 'filer', 'matched_weight'])
 
     # specify set of all Record variables that MUST be read by Tax-Calculator:
-    MUST_READ_VARS = set(['RECID', 'FLPDYR', 'MARS'])
+    MUST_READ_VARS = set(['RECID', 'MARS'])
 
     # specify set of all Record variables that cannot be read in:
     CALCULATED_VARS = set([
@@ -235,7 +235,8 @@ class Records(object):
         self._read_blowup(blowup_factors)
         self._read_weights(weights)
         if start_year is None:
-            self._current_year = self.FLPDYR[0]
+            self._current_year = Records.PUF_YEAR
+            self.FLPDYR.fill(Records.PUF_YEAR)
         elif isinstance(start_year, int):
             self._current_year = start_year
         else:
@@ -255,11 +256,10 @@ class Records(object):
 
     def increment_year(self):
         """
-        Adds one to current year and updates each record's FLPDYR variable.
+        Adds one to current year.
         Also, does variable blowup and reweighting for the new current year.
         """
         self._current_year += 1
-        self.FLPDYR += 1
         # Implement Stage 1 Extrapolation blowup factors
         self._blowup(self._current_year)
         # Implement Stage 2 Extrapolation reweighting

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -24,6 +24,9 @@ class Records(object):
         string describes CSV file in which records data reside;
         DataFrame already contains records data;
         default value is the string 'puf.csv'
+        For details on how to use your own data with the Tax-Calculator,
+        look at the test_Calculator_using_nonstd_input() function in the
+        tests/test_calculator.py file.
 
     blowup_factors: string or Pandas DataFrame
         string describes CSV file in which blowup factors reside;
@@ -39,12 +42,21 @@ class Records(object):
         None implies current_year is set to PUF_YEAR (see below);
         integer implies current_year is set to start_year;
         default value is None
+        NOTE: if specifying data (see above) as being a custom
+              data set, be sure to explicitly set start_year to the
+              custom data's calendar year.  For details on how to
+              use your own data with the Tax-Calculator, look at the
+              test_Calculator_using_nonstd_input() function in the
+              tests/test_calculator.py file.
 
     consider_imputations: boolean
         True implies that if current_year (see start_year above) equals
         PUF_YEAR (see below), then call _impute_variables() method;
         False implies never call _impute_variables() method;
         default value is True
+        For details on how to use your own data with the Tax-Calculator,
+        look at the test_Calculator_using_nonstd_input() function in the
+        tests/test_calculator.py file.
 
     Raises
     ------

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -231,7 +231,7 @@ def test_make_Calculator_user_mods_with_cpi_flags(policyfile):
     ppo = Policy(parameter_dict=policy, start_year=1991,
                  num_years=len(IRATES), inflation_rates=IRATES,
                  wage_growth_rates=WRATES)
-    rec = Records(data=TAX_DTA)
+    rec = Records(data=TAX_DTA, start_year=1991)
     calc = Calculator(policy=ppo, records=rec)
     user_mods = {1991: {"_almdep": [7150, 7250, 7400],
                         "_almdep_cpi": True,


### PR DESCRIPTION
When not specifying a start_year in the Records constructor, the current_year and FLPDYR variable are now set to PUF_YEAR, so that ages will be correctly calculated.  Also, remove the increase of FLPDYR by one in the increment_year() method in order to calculate ages correctly.  These changes imply that FLPDYR no longer needs to be included in the MUST_READ_VARS list.

This pull request resolves issue #517 in a way that assumes the Tax-Calculator will always be using the most recently available IRS/SOI PUF data when two of the arguments of the Records class constructor are at their default values: that is, when data='puf.csv' and start_year=None.

As before these changes, data other than the most recent IRS/SOI PUF data can be read by the Records class as long as the name of the file is supplied as the data argument of the Records constructor and the year of the data is specified in the start_year argument of the Records constructor.

cc @MattHJensen @feenberg @Amy-Xu @GoFroggyRun 