### PR TITLE
Add behavior to long term capital gain

### DIFF
--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -2,6 +2,7 @@
         "start_year": 2013,
         "long_name": "Income effect",
         "description": "Change in the demand for leisure (negative of labor supply) per penny of change in after tax income, evaluated at the pre-policy-change level of income and deductions. That is, the work response to a lump sum tax.",
+        "note": "Usually positive. ", 
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0]
@@ -10,14 +11,15 @@
         "start_year": 2013,
         "long_name": "Substitution effect",
         "description": "The taxpayer's taxable income changes according to the product of this parameter, the taxpayer's taxable income before the policy change, and the percent change in the after tax rate (1-MTR). ",
+        "note": "Usually positive. ", 
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0]
     },
     "_BE_CG_per":{
         "start_year": 2013,
-        "long_name": "Persistent",
-        "description": "Behavior effect",
+        "long_name": "Persistent Elasticity of Capital gains",
+        "description": "Defined as percentage change of long term capital gain over percentage change of after tax rate. Usually positive. ",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0]

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -45,7 +45,6 @@ def update_ordinary_income(behavioral_effect, calc_y):
 
 def update_cap_gain_income(cap_gain_behavioral_effect, calc_y):
     calc_y.records.p23250 = calc_y.records.p23250 + cap_gain_behavioral_effect
-    calc_y.records.e01100 = calc_y.records.e01100 + cap_gain_behavioral_effect
     return calc_y
 
 

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -62,7 +62,7 @@ def behavior(calc_x, calc_y):
 
     CG_mtr_x, CG_mtr_y = mtr_xy(calc_x, calc_y,
                                 mtr_of='p23250',
-                                liability_type='combined')
+                                liability_type='iitax')
 
     # Calculate the percent change in after-tax rate for wage and capital gain.
     wage_pctdiff = ((1 - wage_mtr_y) - (1 - wage_mtr_x)) / (1 - wage_mtr_x)

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -4,7 +4,7 @@ from .policy import Policy
 from .parameters_base import ParametersBase
 
 
-def update_income(behavioral_effect, calc_y):
+def update_ordinary_income(behavioral_effect, calc_y):
     delta_inc = np.where(calc_y.records.c00100 > 0, behavioral_effect, 0)
 
     # Attribute the behavioral effects across itemized deductions,
@@ -52,29 +52,45 @@ def behavior(calc_x, calc_y, update_income=update_income):
     """
 
     # Calculate marginal tax rates for plan x and plan y.
-    _, _, combined_mtr_x = calc_x.mtr()
-    mtr_x = combined_mtr_x
+    wage_mtr_x, wage_mtr_y = mtr_xy(calc_x, calc_y,
+                                    mtr_of='e00200p',
+                                    liability_type='combined')
 
-    _, _, combined_mtr_y = calc_y.mtr()
-    mtr_y = combined_mtr_y
+    CG_mtr_x, CG_mtr_y = mtr_xy(calc_x, calc_y,
+                                mtr_of='e23250',
+                                liability_type='iitax')
 
-    # Calculate the percent change in after-tax rate.
-    pct_diff_atr = ((1 - mtr_y) - (1 - mtr_x)) / (1 - mtr_x)
+    # Calculate the percent change in after-tax rate for wage and capital gain.
+    wage_pctdiff = ((1 - wage_mtr_y) - (1 - wage_mtr_x)) / (1 - wage_mtr_x)
 
     # Calculate the magnitude of the substitution and income effects.
-    substitution_effect = (calc_y.behavior.BE_sub * pct_diff_atr *
+    substitution_effect = (calc_y.behavior.BE_sub * wage_pctdiff *
                            (calc_x.records.c04800))
 
     income_effect = calc_y.behavior.BE_inc * (calc_y.records._combined -
                                               calc_x.records._combined)
-    calc_y_behavior = copy.deepcopy(calc_y)
 
     combined_behavioral_effect = income_effect + substitution_effect
 
-    calc_y_behavior = update_income(combined_behavioral_effect,
-                                    calc_y_behavior)
+    calc_y_behavior = copy.deepcopy(calc_y)
+    calc_y_behavior = update_ordinary_income(combined_behavioral_effect,
+                                             calc_y_behavior)
 
     return calc_y_behavior
+
+
+def mtr_xy(calc_x, calc_y, mtr_of='e00200p', liability_type='combined'):
+    iitax_x, payroll_x, combined_x = calc_x.mtr(mtr_of)
+    iitax_y, payroll_y, combined_y = calc_y.mtr(mtr_of)
+
+    if liability_type == 'combined':
+        return (combined_x, combined_y)
+    elif liability_type == 'payroll':
+        return (payroll_x, payroll_y)
+    elif liability_type == 'iitax':
+        return (iitax_x, iitax_y)
+    else:
+        raise ValueError('Choose from combined, iitax, and payroll.')
 
 
 class Behavior(ParametersBase):

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -69,7 +69,8 @@ def test_make_behavioral_Calculator():
 
 def test_update_behavior():
     beh = Behavior(start_year=2013)
-    beh.update_behavior({2014: {'_BE_sub': [0.5]}})
+    beh.update_behavior({2014: {'_BE_sub': [0.5]},
+                         2015: {'_BE_CG_per': [1.2]}})
     policy = Policy()
     should_be = np.full((policy.DEFAULT_NUM_YEARS,), 0.5)
     should_be[0] = 0.0
@@ -81,6 +82,7 @@ def test_update_behavior():
     assert beh.current_year == 2015
     assert beh.BE_sub == 0.5
     assert beh.BE_inc == 0.0
+    assert beh.BE_CG_per == 1.2
 
 
 def test_behavior_default_data():


### PR DESCRIPTION
Per request of issue #226, the behavior effect of capital gain is added in this PR. Taxpayers are assumed to change the timing and amounts of their realized cap gain when facing higher rates. In our code, we define persistent elasticity for long term capital gain as, percentage difference of long term capital gain over percentage difference of after tax rate. Specifically, the marginal tax rate (for the after tax rate) is calculated the combined tax liability change (including both individual income tax and payroll), over one cent margin of net long term cap gain (p23250). Then the capital gain behavior effect, backed out from the after tax rates and user-input elasticity, is added on to p23250 and e01100 (not sure about this part).

Adding this behavior seems to close up the results gap between our calculator and budget option, particularly the option increase long term cap gain and dividends rate by two percentage points. Here's a comparison of results, in billions, starting from year 2015.

master (no behavior):
<img width="778" alt="screen shot 2016-01-11 at 5 23 24 pm" src="https://cloud.githubusercontent.com/assets/10549597/12250216/3c10fe90-b893-11e5-858e-d4df07ea1e85.png">

PR (if persistent elasticity == 0.78):
<img width="779" alt="screen shot 2016-01-11 at 6 46 41 pm" src="https://cloud.githubusercontent.com/assets/10549597/12250220/51820b16-b893-11e5-8d16-d1888aa702fd.png">

PR (if persistent elasticity == 1.2)
<img width="777" alt="screen shot 2016-01-11 at 6 46 51 pm" src="https://cloud.githubusercontent.com/assets/10549597/12250225/5e4548cc-b893-11e5-8dc1-fbac786a4eb1.png">

Would very appreciate any suggestions on assumption/implementation/results or anything for this PR. Thanks a lot. @MattHJensen @feenberg @martinholmer @talumbau 


