### PR TITLE
Remove _AMT_CG_rt4 parameter; go back to 0.25 hardwired rate

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -19,6 +19,7 @@
                       [53600,    83400,   41700,      53600,               83400,   41700],
                       [53900,    83800,   41900,      53900,               83800,   41900]]
     },
+
     "_EITC_c": {
         "long_name": "Maximum earned income credit",
 	"description": "This is the maximum amount of earned income credit taxpayers are eligible for; it depends on how many kids they have. ",
@@ -37,8 +38,8 @@
                        [496,    3305,       5460,      6143],
                        [503,    3359,       5548,      6242],
                        [506,    3373,       5572,      6269]]
-    
     },
+
     "_SS_thd50":{
         "long_name": "Threshold for Social Security benefit taxability 1",
 	"description": "The first threshold for Social Security benefit taxability: if taxpayers have provisional income greater than this threshold, up to 50% of their Social Security benefit will be subject to tax under current law.",
@@ -51,9 +52,9 @@
         "cpi_inflated": false,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
         "value":      [[25000,    32000,   0,          25000,               25000,   0]]
-        
     },
-     "_SS_thd85":{
+
+    "_SS_thd85":{
         "long_name": "Threshold for Social Security benefit taxability 2",
 	"description": "The second threshold for Social Security taxability: if taxpayers have provisional income greater than this threshold, up to 85% of their Social Security benefit will be subject to tax under current law.",
         "irs_ref": "Form 1040, line 20a&b, calculation (Worksheet, add line 10 values to line 8).",
@@ -65,9 +66,9 @@
         "cpi_inflated": false,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
         "value":      [[34000,    44000,   0,          34000,               34000,   0]]
-        
     },
-     "_ACTC_rt":{
+
+    "_ACTC_rt":{
         "long_name": "Additional child tax credit rate",
 	"description": "This is the fraction of earnings used in calculating the ACTC, which is a partially refundable credit that supplements the CTC for some taxpayers. ",
         "irs_ref": "Form 8812, line 6, inline.",
@@ -79,9 +80,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":      [0.15]
-        
     },
-     "_STD_Aged":{
+
+    "_STD_Aged":{
         "long_name": "Additional standard deduction for blind and aged",
 	"description": "To get the standard deduction for aged or blind individuals, taxpayers need to add this value to regular standard deduction",
         "irs_ref": "Form 1040, line 40, calculation (the difference of the two tables given in the instruction).",
@@ -100,10 +101,9 @@
 		               [1550, 1250, 1250, 1550, 1550, 1250],
                        [1550, 1250, 1250, 1550, 1550, 1250]],
 	"validations": {"min": "default"}
-
     },
 
-     "_AMT_Child_em":{
+    "_AMT_Child_em":{
         "long_name": "Child AMT exemption additional income base",
 	"description": "The child's AMT exemption is capped by this amount plus the child's earned income.",
         "irs_ref": "Form 6251, line 29, instruction.",
@@ -121,8 +121,8 @@
                    7250,
                    7400,
                    7400]
-        
     },
+
     "_AMT_thd_MarriedS":{
         "long_name": "Extra alminc for married sep",
 	"description": "",
@@ -137,9 +137,9 @@
         "col_label": "",
         "value":  [40400,
 		   41050]
-        
     },
-     "_AMT_tthd":{
+
+    "_AMT_tthd":{
         "long_name": "AMT surtax threshold",
 	"description": "This threshold separates the 26%* and 28%* AMT tax rates: in order to get tentative minimum tax, income below this level is subject to 26% tax rate and above this level subject at 28%.",
         "irs_ref": "Form 6251, line 31, instruction.",
@@ -157,9 +157,9 @@
                   182500,
                   185400,
                   186300]
-        
     },
-     "_II_em":{
+
+    "_II_em":{
         "long_name": "Personal and dependent exemption amount",
 	"description":  "Subtracted from AGI in the calculation of taxable income, per taxpayer and dependent.",
         "irs_ref": "IRS reference: form 1040, line 42. ",
@@ -177,9 +177,9 @@
                     3950,
                     4000,
                     4050]
-        
     },
-     "_KT_c_Age":{
+
+    "_KT_c_Age":{
         "long_name": "Maximum age subject to Kiddie Tax",
 	"description": "At or under this age, the individual is subject to Kiddie Tax.",
         "irs_ref": "Form 6251, line 28, instruction.",
@@ -191,9 +191,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [24]
-        
     },
-     "_AMT_em_pe":{
+
+    "_AMT_em_pe":{
         "long_name": "AMT exemption phaseout ending AMTI (Married filling Separately)",
 	"description": "The AMT exemption is entirely disallowed beyond this AMTI level for individuals who are married but filing separately.",
         "irs_ref": "Form 6251, line 28, instruction.",
@@ -207,9 +207,9 @@
         "col_label": "",
         "value":   [238550,
                     242450]
-        
-    },	
-     "_CTC_c":{
+    },
+
+    "_CTC_c":{
         "long_name": "Maximum child tax credit per child",
 	"description": "The maximum amount of credit allowed for each child. ",
         "irs_ref": "form 1040, line 52, instructions (child tax credit worksheet, line 1). ",
@@ -221,7 +221,8 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [ 1000 ]
-    },	
+    },
+
     "_DCC_c":{
         "long_name": "Max dependent care credit per dependent",
 	"description": "",
@@ -235,7 +236,8 @@
         "col_label": "",
         "value":     [3000]
     },
-     "_EITC_InvestIncome_c":{
+
+    "_EITC_InvestIncome_c":{
         "long_name": "Max disqualifying income for EITC",
 	"description": "The earned income credit may not be claimed by taxpayers whose investment income exceeds this limit.",
         "irs_ref": "Form 1040, line 66a&b, instruction(step2)",
@@ -244,8 +246,8 @@
         "col_var": "",
         "row_var": "FLPDYR",
         "row_label": ["2013",
-		              "2014",
-		              "2015",
+		      "2014",
+		      "2015",
                       "2016"],
         "cpi_inflated": false,
         "col_label": "",
@@ -253,8 +255,9 @@
                     3350,
                     3400,
                     3400]    
-    },	
-     "_ACTC_Income_thd":{
+    },
+
+    "_ACTC_Income_thd":{
         "long_name": "ACTC income threshold",
 	"description": "The portion of earned income below this threshold does not count as base for the additional child tax credit.",
         "irs_ref": "Form 2441, line 3, in-line.",
@@ -266,8 +269,8 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [ 3000 ] 
-        
-    },	
+    },
+
     "_ETC_pe_Single":{
         "long_name": "Education tax credit phaseout ends (Single)",
 	"description": "The education tax credit will be zero for those taxpayers of single filing status with modified AGI (in thousands) higher than this level.",
@@ -284,8 +287,8 @@
         "value":   [63,
                     64,
                     65]
-        
     },
+
     "_ETC_pe_Married":{
         "long_name": "Education tax credit phaseout ends (Married)",
 	"description": "The education tax credit will be zero for those taxpayers of married filing status with modified AGI level (in thousands) higher than this level.",
@@ -302,9 +305,9 @@
         "value":   [127,
                     128,
                     130]
-        
-    },	
-     "_FEI_ec_c":{
+    },
+
+    "_FEI_ec_c":{
         "long_name": "Maximum foreign earned income exclusion",
 	"description": "This amount is the maximum foreign earned income taxpayers could exclude from gross income.",
         "irs_ref": "Form 2555, line 29b, instruction.",
@@ -315,15 +318,16 @@
         "row_label": ["2013",
 		      "2014",
 		      "2015",
-              "2016"],
+                      "2016"],
         "cpi_inflated": false,
         "col_label": "",
         "value": [97600,
                   99200,
                   100800,
                   101300]
-    },	
-     "_EITC_ps_MarriedJ":{
+    },
+
+    "_EITC_ps_MarriedJ":{
         "long_name": "EITC Phaseout Starting AGI (Married filling Jointly)",
 	"description": "This is the additional amount added on the regular EITC phaseout start, only for taxpayers with filling status of married filling jointly. ",
         "irs_ref": "Form 1040, line 66a&b, calcuation (the difference btw EIC phaseout bases of married jointly fillers and other fillers).",
@@ -334,16 +338,16 @@
         "row_label": ["2013",
 		      "2014",
 		      "2015",
-              "2016"],
+                      "2016"],
         "cpi_inflated": true,
         "col_label":"0kids 1kid  2kids 3+kids",
         "value":  [ [5340, 5340, 5340, 5340],
                     [5430, 5430, 5430, 5430],
                     [5510, 5520, 5520, 5520],
                     [5550, 5550, 5550, 5550]]
-        
     },
-     "_LLC_Expense_c":{
+
+    "_LLC_Expense_c":{
         "long_name": "Lifetime learning credit expense limit",
 	"description": "The maximum expense eligible for lifetime learning credit, per child.",
         "irs_ref": "Form 8863, line 11, in-line.",
@@ -355,9 +359,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [10000]
-        
-    },	
-     "_CDCC_crt":{
+    },
+
+    "_CDCC_crt":{
         "long_name": "Maximum child and dependent care credit rate",
 	"description": "This rate is the maximum rate that applied on AGI for child and dependent care credit; This rate decreases as AGI goes up.",
         "irs_ref": "Form 2241, line 8, in-line.",
@@ -369,8 +373,8 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [35]
-        
-    },	
+    },
+
     "_ID_ps":{
         "long_name": "Itemized deduction phaseout AGI start (Pease provision)",
 	"description": "The itemized deductions will be reduced for taxpayers with AGI higher than this level.",
@@ -390,6 +394,7 @@
                       [258250, 	309900,   154950,     284050, 		       309900,  154950],
                       [259400,  311300,   155650,     285350,              311300,  155650]]
     },
+
     "_ID_BenefitSurtax_Switch":{
         "long_name": "Deductions subject to the surtax on itemized deduction benefits",
 	"description": "The surtax on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter. ",
@@ -403,7 +408,8 @@
         "col_label": ["Medical", "State & Local", "Real Estate", "Casualty", "Miscellaneous", "Interest", "Charity"],        
         "value":    [[true, 	   true,           true,          true,          true,           true,      true]]
     },
-     "_EITC_rt":{
+
+    "_EITC_rt":{
         "long_name": "Earned income credit rate",
 	"description": "If one taxpayer's AGI is below AGI phaseout start, he can apply this rate to his earned income to calculate the credit amount eligible. ",
         "irs_ref": "Form 1040, line 66a&b, calculation (table: Max_EIC/Max_EIC_base_income).",
@@ -415,8 +421,9 @@
         "cpi_inflated": false,
         "col_label":["0kids", "1kid", "2kids", "3+kids"],
         "value":    [[0.0765, 0.3400, 0.4000, 0.4500]]        
-    },	
-     "_EITC_prt":{
+    },
+
+    "_EITC_prt":{
         "long_name": "Earned income credit phaseout rate",
 	"description": "Earned income credit will decrease at the this rate when AGI is higher than EITC phaseout start. ",
         "irs_ref": "Form 1040, line 66a&b, calculation (table: Max_EIC_base_income/Phaseout_Base).",
@@ -429,6 +436,7 @@
         "col_label":["0kids", "1kid", "2kids", "3+kids"],
         "value":    [[0.0765, 0.1598, 0.2106, 0.2106]]        
     },
+
     "_SS_Earnings_c":{
         "long_name": "Maximum Taxable Earnings for Social Security",
 	"description": "Only individual earnings below this maximum amount are subjected to Social Security (OASDI) payroll tax.",
@@ -438,8 +446,8 @@
         "col_var": "",
         "row_var": "FLPDYR",
         "row_label": ["2013",
-		              "2014",
-		              "2015",
+		      "2014",
+		      "2015",
                       "2016"],
         "cpi_inflated": true,
         "col_label": "",
@@ -447,9 +455,9 @@
                    117000,
                    118500,
                    118500]
-        
-    },	
-     "_EITC_ps":{
+    },
+
+    "_EITC_ps":{
         "long_name": "Earned income credit phaseout AGI start",
 	"description": "If AGI is higher than this threshold, the amount of EITC will start to decrease. ",
         "irs_ref": "Form 1040, line 66a&b, instructions.",
@@ -458,8 +466,8 @@
         "col_var": "",
         "row_var": "FLPDYR",
         "row_label": ["2013",
-		              "2014",
-		              "2015",
+		      "2014",
+		      "2015",
                       "2016"],
         "cpi_inflated": true,
         "col_label":"0kids 1kid  2kids 3+kids",
@@ -467,9 +475,9 @@
                     [8110, 17830, 17830, 17830],
                     [8240, 18110, 18110, 18110],
                     [8270, 18190, 18190, 18190]]
-        
     },
-     "_II_rt1":{
+
+    "_II_rt1":{
         "long_name": "Personal income tax rate 1",
 	"description": "The lowest tax rate, applied to the portion of taxable income below tax bracket 1. ",
         "irs_ref": "Form 1040, line 44, instruction (Schedule X)",
@@ -481,9 +489,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.1]
-        
-    },	
-     "_II_rt2":{
+    },
+
+    "_II_rt2":{
         "long_name": "Personal income tax rate 2",
 	"description": "The second lowest tax rate, applied to the portion of taxable income below tax bracket 2 and above tax bracket 1. ",
         "irs_ref": "Form 1040, line 44, instruction (Schedule X)",
@@ -495,9 +503,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.15]
-        
-    },	
-     "_II_rt3":{
+    },
+
+    "_II_rt3":{
         "long_name": "Personal income tax rate 3",
 	"description": "The third lowest tax rate, applied to the portion of taxable income below tax bracket 3 and above tax bracket 2. ",
         "irs_ref": "Form 1040, line 44, instruction (Schedule X)",
@@ -509,9 +517,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.25]
-        
-    },	
-     "_II_rt4":{
+    },
+
+    "_II_rt4":{
         "long_name": "Personal income tax rate 4",
 	"description": "The tax rate applied to the portion of taxable income below tax bracket 4 and above tax bracket 3. ",
         "irs_ref": "Form 1040, line 44, instruction (Schedule X)",
@@ -523,9 +531,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.28]
-        
-    },	
-     "_II_rt5":{
+    },
+
+    "_II_rt5":{
         "long_name": "Personal income tax rate 5",
 	"description": "The third highest tax rate, applied to the portion of taxable income below tax bracket 5 and above tax bracket 4. ",
         "irs_ref": "Form 1040, line 44, instruction (Schedule X)",
@@ -537,8 +545,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.33]
-    },	
-     "_II_rt6":{
+    },
+
+    "_II_rt6":{
         "long_name": "Personal income tax rate 6",
 	"description": "The second higher tax rate, applied to the portion of taxable income below tax bracket 6 and above tax bracket 5. ",
         "irs_ref": "Form 1040, line 44, instruction (Schedule X)",
@@ -550,9 +559,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.35]
-        
-    },	
-     "_II_rt7":{
+    },
+
+    "_II_rt7":{
         "long_name": "Personal income tax rate 7",
 	"description": "The highest tax rate, applied to the portion of taxable income below tax bracket 7 and above tax bracket 6. ",
         "irs_ref": "Form 1040, line 44, instruction (Schedule X)",
@@ -564,8 +573,8 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.396]
-        
-    },	
+    },
+
     "_AMT_em_ps":{
         "long_name": "AMT exemption phaseout start",
 	"description": "AMT exemption starts to decrease when AMTI goes beyond this threshold.",
@@ -580,12 +589,12 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":
-                    [[115400, 153900, 76950, 115400, 153900, 76950],
-                    [117300, 156500, 78250, 117300, 156500, 78250],
-                    [119200, 158900, 79450, 119200, 158900, 79450],
-                    [119700, 159700, 79850, 119700, 159700, 79850]]
+        "value": [[115400, 153900, 76950, 115400, 153900, 76950],
+                  [117300, 156500, 78250, 117300, 156500, 78250],
+                  [119200, 158900, 79450, 119200, 158900, 79450],
+                  [119700, 159700, 79850, 119700, 159700, 79850]]
     },
+
     "_CTC_ps":{
         "long_name": "Child tax credit phaseout MAGI start",
 	"description": "Child tax credit begins to decrease when MAGI is above this level.",
@@ -599,6 +608,7 @@
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
         "value":     [[75000,     110000,  55000,      75000,               75000,   55000]]
     },
+
     "_NIIT_thd":{
         "long_name": "Net Investment Income Tax income threshold (UIMC)",
 	"description": "If one taxpayer's MAGI (modified AGI) is more than this threshold, he or she is subject to the additional Medicare tax. ",
@@ -612,6 +622,7 @@
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
         "value":     [[200000, 250000, 125000, 200000, 250000, 125000]]
     },
+
     "_II_em_ps":{
         "long_name": "Personal exemption phaseout starting income",
 	"description": "If taxpayers' AGI is above this level, their personal exemption will start to decrease at the personal exemption phaseout rate (PEP provision). ",
@@ -626,12 +637,12 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":
-		          [ [250000, 300000, 150000, 275000, 300000, 150000], 
-                    [254200, 305050, 152525, 279650, 305050, 152525],
-                    [258250, 309900, 154950, 284040, 309900, 154950],
-                    [259400, 311300, 155650, 285350, 311300, 155650]]    
-     },
+        "value": [[250000, 300000, 150000, 275000, 300000, 150000], 
+                  [254200, 305050, 152525, 279650, 305050, 152525],
+                  [258250, 309900, 154950, 284040, 309900, 154950],
+                  [259400, 311300, 155650, 285350, 311300, 155650]]    
+    },
+
     "_STD":{
         "long_name": "Standard deduction amount",
 	"description": "",
@@ -646,14 +657,14 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate", "dependent"],        
-        "value":
-		          [ [6100, 12200, 6100, 8950, 12200, 6100, 1000], 
-                    [6200, 12400, 6200, 9100, 12400, 6200, 1000],
-                    [6300, 12600, 6300, 9250, 12600, 6300, 1050],
-                    [6300, 12600, 6300, 9300, 12600, 6300, 1050]],
+        "value": [[6100, 12200, 6100, 8950, 12200, 6100, 1000], 
+                  [6200, 12400, 6200, 9100, 12400, 6200, 1000],
+                  [6300, 12600, 6300, 9250, 12600, 6300, 1050],
+                  [6300, 12600, 6300, 9300, 12600, 6300, 1050]],
 	"validations": {"min": "default"}
-     },
-     "_II_brk1":{
+    },
+
+    "_II_brk1":{
         "long_name": "Personal income tax bracket (upper threshold) 1",
 	"description": "Taxable income below this threshold is taxed at tax rate 1. ",
         "irs_ref": "Form 1040, line 40, in-line (Formside notes).",
@@ -667,13 +678,14 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":[   [8925, 17850, 8925, 12750, 17850, 8925], 
-                    [9075, 18150, 9075, 12950, 18150, 9075],
-                    [9225, 18450, 9225, 13150, 18450, 9225],
-                    [9275, 18550, 9275, 13250, 18550, 9275]],
+        "value":[[8925, 17850, 8925, 12750, 17850, 8925], 
+                 [9075, 18150, 9075, 12950, 18150, 9075],
+                 [9225, 18450, 9225, 13150, 18450, 9225],
+                 [9275, 18550, 9275, 13250, 18550, 9275]],
 	"validations":{"min": 0, "max": "_II_brk2"}
-     },
-     "_II_brk2":{
+    },
+
+    "_II_brk2":{
         "long_name": "Personal income tax bracket (upper threshold) 2",
         "description": "Income below this threshold and above tax bracket 1 is taxed at tax rate 2. ",
         "irs_ref": "Form 1040, line 40, in-line (Formside notes).",
@@ -686,13 +698,14 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":[   [36250, 72500, 36250, 48600, 72500, 36250], 
-                    [36900, 73800, 36900, 49400, 73800, 36900],
-                    [37450, 74900, 37450, 50200, 74900, 37450],
-                    [37650, 75300, 37650, 50400, 75300, 37650]],
+        "value":[[36250, 72500, 36250, 48600, 72500, 36250], 
+                 [36900, 73800, 36900, 49400, 73800, 36900],
+                 [37450, 74900, 37450, 50200, 74900, 37450],
+                 [37650, 75300, 37650, 50400, 75300, 37650]],
 	"validations":{"min": "_II_brk1", "max": "_II_brk3"}
-     },
-     "_II_brk3":{
+    },
+
+    "_II_brk3":{
         "long_name": "Personal income tax bracket (upper threshold) 3",
         "description": "Income below this threshold and above tax bracket 2 is taxed at tax rate 3.",
         "irs_ref": "Form 1040, line 40, in-line (Formside notes).",
@@ -705,13 +718,14 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":[   [87850, 146400, 73200, 125450, 146400, 73200], 
-                    [89350, 148850, 74425, 127550, 148850, 74425],
-                    [90750, 151200, 75600, 129600, 151200, 75600],
-                    [91150, 151900, 75950, 130150, 151900, 75950]],
+        "value": [[87850, 146400, 73200, 125450, 146400, 73200], 
+                  [89350, 148850, 74425, 127550, 148850, 74425],
+                  [90750, 151200, 75600, 129600, 151200, 75600],
+                  [91150, 151900, 75950, 130150, 151900, 75950]],
 	"validations":{"min": "_II_brk2", "max": "_II_brk4"}
-     },
-     "_II_brk4":{
+    },
+
+    "_II_brk4":{
         "long_name": "Personal income tax bracket (upper threshold) 4",
         "description": "Income below this threshold and above tax bracket 3 is taxed at tax rate 4.",
         "irs_ref": "Form 1040, line 40, in-line (Formside notes).",
@@ -724,13 +738,14 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":[   [183250, 223050, 111525, 203150, 223050, 111525], 
-                    [186350, 226850, 113425, 206600, 226850, 113425],
-                    [189300, 230450, 115225, 209850, 230450, 115225],
-                    [190150, 231450, 115725, 210800, 231450, 115725]],
+        "value":[[183250, 223050, 111525, 203150, 223050, 111525], 
+                 [186350, 226850, 113425, 206600, 226850, 113425],
+                 [189300, 230450, 115225, 209850, 230450, 115225],
+                 [190150, 231450, 115725, 210800, 231450, 115725]],
 	"validations":{"min": "_II_brk3", "max": "_II_brk5"}
-     },
-     "_II_brk5":{
+    },
+
+    "_II_brk5":{
         "long_name": "Personal income tax bracket (upper threshold) 5",
         "description": "Income below this threshold and above tax bracket 4 is taxed at tax rate 5.",
         "irs_ref": "Form 1040, line 40, in-line (Formside notes).",
@@ -743,13 +758,14 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":[   [398350, 398350, 199175, 398350, 398350, 199175], 
-                    [405100, 405100, 202550, 405100, 405100, 202550],
-                    [411500, 411500, 205750, 411500, 411500, 205750],
-                    [413350, 413350, 206675, 413350, 413350, 206675]],
+        "value": [[398350, 398350, 199175, 398350, 398350, 199175], 
+                  [405100, 405100, 202550, 405100, 405100, 202550],
+                  [411500, 411500, 205750, 411500, 411500, 205750],
+                  [413350, 413350, 206675, 413350, 413350, 206675]],
 	"validations":{"min": "_II_brk4", "max": "_II_brk6"}
-     },
-     "_II_brk6":{
+    },
+
+    "_II_brk6":{
         "long_name": "Personal income tax bracket (upper threshold) 6",
         "description": "Income below this threshold and above tax bracket 5 is taxed at tax rate 6.",
         "irs_ref": "Form 1040, line 40, in-line (Formside notes).",
@@ -762,13 +778,14 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":[   [400000, 450000, 225000, 425000, 450000, 225000],
-                    [406750, 457600, 228800, 432200, 457600, 228800],
-                    [413200, 464850, 232425, 439000, 464850, 232425],
-                    [415050, 466950, 233475, 441000, 466950, 233475]],
+        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
+                  [406750, 457600, 228800, 432200, 457600, 228800],
+                  [413200, 464850, 232425, 439000, 464850, 232425],
+                  [415050, 466950, 233475, 441000, 466950, 233475]],
 	"validations":{"min": "_II_brk5"}
-     },
-     "_FICA_ss_trt":{
+    },
+
+    "_FICA_ss_trt":{
         "long_name": "Social Security payroll tax rate",
 	"description": "Social Security FICA rate, including both employer and employee.",
         "irs_ref": "Form , line , ",
@@ -780,10 +797,9 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.124]
-        
-
     },
-     "_FICA_mc_trt":{
+
+    "_FICA_mc_trt":{
         "long_name": "Medicare payroll tax rate",
         "description": "Medicare FICA rate, including both employer and employee.",
         "irs_ref": "Form , line , ",
@@ -797,7 +813,6 @@
         "value":     [0.029]
     },
 
-
     "_SS_percentage1":{
         "long_name": "Social Security taxable income percentage 1",
 	"description": "Under current law if their provisional income is above the first threshold for Social Security taxability but below the second threshold, taxpayers need to apply this percentage to both the excess of their provisonal income over the first threshold and their Social Security benefits, and then include the smaller one in their AGI.",
@@ -810,8 +825,8 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.5]
-        
     },
+
     "_SS_percentage2":{
         "long_name": "Social Security taxable income percentage 2",
 	"description": "Under current law if their provisional income is above the second threshold for Social Security taxability, taxpayers need to apply this percentage to both the excess of their provisional income over the second threshold and their social secuirty benefits, and then include the smaller one in their AGI.",
@@ -824,8 +839,8 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.85]
-        
     },
+
     "_II_prt":{
         "long_name": "Personal exemption phaseout rate",
 	"description": "Personal exemption amount will decrease by this rate for each dollar of AGI exceeding exemption phaseout start.",
@@ -839,7 +854,8 @@
         "col_label": "",
         "value":     [0.02]        
     },
-     "_ID_Medical_frt":{
+
+    "_ID_Medical_frt":{
         "long_name": "Deduction for medical expenses; floor as a percent of AGI",
 	"description": "Taxpayers are eligible to deduct the portion of their medical expense exceeding this percentage of AGI.",
         "irs_ref": "Form 1040 Schedule A, line 3, in-line. ",
@@ -853,7 +869,8 @@
         "value":     [0.1],
 	"validations": {"min": "default"}
     },
-     "_ID_Medical_HC":{
+
+    "_ID_Medical_HC":{
         "long_name": "Medical expense deduction haircut",
 	"description": "This percentage can be applied to limit the amount of medical expense deduction allowed.",
         "irs_ref": "",
@@ -866,7 +883,8 @@
         "col_label": "",
         "value":     [0.0] 
     },
-     "_ID_Charity_frt":{
+
+    "_ID_Charity_frt":{
         "long_name": "Deduction for charitable contributions; floor as a percent of AGI",
         "description": "Taxpayers are eligible to deduct the portion of their charitable expense exceeding this percentage of AGI.",
         "irs_ref": "",
@@ -880,6 +898,7 @@
         "value":     [0.0],
         "validations": {"min": "default"}
     },
+
     "_ID_Charity_HC":{
         "long_name": "Charity expense deduction haircut",
 	"description": "This percentage can be applied to limit the amount of charity expense deduction allowed.",
@@ -893,7 +912,8 @@
         "col_label": "",
         "value":     [0.0] 
     },
-     "_ID_Casualty_frt":{
+
+    "_ID_Casualty_frt":{
         "long_name": "Deduction for casualty loss; floor as a percent of AGI",
 	"description": "Taxpayers are eligible to deduct the portion of their casualty loss exceeding this percentage of AGI.",
         "irs_ref": "Form 4684, line 17, in-line.",
@@ -907,6 +927,7 @@
         "value":     [0.1],
 	"validations": {"min": "default"}
     },
+
     "_ID_Casualty_HC":{
         "long_name": "Casualty expense deduction haircut",
 	"description": "This percentage can be applied to limit the amount of casualty expense deduction allowed.",
@@ -920,7 +941,8 @@
         "col_label": "",
         "value":     [0.0] 
     },
-     "_ID_Miscellaneous_frt":{
+
+    "_ID_Miscellaneous_frt":{
         "long_name": "Deduction for miscellaneous expenses; floor as a percent of AGI",
 	"description": "Taxpayers are eligible to deduct the portion of their miscellaneous expense exceeding this percentage of AGI.",
         "irs_ref": "Form 1040 Schedule A, line 28, instructions. ",
@@ -934,7 +956,8 @@
         "value":     [0.02],
 	"validations": {"min": "default"}
     },
-     "_ID_Miscellaneous_HC":{
+
+    "_ID_Miscellaneous_HC":{
         "long_name": "Miscellaneous expense deduction haircut",
 	"description": "This percentage can be applied to limit the amount of miscellaneous expense deduction allowed.",
         "irs_ref": "",
@@ -947,7 +970,8 @@
         "col_label": "",
         "value":     [0.0] 
     },
-     "_ID_Charity_crt_Cash":{
+
+    "_ID_Charity_crt_Cash":{
         "long_name": "Deduction for charitable cash contributions; ceiling as a percent of AGI",
 	"description": "The deduction for Charity in form of cash is capped at this percentage of AGI. ",
         "irs_ref": "Pub. 526, Limits on Deductions: 50% Limit Organizations. ",
@@ -961,6 +985,7 @@
         "value":     [0.5],
 	"validations": {"max": "default"}
     },
+
     "_ID_Charity_crt_Asset":{
         "long_name": "Deduction for charitable asset contributions; ceiling as a percent of AGI",
 	    "description": "The deduction for Charity contributed in the form of assets is capped at this percentage of AGI. ",
@@ -975,6 +1000,7 @@
         "value":     [0.3],
 	"validations": {"max": "default"}
     },
+
     "_ID_prt":{
         "long_name": "Itemized deduction phaseout rate (Pease)",
 	"description": "Taxpayers will not be eligible to deduct the full amount of itemized deduction if their AGI is above the phaseout start. The deductible portion would be decreased at this rate for each dollar exceeding the start.",
@@ -988,6 +1014,7 @@
         "col_label": "",
         "value":     [0.03]        
     },
+
     "_ID_crt":{
         "long_name": "Itemized deduction maximum phaseout as a percent of total itemized deductions (Pease)",
 	"description": "The phaseout amount is capped at this percentage of the original total deduction. ",
@@ -1001,6 +1028,7 @@
         "col_label": "",
         "value":     [0.8]        
     },
+
     "_ID_StateLocalTax_HC":{
         "long_name": "State and local taxes (Income and Sales) deduction haircut.",
         "description": "This percentage reduces the state and local tax deduction." ,
@@ -1014,6 +1042,7 @@
         "col_label": "",
         "value": [0]
     },
+
     "_ID_RealEstate_HC":{
         "long_name": "Real estate taxes deduction haircut.",
         "description": "This percentage reduces real estate taxes paid eligible to deduct in itemized deduction." ,
@@ -1027,7 +1056,8 @@
         "col_label": "",
         "value": [0]
     },
-     "_ID_InterestPaid_HC":{
+
+    "_ID_InterestPaid_HC":{
         "long_name": "Interest deduction haircut",
 	"description": "This percentage can be applied to limit the amount of interest deduction allowed.",
         "irs_ref": "",
@@ -1040,6 +1070,7 @@
         "col_label": "",
         "value":     [0.0] 
     },
+
     "_ID_BenefitSurtax_crt":{
         "long_name": "Credit on itemized deduction benefit surtax (percent of AGI)",
 	"description": "The surtax on specified itemized deductions applies to benefits in excess of this percent of AGI. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
@@ -1053,6 +1084,7 @@
         "col_label": "",
         "value":     [1.0] 
     },
+
     "_ID_BenefitSurtax_trt":{
         "long_name": "Surtax rate on the benefits from specified itemized deductions",
 	"description": "The benefit from specified itemized deductions exceeding the credit is taxed at this rate. A surtax rate of 1 strictly limits the benefit from specified itemized deductions to the specified credit. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
@@ -1066,6 +1098,7 @@
         "col_label": "",
         "value":     [1.0] 
     },
+
     "_NIIT_trt":{
         "long_name": "Net Investment Income Tax rate (UIMC)",
 	"description": "Also called the Unearned Income Medicare Contribution. The lessor of net investment income and the amount by which MAGI exceeds a threshold is taxed at this rate.",
@@ -1079,6 +1112,7 @@
         "col_label": "",
         "value":     [0.038]        
     },
+
     "_AMT_prt":{
         "long_name": "AMT exemption phaseout rate",
 	"description": "AMT exemption will decrease at this rate for each dollar of AMTI exceeding AMT phaseout start. ",
@@ -1092,6 +1126,7 @@
         "col_label": "",
         "value":     [0.25]        
     },
+
     "_AMT_trt1":{
         "long_name": "AMT rate for AMTI under the surtax threshold",
 	"description": "The tax rate applied to the portion of AMT income below the surtax threshold. ",
@@ -1105,6 +1140,7 @@
         "col_label": "",
         "value":     [0.26]        
     },
+
     "_AMT_trt2":{
         "long_name": "Additional AMT rate for AMTI above the surtax threshold",
 	"description": "The tax rate applied to the portion of AMT income above the surtax threshold.",
@@ -1118,6 +1154,7 @@
         "col_label": "",
         "value":     [0.02]        
     },
+
     "_CTC_prt":{
         "long_name": "Child tax credit phaseout rate",
 	"description": "The amount of credit starts to decrease at this rate if MAGI is higher than child tax credit phaseout start. ",
@@ -1131,6 +1168,7 @@
         "col_label": "",
         "value":     [0.05]        
     },
+
     "_CTC_additional":{
         "long_name": "Additional additional child tax credit amount (Lee-Rubio)",
 	"description": "In addition to all the credits currently available for dependents, this parameter gives each qualifying child a fixed amount of partially refundable credit, limited by the sum of total income and payroll tax liabilities.",
@@ -1144,6 +1182,7 @@
         "col_label": "",
         "value":     [0]        
     },
+
     "_CTC_additional_ps":{
         "long_name": "Additional additional child tax credit phaseout starting AGI (Lee-Rubio)",
 	"description": "The amount of additional additional child tax credit is reduced for taxpayers with AGI higher than this level. ",
@@ -1156,10 +1195,11 @@
                       "2015"],
         "cpi_inflated": false,
         "col_label": "",
-        "value":     [[150000, 300000, 150000, 200000],
-		              [150000, 300000, 150000, 200000],
-                      [150000, 300000, 150000, 200000]]   
+        "value": [[150000, 300000, 150000, 200000],
+		  [150000, 300000, 150000, 200000],
+                  [150000, 300000, 150000, 200000]]   
     },
+
     "_CTC_additional_prt":{
         "long_name": "Additional additional child tax credit amount phaseout rate (Lee-Rubio)",
 	"description": "The amount of additional additional child tax credit is reduced at this rate per dollar exceeding the phaseout starting AGI. ",
@@ -1173,6 +1213,7 @@
         "col_label": "",
         "value":     [0.4]       
     },
+
     "_ACTC_ChildNum":{
         "long_name": "Additional child tax credit minimum number of qualified children",
 	"description": "Families with this number of qualified children or more may qualify for the additional child tax credit, which is a partially refundable credit that supplements the CTC for some taxpayers.",
@@ -1186,6 +1227,7 @@
         "col_label": "",
         "value":     [3]        
     },
+
     "_ALD_Interest_ec":{
         "long_name": "Interest income exclusion",
 	"description": "This pencentage can be applied to limit the interest income included in AGI. ",
@@ -1199,6 +1241,7 @@
         "col_label": "",
         "value":     [0]        
     },
+
     "_ALD_StudentLoan_HC":{
         "long_name": "Adjustment for student loan interest haircut",
 	"description": "This pencentage can be applied to limit the student loan interest adjustment allowed. ",
@@ -1212,6 +1255,7 @@
         "col_label": "",
         "value":     [0]        
     },
+
     "_ALD_SelfEmploymentTax_HC":{
         "long_name": "Adjustment for self-employment tax haircut",
 	"description": "This percentage, if greater than zero, reduces the employer equivalent portion of self-employment adjustment. ",
@@ -1225,6 +1269,7 @@
         "col_label": "",
         "value":     [0]        
     },
+
     "_ALD_SelfEmp_HealthIns_HC":{
         "long_name": "Adjustment for self employed health insurance haircut",
 	"description": "This percentage, if greater than zero, reduces the health insurance adjustment for self-employed taxpayers. ",
@@ -1238,6 +1283,7 @@
         "col_label": "",
         "value":     [0]        
     },
+
     "_ALD_KEOGH_SEP_HC":{
         "long_name": "Adjustment for payment to either KEOGH or SEP plan haircut",
 	"description": "Under current law, payments to Keogh or SEP plans can be fully deducted from gross income. Taxpayers can use this haircut to limit the adjustment allowed. ",
@@ -1248,10 +1294,10 @@
         "row_var": "",
         "row_label": ["2013"],
         "cpi_inflated": false,
-        
         "col_label": "",
         "value":     [0]        
     },
+
     "_ALD_EarlyWithdraw_HC":{
         "long_name": "Adjustment for forfeited interest penalty haircut",
 	"description": "Under current law, early withdraw penalty can be fully deducted from gross income. Taxpayers can use this haircut to limit the adjustment allowed.",
@@ -1262,10 +1308,10 @@
         "row_var": "",
         "row_label": ["2013"],
         "cpi_inflated": false,
-        
         "col_label": "",
         "value":     [0]        
     },
+
     "_ALD_Alimony_HC":{
         "long_name": "Adjustment for alimony payment haircut",
 	"description": "Under current law, the full amount of alimony payment is taken as an adjustment from gross income in arriving at AGI. Taxpayers can use this haircut to limit the deduction allowed.",
@@ -1276,10 +1322,10 @@
         "row_var": "",
         "row_label": ["2013"],
         "cpi_inflated": false,
-        
         "col_label": "",
         "value":     [0]        
     },
+
     "_CDCC_ps":{
         "long_name": "Child and dependent care credit phaseout start",
 	"description": "For taxpayers with AGI over this amount, the credit, under the current law, is reduced by one percentage point each $2000 of AGI over this amount. ",
@@ -1288,10 +1334,10 @@
         "row_var": "",
         "row_label": ["2013"],
         "cpi_inflated": false,
-        
         "col_label": "",
         "value":      [15000]        
     },
+
     "_AMED_thd":{
         "long_name": "Additional Medicare threshold",
 	"description": "If their Medicare wages, RRTA compensation and self-employment income is above this threshold, taxpayers are subject to additional Medicare tax. ",
@@ -1302,8 +1348,9 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],        
-        "value":[    [200000,    250000,  125000,     200000,              200000, 125000]]
+        "value": [[200000, 250000, 125000, 200000, 200000, 125000]]
     },
+
     "_AMED_trt":{
         "long_name": "Additional Medicare tax rate",
 	"description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding additional Medicare threshold. ",
@@ -1316,6 +1363,7 @@
         "col_label": "",
         "value": [0.009]
     },
+
     "_CG_rt1":{
         "long_name": "Long term capital gain and qualified dividends rate 1",
 	"description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 1 are taxed at this rate. ",
@@ -1325,10 +1373,10 @@
         "row_var": "",
         "row_label": ["2013"],
         "cpi_inflated": false,
-        
         "col_label": "",
         "value": [0.0] 
     },
+
     "_CG_rt2":{
         "long_name": "Long term capital gain and qualified dividends rate 2",
 	"description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 2 and above threshold 1 are taxed at this rate. ",
@@ -1338,10 +1386,10 @@
         "row_var": "",
         "row_label": ["2013"],
         "cpi_inflated": false,
-        
         "col_label": "",
         "value": [0.15]
     },
+
     "_CG_rt3":{
         "long_name": "Long term capital gain and qualified dividends rate 3",
 	"description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 2 are taxed at this rate. ",
@@ -1354,7 +1402,8 @@
         "col_label": "",
         "value": [0.20] 
     },
-        "_CG_thd1":{
+
+    "_CG_thd1":{
         "long_name": "Long term capital gain and qualified dividends threshold 1",
 	"description": "The capital gain and dividends (stacked on top of regular income)  below this threshold are taxed at capital gain rate 1. ",
 	"irs_ref": "Form 1040 Schedule D tax worksheet, line 15, in-line. ",
@@ -1367,12 +1416,13 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [  [36250, 72500, 36250, 48600, 72500, 36250], 
-                    [36900, 73800, 36900, 49400, 73800, 36900],
-                    [37450, 74900, 37450, 50200, 74900, 37450],
-                    [37650, 75300, 37650, 50400, 75300, 37650]] 
+        "value": [[36250, 72500, 36250, 48600, 72500, 36250], 
+                  [36900, 73800, 36900, 49400, 73800, 36900],
+                  [37450, 74900, 37450, 50200, 74900, 37450],
+                  [37650, 75300, 37650, 50400, 75300, 37650]] 
     },
-        "_CG_thd2":{
+
+    "_CG_thd2":{
         "long_name": "Long term capital gain and qualified dividend threshold 2",
 	"description": "The capital gain and dividends (stacked on top of regular income)  above this threshold are taxed at capital gain rate 3.",
 	"irs_ref": "Form 1040 Schedule D tax worksheet, line 24, in-line. ",
@@ -1384,14 +1434,14 @@
                       "2015",
                       "2016"],
         "cpi_inflated": true,
-        
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [  [400000, 450000, 225000, 425000, 450000, 225000],
-                    [406750, 457600, 228800, 432200, 457600, 228800],
-                    [413200, 464850, 232425, 439000, 464850, 232425],
-                    [415050, 466950, 233475, 441000, 466950, 233475]]
+        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
+                  [406750, 457600, 228800, 432200, 457600, 228800],
+                  [413200, 464850, 232425, 439000, 464850, 232425],
+                  [415050, 466950, 233475, 441000, 466950, 233475]]
     },
-     "_AMT_CG_rt1":{
+
+    "_AMT_CG_rt1":{
         "long_name": "Long term capital gain and qualified dividend rate1",
 	"description": "Capital gain and qualified dividends (stacked on top of regular income) below threshold 1 are taxed at this rate. ",
 	"irs_ref": "Form 6251, line 46, in-line. ",
@@ -1400,10 +1450,10 @@
         "row_var": "",
         "row_label": ["2013"],
         "cpi_inflated": false,
-        
         "col_label": "",
         "value": [0.0] 
     },
+
     "_AMT_CG_rt2":{
         "long_name": "Long term capital gain and qualified dividend rate2",
 	"description": "Capital gain and qualified dividend (stacked on top of regular income) below threshold 2 and above threshold 1 are taxed at this rate.",
@@ -1413,10 +1463,10 @@
         "row_var": "",
         "row_label": ["2013"],
         "cpi_inflated": false,
-        
         "col_label": "",
         "value": [0.15]
     },
+
     "_AMT_CG_rt3":{
         "long_name": "Long term capital gain and qualified dividend rate 3",
 	"description": "The capital gain and qualified dividend (stacked on top of regular income) above threshold 2 are taxed at this rate.",
@@ -1429,19 +1479,8 @@
         "col_label": "",
         "value": [0.20] 
     },
-    "_AMT_CG_rt4":{
-        "long_name": "Long term capital gain and qualified dividend rate 4",
-    "description": "The capital gain and qualified dividend (stacked on top of regular income) above threshold 2 are taxed at this rate.",
-    "irs_ref": "Form 6251, line 60, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.25] 
-    },
-        "_AMT_CG_thd1":{
+
+    "_AMT_CG_thd1":{
         "long_name": "Long term capital gain and qualified dividend threshold 1",
 	"description": "The capital gain plus dividends portion, stacked last, of income below this threshold is taxed at capital gain rate 1.",
 	"irs_ref": "Form 6251, line 43, in-line. ",
@@ -1454,12 +1493,13 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [  [36250, 72500, 36250, 48600, 72500, 36250], 
-                    [36900, 73800, 36900, 49400, 73800, 36900],
-                    [37450, 74900, 37450, 50200, 74900, 37450],
-                    [37650, 75300, 37650, 50400, 75300, 37650]]
+        "value": [[36250, 72500, 36250, 48600, 72500, 36250], 
+                  [36900, 73800, 36900, 49400, 73800, 36900],
+                  [37450, 74900, 37450, 50200, 74900, 37450],
+                  [37650, 75300, 37650, 50400, 75300, 37650]]
     },
-        "_AMT_CG_thd2":{
+
+    "_AMT_CG_thd2":{
         "long_name": "Long term capital gain and qualified dividend threshold 2",
 	"description": "The capital gain plus dividends portion, stacked last, of income above this threshold is taxed at capital gain rate 3.",
 	"irs_ref": "Form 6251, line 49, in-line. ",
@@ -1472,12 +1512,13 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [  [400000, 450000, 225000, 425000, 450000, 225000],
-                    [406750, 457600, 228800, 432200, 457600, 228800],
-                    [413200, 464850, 232425, 439000, 464850, 223425],
-                    [415050, 466950, 233475, 441000, 466950, 233475]]
+        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
+                  [406750, 457600, 228800, 432200, 457600, 228800],
+                  [413200, 464850, 232425, 439000, 464850, 223425],
+                  [415050, 466950, 233475, 441000, 466950, 233475]]
     },
-        "_II_credit":{
+
+    "_II_credit":{
         "long_name": "Personal refundable credit",
 	"description": "This credit amount is fully refundable, phased out based on taxable income. ",
         "irs_ref": "",
@@ -1487,10 +1528,11 @@
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household"],        
+        "col_label": ["single", "joint", "separate", "head of household"],
         "value": [ [0,           0,        0,             0]]
-     },
-        "_II_credit_ps":{
+    },
+
+    "_II_credit_ps":{
         "long_name": "Personal refundable credit phaseout start",
 	"description": "The Personal Refundable credit amount will be reduced for taxpayers with taxable income higher than this level.",
         "irs_ref": "",
@@ -1500,10 +1542,11 @@
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household"],        
+        "col_label": ["single", "joint", "separate", "head of household"],
         "value": [ [0,           0,        0,             0]]
-     },
-        "_II_credit_prt":{
+    },
+
+    "_II_credit_prt":{
         "long_name": "Personal refundable credit phaseout rate",
 	"description": "The Personal Refundable credit amount will be reduced at this rate for each dollar of taxable income exceeding the thresholds.",
         "irs_ref": "",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -843,7 +843,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, c24517,
          f6251, c00100, e60000, t04470,
          c04470, c17000, e18500, c20800, c21040, e04805,
          DOBYR, FLPDYR, SDOBYR, SFOBYR, c02700, AGERANGE,
-         e24515, x60130, e18400, AMT_CG_rt4,
+         e24515, x60130, e18400,
          x60220, x60240, c18300, _taxbc, AMT_tthd, AMT_CG_thd1, AMT_CG_thd2,
          MARS, _sep, AMT_Child_em, AMT_CG_rt1, DSI,
          AMT_CG_rt2, AMT_CG_rt3, AMT_em_ps, AMT_em_pe, x62720, e00700, c24516,
@@ -1036,7 +1036,7 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, c24517,
 
     c62760 = AMT_CG_rt3 * _amt20pc
 
-    c62770 = AMT_CG_rt4 * _amt25pc
+    c62770 = 0.25 * _amt25pc  # tax rate on "Unrecaptured Schedule E Gain"
 
     _tamt2 = c62747 + c62755 + c62760 + c62770  # line62 without 42 being added
 


### PR DESCRIPTION
This pull request eliminates an improperly named tax policy parameter and replaces it the a hardwired 0.25 tax rate, which is how the code was before the mistaken revision was made in pull request #438.  Pull request #438 was merged into the master branch by me on 05-Nov-2015.  The _AMT_CG_rt4 parameter has also been removed from the ```current_law_policy.json``` file, which has no effect on TaxBrain because TaxBrain was not displaying this parameter.

This pull request does not change tax-calculation logic and none of the test results change.

Besides removing _AMT_CG_rt4 from ```current_law_policy.json``` the spacing and formatting of that file has been made less random.  Again, these changes are completely non-substantive; they just make the file somewhat less difficult to read.

cc @MattHJensen @feenberg @GoFroggyRun @talumbau 