### PR TITLE
fix mutation of base_calc from diagnostic table

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -382,6 +382,7 @@ class Calculator(object):
         table = []
         row_years = []
         calc = copy.deepcopy(self)
+        base_calc = copy.deepcopy(base_calc)
 
         for i in range(0, num_years):
             has_behavior = (calc.behavior.BE_sub or calc.behavior.BE_inc or

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -349,6 +349,22 @@ def test_Calculator_diagnostic_table():
     calc.diagnostic_table()
 
 
+def test_Calculator_diagnostic_table_no_mutation():
+    policy_x = Policy()
+    record_x = Records(data=TAX_DTA, weights=WEIGHTS,
+                       start_year=Records.PUF_YEAR)
+    policy_y = Policy()
+    record_y = Records(data=TAX_DTA, weights=WEIGHTS,
+                       start_year=Records.PUF_YEAR)
+    calc_x = Calculator(policy=policy_x, records=record_x)
+    calc_y = Calculator(policy=policy_y, records=record_y)
+    x_start = calc_x.current_year
+    y_start = calc_y.current_year
+    calc_y.diagnostic_table(base_calc=calc_x)
+    assert calc_y.current_year == y_start
+    assert calc_x.current_year == x_start
+
+
 def test_make_Calculator_increment_years_first():
     # create Policy object with custom indexing rates and policy reform
     irates = {2013: 0.01, 2014: 0.01, 2015: 0.02, 2016: 0.01, 2017: 0.03}


### PR DESCRIPTION
The new diagnostic tables allow for the incorporation of behavioral effects by allowing you to pass a base calculator to the method call: `calc_y.diagnostic_table(base_calc = calc_x)`. However, calc_x is mutated by the method; in particular, the year is moved forward in multi-year diagnostic tables. 

This PR creates a hardcopy of base_calc at the top of the method and mutates the copy rather than the passed calculator. I also add a test to ensure that calc_x and calc_y are never advanced in the future. 

@amy-xu, could you please review? 