### PR TITLE
Make SimpleTaxIO class able to write OUTPUT to file or string

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -91,7 +91,7 @@ def main():
                          tax_year=args.TAXYEAR,
                          policy_reform=args.reform,
                          blowup_input_data=args.blowup)
-    inctax.calculate(output_weights=args.weights)
+    inctax.calculate(writing_output_file=True, output_weights=args.weights)
     # return no-error exit code
     return 0
 # end of main function code

--- a/simtax.py
+++ b/simtax.py
@@ -69,7 +69,7 @@ def main():
     simtax = SimpleTaxIO(input_filename=args.INPUT,
                          reform=args.reform,
                          emulate_taxsim_2441_logic=args.taxsim2441)
-    simtax.calculate()
+    simtax.calculate(writing_output_file=True)
     # return no-error exit code
     return 0
 # end of main function code

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -107,16 +107,17 @@ class SimpleTaxIO(object):
         """
         return self._policy.end_year
 
-    def calculate(self):
+    def calculate(self, writing_output_file=False):
         """
         Calculate taxes for all INPUT lines and write or return OUTPUT lines.
 
         Output lines will be written to file if SimpleTaxIO constructor was
-        passed an input_filename string and was passed a reform string or None.
+        passed an input_filename string and a reform string or None and if
+        writing_output_file is True.
 
         Parameters
         ----------
-        write_output_file: boolean
+        writing_output_file: boolean
 
         Returns
         -------
@@ -141,13 +142,14 @@ class SimpleTaxIO(object):
                     ovar[9] = 100 * mtr_fica[idx]
                     output[idx] = ovar
         assert len(output) == len(self._input)
-        # handle calculated output depending on use of input and reform files
+        # handle disposition of calculated output
         olines = ''
-        if self._using_input_file and self._using_reform_file:
-            self.write_output_file(output, self._output_filename)
+        writing_possible = self._using_input_file and self._using_reform_file
+        if writing_possible and writing_output_file:
+            SimpleTaxIO.write_output_file(output, self._output_filename)
         else:
             for idx in range(0, len(output)):
-                olines += SimpleTaxIO._construct_output_line(output[idx])
+                olines += SimpleTaxIO.construct_output_line(output[idx])
         return olines
 
     def number_input_lines(self):
@@ -330,8 +332,65 @@ class SimpleTaxIO(object):
         """
         with open(output_filename, 'w') as output_file:
             for idx in range(0, len(output)):
-                outline = SimpleTaxIO._construct_output_line(output[idx])
+                outline = SimpleTaxIO.construct_output_line(output[idx])
                 output_file.write(outline)
+
+    OVAR_NUM = 28
+    DVAR_NAMES = [  # OPTIONAL DEBUGGING OUTPUT VARIABLE NAMES
+        # '...',  # first debugging variable
+        # '...',  # second debugging variable
+        # etc.
+        # '...'   # last debugging variable
+    ]
+    OVAR_FMT = {1: '{:d}.',  # add decimal point as in Internet-TAXSIM output
+                2: ' {:.0f}',
+                3: ' {:d}',
+                4: ' {:.2f}',
+                5: ' {:.2f}',
+                6: ' {:.2f}',
+                7: ' {:.2f}',
+                8: ' {:.2f}',
+                9: ' {:.2f}',
+                10: ' {:.2f}',
+                11: ' {:.2f}',
+                12: ' {:.2f}',
+                13: ' {:.2f}',
+                14: ' {:.2f}',
+                15: ' {:.2f}',
+                16: ' {:.2f}',
+                17: ' {:.2f}',
+                18: ' {:.2f}',
+                19: ' {:.2f}',
+                20: ' {:.2f}',
+                21: ' {:.2f}',
+                22: ' {:.2f}',
+                23: ' {:.2f}',
+                24: ' {:.2f}',
+                25: ' {:.2f}',
+                26: ' {:.2f}',
+                27: ' {:.2f}',
+                28: ' {:.2f}'}
+
+    @staticmethod
+    def construct_output_line(output_dict):
+        """
+        Construct line of OUTPUT from a filing unit output_dict.
+
+        Parameters
+        ----------
+        output_dict: dictionary
+            calculated output values indexed from 1 to len(output_dict).
+
+        Returns
+        -------
+        output_line: string
+        """
+        outline = ''
+        for vnum in range(1, len(output_dict) + 1):
+            fnum = min(vnum, SimpleTaxIO.OVAR_NUM)
+            outline += SimpleTaxIO.OVAR_FMT[fnum].format(output_dict[vnum])
+        outline += '\n'
+        return outline
 
     # --- begin private methods of SimpleTaxIO class --- #
 
@@ -586,63 +645,5 @@ class SimpleTaxIO(object):
         recs.e19200[idx] = ivar[20]  # AMT-nonpreferred deductions
         recs.p22250[idx] = ivar[21]  # short-term capital gains (+/-)
         recs.p23250[idx] = ivar[22]  # long-term capital gains (+/-)
-
-    OVAR_NUM = 28
-    DVAR_NAMES = [  # OPTIONAL DEBUGGING OUTPUT VARIABLE NAMES
-        # '...',  # first debugging variable
-        # '...',  # second debugging variable
-        # etc.
-        # '...'   # last debugging variable
-    ]
-    OVAR_FMT = {1: '{:d}.',  # add decimal point as in Internet-TAXSIM output
-                2: ' {:.0f}',
-                3: ' {:d}',
-                4: ' {:.2f}',
-                5: ' {:.2f}',
-                6: ' {:.2f}',
-                7: ' {:.2f}',
-                8: ' {:.2f}',
-                9: ' {:.2f}',
-                10: ' {:.2f}',
-                11: ' {:.2f}',
-                12: ' {:.2f}',
-                13: ' {:.2f}',
-                14: ' {:.2f}',
-                15: ' {:.2f}',
-                16: ' {:.2f}',
-                17: ' {:.2f}',
-                18: ' {:.2f}',
-                19: ' {:.2f}',
-                20: ' {:.2f}',
-                21: ' {:.2f}',
-                22: ' {:.2f}',
-                23: ' {:.2f}',
-                24: ' {:.2f}',
-                25: ' {:.2f}',
-                26: ' {:.2f}',
-                27: ' {:.2f}',
-                28: ' {:.2f}'}
-
-    @staticmethod
-    def _construct_output_line(output_dict):
-        """
-        Construct line of OUTPUT from a filing unit output_dict.
-
-        Parameters
-        ----------
-        output_dict: dictionary
-            calculated output values indexed from 1 to len(output_dict).
-
-        Returns
-        -------
-        output_line: string
-        """
-        outline = ""
-        for vnum in range(1, len(output_dict) + 1):
-            fnum = min(vnum, SimpleTaxIO.OVAR_NUM)
-            outline += SimpleTaxIO.OVAR_FMT[fnum].format(output_dict[vnum])
-        outline += '\n'
-        return outline
-
 
 # end SimpleTaxIO class

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -23,6 +23,17 @@ RAWINPUTFILE_CONTENTS = (
     u'4,6\n'
 )
 
+EXPECTED_OUTPUT = (  # from using RAWINPUTFILE_CONTENTS as input
+    '1. 2021 0 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 '
+    '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
+    '2. 2021 0 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 '
+    '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
+    '3. 2021 0 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 '
+    '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
+    '4. 2021 0 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 '
+    '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
+)
+
 
 @pytest.yield_fixture
 def rawinputfile():
@@ -46,7 +57,7 @@ def test_1(rawinputfile):  # pylint: disable=redefined-outer-name
     Test IncomeTaxIO constructor with no policy reform and no blowup.
     """
     IncomeTaxIO.show_iovar_definitions()
-    taxyear = 2020
+    taxyear = 2021
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
                          policy_reform=None,
@@ -58,7 +69,7 @@ def test_2(rawinputfile):  # pylint: disable=redefined-outer-name
     """
     Test IncomeTaxIO calculate method with no output writing and no blowup.
     """
-    taxyear = 2020
+    taxyear = 2021
     reform_dict = {
         2016: {'_SS_Earnings_c': [300000]},
         2018: {'_SS_Earnings_c': [500000]},
@@ -68,8 +79,8 @@ def test_2(rawinputfile):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=reform_dict,
                          blowup_input_data=False)
-    inctax.calculate(write_output_file=False)
-    assert inctax.tax_year() == taxyear
+    output = inctax.calculate()
+    assert output == EXPECTED_OUTPUT
 
 
 REFORM_CONTENTS = """
@@ -153,8 +164,8 @@ def test_3(rawinputfile, reformfile1):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=reformfile1.name,
                          blowup_input_data=False)
-    inctax.calculate(write_output_file=False)
-    assert inctax.tax_year() == taxyear
+    output = inctax.calculate()
+    assert output == EXPECTED_OUTPUT
 
 
 def test_4(reformfile2):  # pylint: disable=redefined-outer-name
@@ -168,5 +179,5 @@ def test_4(reformfile2):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=reformfile2.name,
                          blowup_input_data=False)
-    inctax.calculate(write_output_file=False)
-    assert inctax.tax_year() == taxyear
+    output = inctax.calculate()
+    assert output == EXPECTED_OUTPUT

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -148,5 +148,5 @@ def test_3(input_file):  # pylint: disable=redefined-outer-name
     simtax = SimpleTaxIO(input_filename=input_file.name,
                          reform=policy_reform,
                          emulate_taxsim_2441_logic=False)
-    simtax.calculate(write_output_file=False)
+    simtax.calculate()
     assert simtax.number_input_lines() == NUM_INPUT_LINES


### PR DESCRIPTION
These changes make it easier to use the SimpleTaxIO class and the IncomeTaxIO class, which uses SimpleTaxIO static output functions, in the pytest suite of tests.

These changes have no effect on the central tax-calculation logic or on any of the test results.
