### PR TITLE
Add --mtr option to inctax.py and associated logic to IncomeTaxIO class

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -72,6 +72,12 @@ def main():
                               '--blowup option is used'),
                         default=False,
                         action="store_true")
+    parser.add_argument('--mtr',
+                        help=('optional flag that causes OUTPUT to include '
+                              'calculated marginal tax rates expressed in '
+                              'percentage terms (instead of zeros).'),
+                        default=False,
+                        action="store_true")
     parser.add_argument('INPUT',
                         help=('INPUT is name of required CSV file that '
                               'contains a subset of variables included in '
@@ -91,7 +97,9 @@ def main():
                          tax_year=args.TAXYEAR,
                          policy_reform=args.reform,
                          blowup_input_data=args.blowup)
-    inctax.calculate(writing_output_file=True, output_weights=args.weights)
+    inctax.calculate(writing_output_file=True,
+                     output_weights=args.weights,
+                     output_mtr=args.mtr)
     # return no-error exit code
     return 0
 # end of main function code

--- a/inctax.py
+++ b/inctax.py
@@ -74,8 +74,9 @@ def main():
                         action="store_true")
     parser.add_argument('--mtr',
                         help=('optional flag that causes OUTPUT to include '
-                              'calculated marginal tax rates expressed in '
-                              'percentage terms (instead of zeros).'),
+                              'calculated marginal federal income tax rate '
+                              'expressed in percentage terms (instead of '
+                              'zero).'),
                         default=False,
                         action="store_true")
     parser.add_argument('INPUT',

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -152,8 +152,8 @@ class IncomeTaxIO(object):
             whether or not to use s006 as an additional output variable.
 
         output_mtr: boolean
-            whether or not write calculated marginal tax rates instead of
-            zeros.
+            whether or not write calculated marginal federal income tax
+            rate instead of zero.
 
         Returns
         -------
@@ -163,8 +163,7 @@ class IncomeTaxIO(object):
         """
         output = {}  # dictionary indexed by Records index for filing unit
         if output_mtr:
-            (mtr_fica, mtr_iitx,
-             _) = self._calc.mtr(wrt_full_compensation=False)
+            (_, mtr_iitx, _) = self._calc.mtr(wrt_full_compensation=False)
         else:
             self._calc.calc_all()
         for idx in range(0, self._calc.records.dim):
@@ -173,7 +172,6 @@ class IncomeTaxIO(object):
             ovar[6] = 0.0  # no FICA tax liability included in output
             if output_mtr:
                 ovar[7] = 100 * mtr_iitx[idx]
-                ovar[9] = 100 * mtr_fica[idx]
             output[idx] = ovar
         assert len(output) == self._calc.records.dim
         # handle disposition of calculated output
@@ -213,7 +211,7 @@ class IncomeTaxIO(object):
                '[ 6] FICA (OASDI+HI) tax liability [ALWAYS ZERO]\n'
                '[ 7] marginal federal inc tax rate [ZERO UNLESS --mtr USED]\n'
                '[ 8] marginal state income tax rate [ALWAYS ZERO]\n'
-               '[ 9] marginal FICA tax rate [ZERO UNLESS --mtr USED]\n'
+               '[ 9] marginal FICA tax rate [ALWAYS ZERO]\n'
                '[10] federal adjusted gross income, AGI\n'
                '[11] unemployment (UI) benefits included in AGI\n'
                '[12] social security (OASDI) benefits included in AGI\n'

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -34,6 +34,17 @@ EXPECTED_OUTPUT = (  # from using RAWINPUTFILE_CONTENTS as input
     '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
 )
 
+EXPECTED_OUTPUT_MTR = (  # from using RAWINPUTFILE_CONTENTS as input
+    '1. 2021 0 0.00 0.00 0.00 -7.65 0.00 0.00 0.00 0.00 0.00 0.00 0.00 '
+    '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
+    '2. 2021 0 0.00 0.00 0.00 -7.65 0.00 0.00 0.00 0.00 0.00 0.00 0.00 '
+    '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
+    '3. 2021 0 0.00 0.00 0.00 -7.65 0.00 0.00 0.00 0.00 0.00 0.00 0.00 '
+    '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
+    '4. 2021 0 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 '
+    '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
+)
+
 
 @pytest.yield_fixture
 def rawinputfile():
@@ -61,7 +72,7 @@ def test_1(rawinputfile):  # pylint: disable=redefined-outer-name
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
                          policy_reform=None,
-                         blowup_input_data=False)
+                         blowup_input_data=True)
     assert inctax.tax_year() == taxyear
 
 
@@ -79,8 +90,13 @@ def test_2(rawinputfile):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=reform_dict,
                          blowup_input_data=False)
-    output = inctax.calculate()
-    assert output == EXPECTED_OUTPUT
+    output = inctax.calculate(output_mtr=True)
+    print "============================================================="
+    print output
+    print "============================================================="
+    print EXPECTED_OUTPUT_MTR
+    print "============================================================="
+    assert output == EXPECTED_OUTPUT_MTR
 
 
 REFORM_CONTENTS = """

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -91,11 +91,6 @@ def test_2(rawinputfile):  # pylint: disable=redefined-outer-name
                          policy_reform=reform_dict,
                          blowup_input_data=False)
     output = inctax.calculate(output_mtr=True)
-    print "============================================================="
-    print output
-    print "============================================================="
-    print EXPECTED_OUTPUT_MTR
-    print "============================================================="
     assert output == EXPECTED_OUTPUT_MTR
 
 

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -17,10 +17,10 @@ import tempfile
 RAWINPUTFILE_FUNITS = 4
 RAWINPUTFILE_CONTENTS = (
     u'RECID,MARS\n'
-    u'1,2\n'
-    u'2,1\n'
-    u'3,4\n'
-    u'4,6\n'
+    u'    1,   2\n'
+    u'    2,   1\n'
+    u'    3,   4\n'
+    u'    4,   6\n'
 )
 
 EXPECTED_OUTPUT = (  # from using RAWINPUTFILE_CONTENTS as input


### PR DESCRIPTION
The new --mtr option causes the calculated marginal federal income tax rate to be included in inctax.py output (rather than the marginal rate being zero when the --mtr option is not used).