### PR TITLE
Add another Calculator test

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -217,10 +217,6 @@ class Records(object):
         'c07600', 'c07240', 'c62100_everyone',
         '_surtax', '_combined', 'x04500', '_personal_credit'])
 
-    READ_VARS = set()
-    UNREAD_VARS = set()
-    ZEROED_VARS = set()
-
     def __init__(self,
                  data="puf.csv",
                  blowup_factors=BLOWUP_FACTORS_PATH,
@@ -493,7 +489,7 @@ class Records(object):
         """
         Read Records data from file or use specified DataFrame as data.
         """
-        if isinstance(data, pd.core.frame.DataFrame):
+        if isinstance(data, pd.DataFrame):
             tax_dta = data
         elif isinstance(data, str):
             if data.endswith("gz"):
@@ -508,23 +504,24 @@ class Records(object):
         tax_dta = tax_dta[tax_dta.RECID != 999999]
         self.dim = len(tax_dta)
         # create variables using tax_dta DataFrame column names
+        READ_VARS = set()
         for varname in list(tax_dta.columns.values):
             if varname not in Records.VALID_READ_VARS:
                 msg = 'Records data variable name {} not in VALID_READ_VARS'
                 raise ValueError(msg.format(varname))
-            Records.READ_VARS.add(varname)
+            READ_VARS.add(varname)
             setattr(self, varname, tax_dta[varname].values)
         # check that MUST_READ_VARS are all present in tax_dta
-        UNREAD_MUST_VARS = Records.MUST_READ_VARS - Records.READ_VARS
+        UNREAD_MUST_VARS = Records.MUST_READ_VARS - READ_VARS
         if len(UNREAD_MUST_VARS) > 0:
             msg = 'Records data missing {} MUST_READ_VARS'
             raise ValueError(msg.format(len(UNREAD_MUST_VARS)))
         # create variables that are set to all zeros
-        Records.UNREAD_VARS = Records.VALID_READ_VARS - Records.READ_VARS
-        Records.ZEROED_VARS = Records.CALCULATED_VARS | Records.UNREAD_VARS
-        for varname in Records.ZEROED_VARS:
+        UNREAD_VARS = Records.VALID_READ_VARS - READ_VARS
+        ZEROED_VARS = Records.CALCULATED_VARS | UNREAD_VARS
+        for varname in ZEROED_VARS:
             setattr(self, varname, np.zeros((self.dim,)))
-        # create variables that are derived from MARS
+        # create variables derived from MARS, which is in MUST_READ_VARS
         self._num = np.where(self.MARS == 2,
                              2., 1.)
         self._sep = np.where(np.logical_or(self.MARS == 3, self.MARS == 6),
@@ -534,7 +531,7 @@ class Records(object):
         """
         Read Records weights from file or use specified DataFrame as data.
         """
-        if isinstance(weights, pd.core.frame.DataFrame):
+        if isinstance(weights, pd.DataFrame):
             WT = weights
         elif isinstance(weights, str):
             try:
@@ -559,7 +556,7 @@ class Records(object):
         Read Records blowup factors from file or
         use specified DataFrame as data.
         """
-        if isinstance(blowup_factors, pd.core.frame.DataFrame):
+        if isinstance(blowup_factors, pd.DataFrame):
             BF = blowup_factors
         elif isinstance(blowup_factors, str):
             try:

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -34,11 +34,11 @@ WRATES = {1991: 0.0276, 1992: 0.0419, 1993: 0.0465, 1994: 0.0498,
 RAWINPUTFILE_FUNITS = 4
 RAWINPUTFILE_YEAR = 2015
 RAWINPUTFILE_CONTENTS = (
-    'RECID,FLPDYR,MARS\n'
-    '1,2015,2\n'
-    '2,2015,1\n'
-    '3,2015,4\n'
-    '4,2015,6\n'
+    'RECID,MARS\n'
+    '1,2\n'
+    '2,1\n'
+    '3,4\n'
+    '4,6\n'
 )
 
 

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -139,9 +139,7 @@ def run():
     exp_results = pd.read_csv(exp_results_file, compression='gzip')
     exp_set = set(exp_results.columns)  # fix-up to bad colname in exp_results
     cur_set = set(df.columns)
-
-    assertexp_set == cur_set
-
+    assert exp_set == cur_set
     for label in exp_results.columns:
         lhs = exp_results[label].values.reshape(len(exp_results))
         rhs = totaldf[label].values.reshape(len(exp_results))

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal
 import pandas as pd
 import tempfile
 import pytest
-from taxcalc import Policy, Records, Calculator, Growth
+from taxcalc import Policy, Records, Calculator
 from taxcalc import create_distribution_table, create_difference_table
 
 
@@ -31,15 +31,40 @@ WRATES = {1991: 0.0276, 1992: 0.0419, 1993: 0.0465, 1994: 0.0498,
           1999: 0.0437, 2000: 0.0435, 2001: 0.0430, 2002: 0.0429,
           2003: 0.0429, 2004: 0.0429}
 
+RAWINPUTFILE_FUNITS = 4
+RAWINPUTFILE_YEAR = 2015
+RAWINPUTFILE_CONTENTS = (
+    'RECID,FLPDYR,MARS\n'
+    '1,2015,2\n'
+    '2,2015,1\n'
+    '3,2015,4\n'
+    '4,2015,6\n'
+)
+
+
+@pytest.yield_fixture
+def rawinputfile():
+    """
+    Temporary input file that contains minimum required input varaibles.
+    """
+    ifile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    ifile.write(RAWINPUTFILE_CONTENTS)
+    ifile.close()
+    # must close and then yield for Windows platform
+    yield ifile
+    if os.path.isfile(ifile.name):
+        try:
+            os.remove(ifile.name)
+        except OSError:
+            pass  # sometimes we can't remove a generated temporary file
+
 
 @pytest.yield_fixture
 def policyfile():
-
     txt = """{"_almdep": {"value": [7150, 7250, 7400]},
              "_almsep": {"value": [40400, 41050]},
              "_rt5": {"value": [0.33 ]},
              "_rt7": {"value": [0.396]}}"""
-
     f = tempfile.NamedTemporaryFile(mode="a", delete=False)
     f.write(txt + "\n")
     f.close()
@@ -60,7 +85,7 @@ def run():
     for attr in dir(calc.records):
         value = getattr(calc.records, attr)
         if hasattr(value, "shape"):
-            if (value.shape == rshape):
+            if value.shape == rshape:
                 totaldf[attr] = value
     Col_names = ['EICYB1', 'EICYB2', 'EICYB3', 'NIIT', '_addamt', '_addtax',
                  '_agep', '_ages', '_agierr', '_alminc', '_amed', '_amt15pc',
@@ -115,7 +140,7 @@ def run():
     exp_set = set(exp_results.columns)  # fix-up to bad colname in exp_results
     cur_set = set(df.columns)
 
-    assert(exp_set == cur_set)
+    assertexp_set == cur_set
 
     for label in exp_results.columns:
         lhs = exp_results[label].values.reshape(len(exp_results))
@@ -292,7 +317,7 @@ def test_Calculator_create_distribution_table():
     assert isinstance(dt2, pd.DataFrame)
 
 
-def test_calculate_mtr():
+def test_Calculator_mtr():
     policy = Policy()
     puf = Records(TAX_DTA, weights=WEIGHTS, start_year=2009)
     calc = Calculator(policy=policy, records=puf)
@@ -319,10 +344,9 @@ def test_Calculator_create_difference_table():
     assert isinstance(dtable, pd.DataFrame)
 
 
-def test_diagnostic_table():
+def test_Calculator_diagnostic_table():
     policy = Policy()
-    TAX_DTA.FLPDYR += 18  # flpdyr==2009 so that Records ctor will apply blowup
-    puf = Records(data=TAX_DTA, weights=WEIGHTS)
+    puf = Records(data=TAX_DTA, weights=WEIGHTS, start_year=Records.PUF_YEAR)
     calc = Calculator(policy=policy, records=puf)
     calc.diagnostic_table()
 
@@ -351,6 +375,27 @@ def test_make_Calculator_increment_years_first():
     exp_II_em = np.array([3900, 3950, 5000, 6000, 6000])
     assert_array_equal(calc.policy._STD_Aged, exp_STD_Aged)
     assert_array_equal(calc.policy._II_em, exp_II_em)
+
+
+def test_Calculator_using_nonstd_input(rawinputfile):
+    # check Calculator handling of raw, non-standard input data with no aging
+    policy = Policy()
+    policy.set_year(RAWINPUTFILE_YEAR)  # set policy params to input data year
+    nonpuf = Records(data=rawinputfile.name,
+                     start_year=RAWINPUTFILE_YEAR,  # set raw input data year
+                     consider_imputations=False)  # keeps raw data unchanged
+    assert nonpuf.dim == RAWINPUTFILE_FUNITS
+    calc = Calculator(policy=policy,
+                      records=nonpuf,
+                      sync_years=False)  # keeps raw data unchanged
+    assert calc.current_year == RAWINPUTFILE_YEAR
+    calc.calc_all()
+    exp_iitax = np.zeros((nonpuf.dim,))
+    assert_array_equal(nonpuf._iitax, exp_iitax)
+    mtr_fica, _, _ = calc.mtr(wrt_full_compensation=False)
+    exp_mtr_fica = np.zeros((nonpuf.dim,))
+    exp_mtr_fica.fill(0.153)
+    assert_array_equal(mtr_fica, exp_mtr_fica)
 
 
 class TaxCalcError(Exception):

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -37,13 +37,11 @@ def test_create_records_with_wrong_start_year():
 
 def test_blow_up():
     tax_dta = pd.read_csv(TAX_DTA_PATH, compression='gzip')
-    extra_years = Records.PUF_YEAR - 1991
-    tax_dta.FLPDYR += extra_years
     parms = Policy()
     parms_start_year = parms.current_year
-    recs = Records(data=tax_dta)
+    recs = Records(data=tax_dta, start_year=Records.PUF_YEAR)
     assert recs.current_year == Records.PUF_YEAR
-    # r.current_year == PUF_YEAR implies Calculator ctor will call r.blowup()
+    # r.current_year == PUF_YEAR ==> Calculator ctor will call r.blowup()
     calc = Calculator(policy=parms, records=recs)
     assert calc.current_year == parms_start_year
 


### PR DESCRIPTION
The new test shows how to compute tax liabilities and marginal tax rates for minimal, non-PUF data that are considered raw, and hence, are not to be subjected to any imputation or aging logic.

Also, remove several pylint warnings and make the Records class READ_VARS, UNREAD_VARS, and ZEROED_VARS sets local to the private Records._read_data() method.