### PR TITLE
Fix calculation of employer share of FICA taxes in ExpandIncome function

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1681,17 +1681,13 @@ def Taxer_i(inc_in, MARS, II_rt1, II_rt2, II_rt3, II_rt4, II_rt5, II_rt6,
     return inc_out
 
 
-@iterate_jit(nopython=True, parameters=['FICA_ss_trt', 'SS_Earnings_c',
-                                        'FICA_mc_trt'])
-def ExpandIncome(FICA_ss_trt, SS_Earnings_c, e00200, FICA_mc_trt, e02400,
-                 c02500, c00100, e00400):
+@iterate_jit(nopython=True)
+def ExpandIncome(_fica_was, e02400, c02500, c00100, e00400):
     """
     ExpandIncome function: ...
     """
-    employer_share_fica = (max(0,
-                               0.5 * FICA_ss_trt * min(SS_Earnings_c, e00200) +
-                               0.5 * FICA_mc_trt * e00200))
-    non_taxable_ss_benefits = (e02400 - c02500)
+    employer_share_fica = 0.5 * _fica_was
+    non_taxable_ss_benefits = e02400 - c02500
     _expanded_income = (c00100 +  # AGI
                         e00400 +  # Non-taxable interest
                         non_taxable_ss_benefits +


### PR DESCRIPTION
The old logic in the ExpandIncome function computed half the FICA tax on wage-and-salary income incorrectly in situations where both members of a couple have earnings and their combined earnings exceed the OASDI maximum taxable earnings level (SS_Earnings_c).  This pull request corrects that problem.

The logic revision in this pull request did not change any taxcalc test results, but it may affect the results generated by the dynamic model and affect the display of distributional tax results in TaxBrain.

cc @MattHJensen @feenberg @rickecon @talumbau @Amy-Xu @GoFroggyRun 