### PR TITLE
Allow input_data to be a Pandas DataFrame in IncomeTaxIO constructor

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -75,8 +75,8 @@ def main():
     parser.add_argument('INPUT',
                         help=('INPUT is name of required CSV file that '
                               'contains a subset of variables included in '
-                              'the Records.VALID_READ_VARS set.  INPUT must '
-                              'end in ".csv" or ".gz".'))
+                              'the Records.VALID_READ_VARS set. '
+                              'INPUT must end in ".csv".'))
     parser.add_argument('TAXYEAR',
                         help=('TAXYEAR is calendar year for which federal '
                               'income taxes are computed (e.g., 2013).'),
@@ -87,9 +87,9 @@ def main():
         IncomeTaxIO.show_iovar_definitions()
         return 0
     # instantiate IncometaxIO object and do federal income tax calculations
-    inctax = IncomeTaxIO(input_filename=args.INPUT,
+    inctax = IncomeTaxIO(input_data=args.INPUT,
                          tax_year=args.TAXYEAR,
-                         reform=args.reform,
+                         policy_reform=args.reform,
                          blowup_input_data=args.blowup)
     inctax.calculate(output_weights=args.weights)
     # return no-error exit code

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -59,7 +59,7 @@ class IncomeTaxIO(object):
         """
         # pylint: disable=too-many-statements
         # pylint: disable=too-many-branches
-        if isinstance(input_data, str):
+        if isinstance(input_data, six.string_types):
             # check that input_data string ends with ".csv"
             if input_data.endswith('.csv'):
                 inp = '{}-{}'.format(input_data[:-4], str(tax_year)[2:])

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -10,6 +10,7 @@ Tax-Calculator tax-filing-unit Records class.
 import pandas as pd
 import numpy as np
 import os
+import six
 from numba import vectorize, float64
 from pkg_resources import resource_stream, Requirement
 
@@ -506,7 +507,7 @@ class Records(object):
         """
         if isinstance(data, pd.DataFrame):
             tax_dta = data
-        elif isinstance(data, str):
+        elif isinstance(data, six.string_types):
             if data.endswith("gz"):
                 tax_dta = pd.read_csv(data, compression='gzip')
             else:
@@ -548,7 +549,7 @@ class Records(object):
         """
         if isinstance(weights, pd.DataFrame):
             WT = weights
-        elif isinstance(weights, str):
+        elif isinstance(weights, six.string_types):
             try:
                 if not os.path.exists(weights):
                     # grab weights out of EGG distribution
@@ -573,7 +574,7 @@ class Records(object):
         """
         if isinstance(blowup_factors, pd.DataFrame):
             BF = blowup_factors
-        elif isinstance(blowup_factors, str):
+        elif isinstance(blowup_factors, six.string_types):
             try:
                 if not os.path.exists(blowup_factors):
                     # grab blowup factors out of EGG distribution

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -8,7 +8,7 @@ Tests for Tax-Calculator IncomeTaxIO class.
 
 import os
 from taxcalc import IncomeTaxIO  # pylint: disable=import-error
-from io import StringIO
+from io import BytesIO
 import pandas as pd
 import pytest
 import tempfile
@@ -161,7 +161,7 @@ def test_4(reformfile2):  # pylint: disable=redefined-outer-name
     """
     Test IncomeTaxIO calculate method with no output writing and with blowup.
     """
-    input_stream = StringIO(RAWINPUTFILE_CONTENTS.decode())
+    input_stream = BytesIO(RAWINPUTFILE_CONTENTS)
     input_dataframe = pd.read_csv(input_stream)
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=input_dataframe,

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -161,7 +161,7 @@ def test_4(reformfile2):  # pylint: disable=redefined-outer-name
     """
     Test IncomeTaxIO calculate method with no output writing and with blowup.
     """
-    input_stream = StringIO(unicode(RAWINPUTFILE_CONTENTS))
+    input_stream = StringIO(RAWINPUTFILE_CONTENTS.decode())
     input_dataframe = pd.read_csv(input_stream)
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=input_dataframe,

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -8,7 +8,7 @@ Tests for Tax-Calculator IncomeTaxIO class.
 
 import os
 from taxcalc import IncomeTaxIO  # pylint: disable=import-error
-from io import BytesIO
+from io import StringIO
 import pandas as pd
 import pytest
 import tempfile
@@ -16,11 +16,11 @@ import tempfile
 
 RAWINPUTFILE_FUNITS = 4
 RAWINPUTFILE_CONTENTS = (
-    'RECID,MARS\n'
-    '1,2\n'
-    '2,1\n'
-    '3,4\n'
-    '4,6\n'
+    u'RECID,MARS\n'
+    u'1,2\n'
+    u'2,1\n'
+    u'3,4\n'
+    u'4,6\n'
 )
 
 
@@ -161,7 +161,7 @@ def test_4(reformfile2):  # pylint: disable=redefined-outer-name
     """
     Test IncomeTaxIO calculate method with no output writing and with blowup.
     """
-    input_stream = BytesIO(RAWINPUTFILE_CONTENTS)
+    input_stream = StringIO(RAWINPUTFILE_CONTENTS)
     input_dataframe = pd.read_csv(input_stream)
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=input_dataframe,

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -96,6 +96,7 @@ def test_1(input_file):  # pylint: disable=redefined-outer-name
     """
     Test SimpleTaxIO constructor with no policy reform.
     """
+    SimpleTaxIO.show_iovar_definitions()
     simtax = SimpleTaxIO(input_filename=input_file.name,
                          reform=None,
                          emulate_taxsim_2441_logic=False)


### PR DESCRIPTION
These revisions allow the constructor to accept not only a string for a CSV input file, but also a Pandas DataFrame that is suitable for passing to the Records class constructor.  These revisions make it easier to use the IncomeTaxIO class in the pytest suite of tests.