### PR TITLE
Add --weights option to inctax.py program

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -24,7 +24,7 @@ def main():
                      'the Tax-Calculator. '
                      'The INPUT file is a CSV-formatted file that contains '
                      'variable names that are a subset of the '
-                     'Records.VALID_READ_VARS set.  The OUTPUT file uses '
+                     'Records.VALID_READ_VARS set.  The OUTPUT file is in '
                      'Internet-TAXSIM format.  The OUTPUT filename is the '
                      'INPUT filename (excluding the .csv suffix or '
                      '.gz suffix, or both) followed by '
@@ -56,13 +56,20 @@ def main():
                               'of current-law policy.'),
                         default=None)
     parser.add_argument('--blowup',
-                        help=('optional flag that requires INPUT to be '
-                              '"puf.csv", the contents of which will be '
-                              'aged using default blowup factors from '
-                              'Records.PUF_YEAR to the TAXYEAR. '
+                        help=('optional flag that triggers the default '
+                              'imputation and blowup (or aging) logic built '
+                              'into the Tax-Calculator that will age the '
+                              'INPUT data from Records.PUF_YEAR to TAXYEAR. '
                               'No --blowup option implies INPUT data are '
                               'considered raw data that are not aged or '
                               'adjusted in any way.'),
+                        default=False,
+                        action="store_true")
+    parser.add_argument('--weights',
+                        help=('optional flag that causes OUTPUT to have an '
+                              'additional variable [29] containing the s006 '
+                              'sample weight, which will be aged if the '
+                              '--blowup option is used'),
                         default=False,
                         action="store_true")
     parser.add_argument('INPUT',
@@ -80,14 +87,11 @@ def main():
         IncomeTaxIO.show_iovar_definitions()
         return 0
     # instantiate IncometaxIO object and do federal income tax calculations
-    if args.blowup and args.INPUT != 'puf.csv':
-        msg = 'INPUT must be "puf.csv" when using --blowup option'
-        raise ValueError(msg)
     inctax = IncomeTaxIO(input_filename=args.INPUT,
                          tax_year=args.TAXYEAR,
                          reform_filename=args.reform,
                          blowup_input_data=args.blowup)
-    inctax.calculate()
+    inctax.calculate(output_weights=args.weights)
     # return no-error exit code
     return 0
 # end of main function code

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -116,13 +116,16 @@ class IncomeTaxIO(object):
         """
         return self._calc.policy.current_year
 
-    def calculate(self, write_output_file=True):
+    def calculate(self, write_output_file=True, output_weights=False):
         """
         Calculate taxes for all INPUT lines and write OUTPUT to file.
 
         Parameters
         ----------
         write_output_file: boolean
+
+        output_weights: boolean
+            whether or not to use s006 as an additional output variable.
 
         Returns
         -------
@@ -131,7 +134,8 @@ class IncomeTaxIO(object):
         output = {}  # dictionary indexed by Records index for filing unit
         self._calc.calc_all()
         for idx in range(0, self._calc.records.dim):
-            ovar = SimpleTaxIO.extract_output(self._calc.records, idx)
+            ovar = SimpleTaxIO.extract_output(self._calc.records, idx,
+                                              extract_weight=output_weights)
             ovar[6] = 0.0  # no FICA tax liability included in output
             output[idx] = ovar
         # write contents of output dictionary to OUTPUT file


### PR DESCRIPTION
This enhancement allows the inctax.py program to do the following sort of thing: use ```puf.csv``` as INPUT, impute and age INPUT to the TAXYEAR (using the ```--blowup``` option), and write out the federal income tax liability and various intermediate values (AGI, etc.) and the aged sample weight in the TAXYEAR as output variable 29 (using the new ```--weights``` option).  The output file can then be tabulated (using the weights) to confirm that aggregate results for TAXYEAR are the same as those reported by the Tax-Calculator diagnostic_table() and by TaxBrain.  Having individual filing unit information that aggregates to know totals may be useful in investigating the questionable looking aggregate results from Tax-Calculator and/or TaxBrain.