### PR TITLE
Fix Policy.implement_reform logic so Policy.current_year is unchanged

### DIFF
--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -219,7 +219,7 @@ class Policy(ParametersBase):
 
     def implement_reform(self, reform):
         """
-        Implement multi-year policy reform and set current_year=start_year.
+        Implement multi-year policy reform and leave current_year unchanged.
 
         Parameters
         ----------
@@ -234,6 +234,7 @@ class Policy(ParametersBase):
             if reform is not a dictionary.
             if each YEAR in reform is not an integer.
             if minimum YEAR in the YEAR:MODS pairs is less than start_year.
+            if minimum YEAR in the YEAR:MODS pairs is less than current_year.
             if maximum YEAR in the YEAR:MODS pairs is greater than end_year.
 
         Returns
@@ -252,7 +253,8 @@ class Policy(ParametersBase):
         policy object (policy) containing current-law policy parameters,
         and the implement_reform(reform) call applies the (possibly
         multi-year) reform specified in reform and then sets the
-        current_year to start_year with parameters set for that year.
+        current_year to the value of current_year when implement_reform
+        was called with parameters set for that pre-call year.
 
         An example of a multi-year, multi-parameter reform is as follows::
 
@@ -280,8 +282,6 @@ class Policy(ParametersBase):
         required by the private _update method, whose documentation
         provides several MODS dictionary examples.
         """
-        if self.current_year != self.start_year:
-            self.set_year(self.start_year)
         if not isinstance(reform, dict):
             msg = 'reform passed to implement_reform is not a dictionary'
             ValueError(msg)
@@ -296,15 +296,18 @@ class Policy(ParametersBase):
         if first_reform_year < self.start_year:
             msg = 'reform provision in year={} < start_year={}'
             ValueError(msg.format(first_reform_year, self.start_year))
+        if first_reform_year < self.current_year:
+            msg = 'reform provision in year={} < current_year={}'
+            ValueError(msg.format(first_reform_year, self.current_year))
         last_reform_year = max(reform_years)
         if last_reform_year > self.end_year:
             msg = 'reform provision in year={} > end_year={}'
             ValueError(msg.format(last_reform_year, self.end_year))
+        precall_current_year = self.current_year
         for year in reform_years:
-            if year != self.start_year:
-                self.set_year(year)
+            self.set_year(year)
             self._update({year: reform[year]})
-        self.set_year(self.start_year)
+        self.set_year(precall_current_year)
 
     # ----- begin private methods of Policy class -----
 

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -556,13 +556,47 @@ def reform_file():
             pass  # sometimes we can't remove a generated temporary file
 
 
-def test_read_json_reform_file_and_implement_reform(reform_file):
+def test_read_json_reform_file_and_implement_reform_a(reform_file):
     """
     Test reading and translation of reform file into a reform dictionary
     that is then used to call implement_reform method.
+    NOTE: implement_reform called when policy.current_year == policy.start_year
     """
     reform = Policy.read_json_reform_file(reform_file.name)
     policy = Policy()
+    policy.implement_reform(reform)
+    syr = policy.start_year
+    amt_tthd = policy._AMT_tthd
+    assert amt_tthd[2015 - syr] == 200000
+    assert amt_tthd[2016 - syr] > 200000
+    assert amt_tthd[2017 - syr] == 300000
+    assert amt_tthd[2018 - syr] > 300000
+    ii_em = policy._II_em
+    assert ii_em[2016 - syr] == 6000
+    assert ii_em[2017 - syr] == 6000
+    assert ii_em[2018 - syr] == 7500
+    assert ii_em[2019 - syr] > 7500
+    assert ii_em[2020 - syr] == 9000
+    assert ii_em[2021 - syr] > 9000
+    amt_em = policy._AMT_em
+    assert amt_em[2016 - syr, 0] > amt_em[2015 - syr, 0]
+    assert amt_em[2017 - syr, 0] > amt_em[2016 - syr, 0]
+    assert amt_em[2018 - syr, 0] == amt_em[2017 - syr, 0]
+    assert amt_em[2019 - syr, 0] == amt_em[2017 - syr, 0]
+    assert amt_em[2020 - syr, 0] == amt_em[2017 - syr, 0]
+    assert amt_em[2021 - syr, 0] > amt_em[2020 - syr, 0]
+    assert amt_em[2022 - syr, 0] > amt_em[2021 - syr, 0]
+
+
+def test_read_json_reform_file_and_implement_reform_b(reform_file):
+    """
+    Test reading and translation of reform file into a reform dictionary
+    that is then used to call implement_reform method.
+    NOTE: implement_reform called when policy.current_year > policy.start_year
+    """
+    reform = Policy.read_json_reform_file(reform_file.name)
+    policy = Policy()
+    policy.set_year(2015)  # the only difference between this and prior test
     policy.implement_reform(reform)
     syr = policy.start_year
     amt_tthd = policy._AMT_tthd


### PR DESCRIPTION
This pull request is intended to resolve the efficiency issues identified in issue #530.  The logic of the Policy.implement_reform() method has been generalized, the documentation of the method has been revised to reflect this logic change, and a test has been added to test_policy.py to verify that the new logic works.  The new Policy implement_reform logic should support the original code Amy described in issue #530.

cc @Amy-Xu @MattHJensen @feenberg @talumbau @GoFroggyRun 