### PR TITLE
fix bug in personal refundable credit phaseout rate 

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -576,7 +576,7 @@ def Personal_Credit(c04500, MARS, II_credit, II_credit_ps, II_credit_prt):
     else:
         credit_phaseout = 0.0
 
-    _personal_credit = _personal_credit - credit_phaseout
+    _personal_credit = max(0, _personal_credit - credit_phaseout)
 
     return _personal_credit
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -576,7 +576,7 @@ def Personal_Credit(c04500, MARS, II_credit, II_credit_ps, II_credit_prt):
     else:
         credit_phaseout = 0.0
 
-    _personal_credit = max(0, _personal_credit - credit_phaseout)
+    _personal_credit = max(0.0, _personal_credit - credit_phaseout)
 
     return _personal_credit
 


### PR DESCRIPTION
The personal refundable credit should only reduce taxes. Before, if the phaseout rate was positive, the credit could increase taxes. 

This does not affect baseline results. @martinholmer, could you please review? 