### PR TITLE
Improve IncomeTaxIO class logic

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -54,12 +54,6 @@ def main():
                               '//-comments. No REFORM filename implies use '
                               'of current-law policy.'),
                         default=None)
-    parser.add_argument('--mtrinc',
-                        help=('MTRINC is name of income type for which '
-                              'marginal tax rates are computed. No MTRINC '
-                              'implies using taxpayer earnings as the income '
-                              'type for which to compute marginal tax rates.'),
-                        default='e00200p')
     parser.add_argument('--blowup',
                         help=('optional flag that causes INPUT variables to '
                               'be aged using default blowup factors from the '
@@ -87,7 +81,7 @@ def main():
                          tax_year=args.TAXYEAR,
                          reform_filename=args.reform,
                          blowup_input_data=args.blowup)
-    inctax.calculate(mtr_inctype=args.mtrinc)
+    inctax.calculate()
     # return no-error exit code
     return 0
 # end of main function code

--- a/inctax.py
+++ b/inctax.py
@@ -22,11 +22,12 @@ def main():
                      'tax filing units specified in the INPUT file with the '
                      'OUTPUT computed from the INPUT for the TAXYEAR using '
                      'the Tax-Calculator. '
-                     'The INPUT file is a CSV-formatted file that includes '
-                     'a subset of IRS-SOI PUF variables. The OUTPUT file uses '
+                     'The INPUT file is a CSV-formatted file that contains '
+                     'variable names that are a subset of the '
+                     'Records.VALID_READ_VARS set.  The OUTPUT file uses '
                      'Internet-TAXSIM format.  The OUTPUT filename is the '
-                     'INPUT filename (excluding the .csv suffix, the .csv.gz '
-                     'suffix, or the .gz suffix) followed by '
+                     'INPUT filename (excluding the .csv suffix or '
+                     '.gz suffix, or both) followed by '
                      'a string equal to "-YY" (where the YY is the last two '
                      'digits in the TAXYEAR) and all that is followed by a '
                      'trailing string.  The trailing string is ".out-inctax" '
@@ -55,28 +56,33 @@ def main():
                               'of current-law policy.'),
                         default=None)
     parser.add_argument('--blowup',
-                        help=('optional flag that causes INPUT variables to '
-                              'be aged using default blowup factors from the '
-                              'year of the INPUT data to the TAXYEAR.  No '
-                              '--blowup option implies INPUT data are not '
+                        help=('optional flag that requires INPUT to be '
+                              '"puf.csv", the contents of which will be '
+                              'aged using default blowup factors from '
+                              'Records.PUF_YEAR to the TAXYEAR. '
+                              'No --blowup option implies INPUT data are '
+                              'considered raw data that are not aged or '
                               'adjusted in any way.'),
                         default=False,
                         action="store_true")
     parser.add_argument('INPUT',
                         help=('INPUT is name of required CSV file that '
-                              'contains a subset of IRS-SOI PUF variables. '
-                              'The CSV file may be included in a compressed '
-                              'GZIP file with the name ending in ".gz".'))
+                              'contains a subset of variables included in '
+                              'the Records.VALID_READ_VARS set.  INPUT must '
+                              'end in ".csv" or ".gz".'))
     parser.add_argument('TAXYEAR',
-                        help=('TAXYEAR is calendar year for which income '
-                              'taxes are computed (e.g., 2013).'),
+                        help=('TAXYEAR is calendar year for which federal '
+                              'income taxes are computed (e.g., 2013).'),
                         type=int)
     args = parser.parse_args()
     # optionally show INPUT and OUTPUT variable definitions and exit
     if args.iohelp:
         IncomeTaxIO.show_iovar_definitions()
         return 0
-    # instantiate IncometaxIO object and do tax calculations
+    # instantiate IncometaxIO object and do federal income tax calculations
+    if args.blowup and args.INPUT != 'puf.csv':
+        msg = 'INPUT must be "puf.csv" when using --blowup option'
+        raise ValueError(msg)
     inctax = IncomeTaxIO(input_filename=args.INPUT,
                          tax_year=args.TAXYEAR,
                          reform_filename=args.reform,

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -112,14 +112,12 @@ class IncomeTaxIO(object):
         """
         return self._calc.policy.current_year
 
-    def calculate(self, mtr_inctype='e00200p', write_output_file=True):
+    def calculate(self, write_output_file=True):
         """
         Calculate taxes for all INPUT lines and write OUTPUT to file.
 
         Parameters
         ----------
-        mtr_inctype: string
-
         write_output_file: boolean
 
         Returns
@@ -128,16 +126,9 @@ class IncomeTaxIO(object):
         """
         output = {}  # dictionary indexed by Records index for filing unit
         self._calc.calc_all()
-        (mtr_fica, mtr_iitax, _) = self._calc.mtr(income_type_str=mtr_inctype,
-                                                  wrt_full_compensation=False)
         for idx in range(0, self._calc.records.dim):
             ovar = SimpleTaxIO.extract_output(self._calc.records, idx)
-            ovar[7] = 100.0 * mtr_iitax[idx]
-            if self._calc.records.MARS[idx] == 2:
-                ovar[6] = 0.0  # no FICA tax liability calculated for couples
-                ovar[9] = 0.0  # no marginal FICA tax rate for couples
-            else:
-                ovar[9] = 100.0 * mtr_fica[idx]
+            ovar[6] = 0.0  # no FICA tax liability included in output
             output[idx] = ovar
         # write contents of output dictionary to OUTPUT file
         if write_output_file:
@@ -167,10 +158,10 @@ class IncomeTaxIO(object):
                '[ 3] state code [ALWAYS ZERO]\n'
                '[ 4] federal income tax liability\n'
                '[ 5] state income tax liability [ALWAYS ZERO]\n'
-               '[ 6] FICA (OASDI+HI) tax liability (sum of ee and er share)\n'
-               '[ 7] marginal federal income tax rate as percent\n'
+               '[ 6] FICA (OASDI+HI) tax liability [ALWAYS ZERO]\n'
+               '[ 7] marginal federal income tax rate [ALWAYS ZERO]\n'
                '[ 8] marginal state income tax rate [ALWAYS ZERO]\n'
-               '[ 9] marginal FICA tax rate as percent\n'
+               '[ 9] marginal FICA tax rate [ALWAYS ZERO]\n'
                '[10] federal adjusted gross income, AGI\n'
                '[11] unemployment (UI) benefits included in AGI\n'
                '[12] social security (OASDI) benefits included in AGI\n'

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -22,9 +22,9 @@ class IncomeTaxIO(object):
     Parameters
     ----------
     input_filename: string
-        name of INPUT file that is CSV formatted using SOI PUF varnames;
-        the CSV file may be contained in a compressed GZIP file with a
-        name ending in '.gz'.
+        name of INPUT file that is CSV formatted containing only variable
+        names in the Records.VALID_READ_VARS set; the CSV file may be
+        contained in a compressed GZIP file with a name ending in '.gz'.
 
     tax_year: integer
         calendar year for which income taxes will be computed for INPUT.
@@ -56,7 +56,7 @@ class IncomeTaxIO(object):
         IncomeTaxIO class constructor.
         """
         # pylint: disable=too-many-branches
-        # check that input_filename ends with '.csv' or '.csv.gz'
+        # check that input_filename ends with ".csv", ".csv.gz" or ".gz"
         if input_filename.endswith('.csv'):
             inp_str = '{}-{}'.format(input_filename[:-4], str(tax_year)[2:])
         elif input_filename.endswith('.csv.gz'):
@@ -64,8 +64,9 @@ class IncomeTaxIO(object):
         elif input_filename.endswith('.gz'):
             inp_str = '{}-{}'.format(input_filename[:-3], str(tax_year)[2:])
         else:
-            msg = 'INPUT file named {} does not end in ".csv" or ".gz"'
-            raise ValueError(msg.format(input_filename))
+            msg = 'INPUT file named {} does not end in {}'
+            raise ValueError(msg.format(input_filename,
+                                        '".csv", ".csv.gz", or ".gz"'))
         # construct output_filename and delete old output file if it exists
         if reform_filename:
             if reform_filename.endswith('.json'):
@@ -97,11 +98,14 @@ class IncomeTaxIO(object):
         # set tax policy parameters to specified tax_year
         policy.set_year(tax_year)
         # read input file contents into Records object
-        # (note that recs does not include the IRS-SOI-PUF aggregate record)
-        recs = Records(data=input_filename, consider_imputations=True)
-        if blowup_input_data is False:
-            # prepare Records object for sync_years=False in Calculator ctor
-            recs.set_current_year(tax_year)
+        if blowup_input_data:
+            recs = Records(data=input_filename,
+                           start_year=Records.PUF_YEAR,
+                           consider_imputations=True)
+        else:
+            recs = Records(data=input_filename,
+                           start_year=tax_year,
+                           consider_imputations=False)
         # create Calculator object
         self._calc = Calculator(policy=policy, records=recs,
                                 sync_years=blowup_input_data)

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -247,6 +247,7 @@ class Records(object):
             self.FLPDYR.fill(Records.PUF_YEAR)
         elif isinstance(start_year, int):
             self._current_year = start_year
+            self.FLPDYR.fill(start_year)
         else:
             msg = ('Records.constructor start_year is neither None nor '
                    'an integer')

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -11,6 +11,8 @@ import sys
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
 from taxcalc import IncomeTaxIO  # pylint: disable=import-error
+import pytest
+import tempfile
 
 
 # use 1991 PUF-like data to emulate current PUF, which is private
@@ -19,7 +21,7 @@ FAUX_PUF_CSV = os.path.join(CUR_PATH, '..', '..', 'tax_all1991_puf.gz')
 
 def test_1():
     """
-    Test IncomeTaxIO constructor with no policy reform.
+    Test IncomeTaxIO constructor with no policy reform and no blowup.
     """
     taxyear = 2020
     inctax = IncomeTaxIO(input_filename=FAUX_PUF_CSV,
@@ -31,12 +33,52 @@ def test_1():
 
 def test_2():
     """
-    Test IncomeTaxIO calculate method with no output writing.
+    Test IncomeTaxIO calculate method with no output writing and no blowup.
     """
     taxyear = 2020
     inctax = IncomeTaxIO(input_filename=FAUX_PUF_CSV,
                          tax_year=taxyear,
                          reform_filename=None,
                          blowup_input_data=False)
+    inctax.calculate(write_output_file=False)
+    assert inctax.tax_year() == taxyear
+
+
+RAWINPUTFILE_FUNITS = 4
+RAWINPUTFILE_CONTENTS = (
+    'RECID,MARS\n'
+    '1,2\n'
+    '2,1\n'
+    '3,4\n'
+    '4,6\n'
+)
+
+
+@pytest.yield_fixture
+def rawinputfile():
+    """
+    Temporary input file that contains minimum required input varaibles.
+    """
+    ifile = tempfile.NamedTemporaryFile(suffix='.csv', mode='a', delete=False)
+    ifile.write(RAWINPUTFILE_CONTENTS)
+    ifile.close()
+    # must close and then yield for Windows platform
+    yield ifile
+    if os.path.isfile(ifile.name):
+        try:
+            os.remove(ifile.name)
+        except OSError:
+            pass  # sometimes we can't remove a generated temporary file
+
+
+def test_3(rawinputfile):  # pylint: disable=redefined-outer-name
+    """
+    Test IncomeTaxIO calculate method with no output writing and with blowup.
+    """
+    taxyear = 2021
+    inctax = IncomeTaxIO(input_filename=rawinputfile.name,
+                         tax_year=taxyear,
+                         reform_filename=None,
+                         blowup_input_data=True)
     inctax.calculate(write_output_file=False)
     assert inctax.tax_year() == taxyear

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -3,18 +3,18 @@ Tests for Tax-Calculator IncomeTaxIO class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 test_incometaxio.py
-# pylint --disable=locally-disabled incometaxio.py
+# pylint --disable=locally-disabled test_incometaxio.py
 # (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 import os
 import sys
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
-sys.path.append(os.path.join(CUR_PATH, '../../'))
+sys.path.append(os.path.join(CUR_PATH, '..', '..'))
 from taxcalc import IncomeTaxIO  # pylint: disable=import-error
 
 
 # use 1991 PUF-like data to emulate current PUF, which is private
-FAUX_PUF_CSV = os.path.join(CUR_PATH, '../../tax_all1991_puf.gz')
+FAUX_PUF_CSV = os.path.join(CUR_PATH, '..', '..', 'tax_all1991_puf.gz')
 
 
 def test_1():

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -71,14 +71,69 @@ def rawinputfile():
             pass  # sometimes we can't remove a generated temporary file
 
 
-def test_3(rawinputfile):  # pylint: disable=redefined-outer-name
+REFORM_CONTENTS = """
+// Example of a reform suitable for use as an optional IncomeTaxIO reform file.
+// This JSON file can contain any number of trailing //-style comments, which
+// will be removed before the contents are converted from JSON to a dictionary.
+// The primary keys are policy parameters and secondary keys are years.
+// Both the primary and secondary key values must be enclosed in quotes (").
+// Boolean variables are specified as true or false (no quotes; all lowercase).
+{
+    "_AMT_tthd": // AMT taxinc threshold separating the two AMT tax brackets
+    {"2015": [200000],
+     "2017": [300000]
+    },
+    "_EITC_c": // maximum EITC amount by number of qualifying kids (0,1,2,3+)
+    {"2016": [[ 900, 5000,  8000,  9000]],
+     "2019": [[1200, 7000, 10000, 12000]]
+    },
+    "_II_em": // personal exemption amount (see indexing changes below)
+    {"2016": [6000],
+     "2018": [7500],
+     "2020": [9000]
+    },
+    "_II_em_cpi": // personal exemption amount indexing status
+    {"2016": false, // values in future years are same as this year value
+     "2018": true   // values in future years indexed with this year as base
+    },
+    "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
+    {"2016": [300000],
+     "2018": [500000],
+     "2020": [700000]
+    },
+    "_AMT_em_cpi": // AMT exemption amount indexing status
+    {"2017": false, // values in future years are same as this year value
+     "2020": true   // values in future years indexed with this year as base
+    }
+}
+"""
+
+
+@pytest.yield_fixture
+def reformfile():
+    """
+    Temporary reform file for IncomeTaxIO constructor.
+    """
+    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    rfile.write(REFORM_CONTENTS)
+    rfile.close()
+    # must close and then yield for Windows platform
+    yield rfile
+    if os.path.isfile(rfile.name):
+        try:
+            os.remove(rfile.name)
+        except OSError:
+            pass  # sometimes we can't remove a generated temporary file
+
+
+def test_3(rawinputfile, reformfile):  # pylint: disable=redefined-outer-name
     """
     Test IncomeTaxIO calculate method with no output writing and with blowup.
     """
     taxyear = 2021
     inctax = IncomeTaxIO(input_filename=rawinputfile.name,
                          tax_year=taxyear,
-                         reform_filename=None,
-                         blowup_input_data=True)
+                         reform_filename=reformfile.name,
+                         blowup_input_data=False)
     inctax.calculate(write_output_file=False)
     assert inctax.tax_year() == taxyear


### PR DESCRIPTION
Revise IncomeTaxIO class constructor logic in light of recent Records changes.  These revisions make it easier to use the inctax.py program in one of two ways: (1) with raw input data that are not adjusted in any way (that is, no imputation and no blowup or aging), or (2) with proprietary 2009 puf.csv data that is imputed and blown up in the standard manner.  The first way may be useful in cross-model-validation work, while the second way may be useful in debugging Tax-Calculator income tax logic.

The inctax.py help has been updated to stress that the input csv file ay contain any subset of variable names in the Records.VALID_READ_VARS set, which contains all the variables that Tax-Calculator knows how to use in tax calculations.

All the py.test suite of tests and the validation/tests continue to pass after these changes were made.