### PR TITLE
Remove unnecessary cast to float from ChildTaxCredit function

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1258,9 +1258,6 @@ def ChildTaxCredit(n24, MARS, CTC_c, c00100, _feided, CTC_ps, _exact,
         _precrd = max(0., _precrd - CTC_prt *
                       max(0., _ctcagi - CTC_ps[MARS - 1]))
 
-    # TODO get rid of this type declaration
-    _precrd = float(_precrd)
-
     return (_nctcr, _precrd, _ctcagi)
 
 


### PR DESCRIPTION
As suggested in TODO comment.  Revision leaves tax-calculation code and test results unchanged.