### PR TITLE
[WIP] Updates on capital gain for Sch D

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -644,14 +644,16 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, p23250, e01100, e58990,
         # line 27 on the latest worksheet
         _LINE27 = max(0., (min(_taxinc, CG_thd2[MARS - 1]) - c24540 - c24534))
         c24598 = CG_rt2 * min(c24597, _LINE27)  # actual 15% tax
+        _LINE30 = min(0, c24534) + min(c24597, _LINE27)
+        _LINE31 = _dwks21 - _LINE30
         # income subject to 20% tax, named _addtax
-        _addtax = CG_rt3 * (_dwks21 - min(0, c24534) - min(c24597, _LINE27))
+        _addtax = CG_rt3 * _LINE31
         _dwks25 = min(_dwks9, e24515)
         _dwks26 = c24516 + c24540
         _dwks28 = max(0., _dwks26 - _taxinc)
         c24610 = max(0., _dwks25 - _dwks28)
         c24615 = 0.25 * c24610
-        _dwks31 = c24540 + c24534 + _dwks21 - min(0, c24534) + c24610
+        _dwks31 = c24540 + c24534 + min(c24597, _LINE27) + _LINE31 + c24610
         c24550 = max(0., _taxinc - _dwks31)
         c24570 = 0.28 * c24550
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -645,7 +645,7 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, p23250, e01100, e58990,
         _LINE27 = max(0., (min(_taxinc, CG_thd2[MARS - 1]) - c24540 - c24534))
         c24598 = CG_rt2 * min(c24597, _LINE27)  # actual 15% tax
         _LINE30 = min(0, c24534) + min(c24597, _LINE27)
-        _LINE31 = _dwks21 - _LINE30
+        _LINE31 = min(0, _dwks21 - _LINE30)
         # income subject to 20% tax, named _addtax
         _addtax = CG_rt3 * _LINE31
         _dwks25 = min(_dwks9, e24515)
@@ -655,7 +655,7 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, p23250, e01100, e58990,
         c24615 = 0.25 * c24610
         _dwks31 = c24540 + c24534 + min(c24597, _LINE27) + _LINE31 + c24610
         c24550 = max(0., _taxinc - _dwks31)
-        c24570 = 0.28 * c24550
+        c24570 = 0.2 * c24550
 
         # if c24540 > CG_thd2[MARS - 1]:
         #    _addtax = (CG_rt3 - CG_rt2) * c24517

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -641,22 +641,26 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, p23250, e01100, e58990,
 
         # if/else 4
         # income subject to 15% tax
-        c24598 = CG_rt2 * c24597  # actual 15% tax
+        # line 27 on the latest worksheet
+        _dnwks27 = max(0., (min(_taxinc, CG_thd2[MARS - 1]) - c24540 - c24534))
+        c24598 = CG_rt2 * min(c24597, _dnwks27)  # actual 15% tax
+        # income subject to 20% tax, named _addtax
+        _addtax = CG_rt3 * (_dwks21 - min(0, c24534) - min(c24597, _dnwks27))
         _dwks25 = min(_dwks9, e24515)
         _dwks26 = c24516 + c24540
         _dwks28 = max(0., _dwks26 - _taxinc)
         c24610 = max(0., _dwks25 - _dwks28)
         c24615 = 0.25 * c24610
-        _dwks31 = c24540 + c24534 + c24597 + c24610
+        _dwks31 = c24540 + c24534 + _dwks21 - min(0, c24534) + c24610
         c24550 = max(0., _taxinc - _dwks31)
         c24570 = 0.28 * c24550
 
-        if c24540 > CG_thd2[MARS - 1]:
-            _addtax = (CG_rt3 - CG_rt2) * c24517
+        # if c24540 > CG_thd2[MARS - 1]:
+        #    _addtax = (CG_rt3 - CG_rt2) * c24517
 
-        elif c24540 <= CG_thd2[MARS - 1] and _taxinc > CG_thd2[MARS - 1]:
-            _addtax = (CG_rt3 - CG_rt2) * min(_dwks21,
-                                              _taxinc - CG_thd2[MARS - 1])
+        # elif c24540 <= CG_thd2[MARS - 1] and _taxinc > CG_thd2[MARS - 1]:
+        #    _addtax = (CG_rt3 - CG_rt2) * min(_dwks21,
+        #                                      _taxinc - CG_thd2[MARS - 1])
 
         c24560 = Taxer_i(c24540, MARS, II_rt1, II_rt2, II_rt3, II_rt4, II_rt5,
                          II_rt6, II_rt7, II_brk1, II_brk2, II_brk3, II_brk4,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -642,10 +642,10 @@ def TaxGains(e00650, c01000, c04800, e01000, c23650, p23250, e01100, e58990,
         # if/else 4
         # income subject to 15% tax
         # line 27 on the latest worksheet
-        _dnwks27 = max(0., (min(_taxinc, CG_thd2[MARS - 1]) - c24540 - c24534))
-        c24598 = CG_rt2 * min(c24597, _dnwks27)  # actual 15% tax
+        _LINE27 = max(0., (min(_taxinc, CG_thd2[MARS - 1]) - c24540 - c24534))
+        c24598 = CG_rt2 * min(c24597, _LINE27)  # actual 15% tax
         # income subject to 20% tax, named _addtax
-        _addtax = CG_rt3 * (_dwks21 - min(0, c24534) - min(c24597, _dnwks27))
+        _addtax = CG_rt3 * (_dwks21 - min(0, c24534) - min(c24597, _LINE27))
         _dwks25 = min(_dwks9, e24515)
         _dwks26 = c24516 + c24540
         _dwks28 = max(0., _dwks26 - _taxinc)

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -214,7 +214,7 @@ class Records(object):
         '_refund', 'c11600', 'e11450', 'e82040', 'e11500',
         '_amed', '_xlin3', '_xlin6', '_cmbtp_itemizer',
         '_cmbtp_standard', '_expanded_income', 'c07300',
-        'c07600', 'c07240', 'c62100_everyone',
+        'c07600', 'c07240', 'c62100_everyone', '_LINE27',
         '_surtax', '_combined', 'x04500', '_personal_credit'])
 
     READ_VARS = set()

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -215,7 +215,8 @@ class Records(object):
         '_amed', '_xlin3', '_xlin6', '_cmbtp_itemizer',
         '_cmbtp_standard', '_expanded_income', 'c07300',
         'c07600', 'c07240', 'c62100_everyone', '_LINE27',
-        '_surtax', '_combined', 'x04500', '_personal_credit'])
+        '_surtax', '_combined', 'x04500', '_personal_credit',
+        '_LINE30', '_LINE31'])
 
     READ_VARS = set()
     UNREAD_VARS = set()


### PR DESCRIPTION
This PR deals with capital gain worksheet for Schedule D. The changes are made according to the latest worksheet on the instruction for Sch D, please see the last two pages [here](https://www.irs.gov/pub/irs-pdf/i1040sd.pdf). I have asked @Amy-Xu to help me verify these changes.

The diagnostic table for this PR now looks like: 
![screen shot 2016-01-08 at 10 55 11 am](https://cloud.githubusercontent.com/assets/13324931/12203044/ee1ae812-b5fa-11e5-8012-4beabaf6f02c.png)
@Amy-Xu, could you take a look?

The issue here is that, although the `py.test` passes, the tax logic is now inconsistent against Internet Taxsim, please refer to the code below:
```
ITs-MacBook-Air:validation Sean.Wang$ ./tests
STARTING WITH VALIDATION TESTS : Fri Jan  8 10:58:21 EST 2016
M	taxcalc/validation/c14.taxdiffs
M	taxcalc/validation/c13.taxdiffs
FINISHED WITH VALIDATION TESTS : Fri Jan  8 11:00:42 EST 2016
VALIDATION TESTS RESULTS: any lines (starting with M) between the
                          STARTING... and FINISHED... lines above
                          indicate a test failure caused by the actual
                          *.taxdiffs results being different from the
                          expected *.taxdiffs results;
                          no M lines implies that all tests passed.
ITs-MacBook-Air:validation Sean.Wang$ git status
On branch Sch_D
```
And the diff files for c13 and c14 respectively:
```
[13] TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  4  53660    700   2250.00 [1961]
                       #big_inctax_diffs=            52960
[14] TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  4  54029    714   2250.00 [4296]
                       #big_inctax_diffs=            53315
```
@MattHJensen @martinholmer Any comments, concerns or remarks would be appreciated. 