### PR TITLE
Generalize format of SimpleTaxIO ovar[2], the tax year

### DIFF
--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -565,7 +565,7 @@ class SimpleTaxIO(object):
         # '...'   # last debugging variable
     ]
     OVAR_FMT = {1: '{:d}.',  # add decimal point as in Internet-TAXSIM output
-                2: ' {:d}',
+                2: ' {:.0f}',
                 3: ' {:d}',
                 4: ' {:.2f}',
                 5: ' {:.2f}',


### PR DESCRIPTION
Trivial output format change to handle cases in which inctax.py INPUT file does not include a FLPDYR variable.