### PR TITLE
Simplify Policy constants to eliminate FIRST_BUDGET_YEAR

### DIFF
--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -57,9 +57,8 @@ class Policy(ParametersBase):
 
     DEFAULTS_FILENAME = 'current_law_policy.json'
     JSON_START_YEAR = 2013  # remains the same unless earlier data added
-    FIRST_BUDGET_YEAR = 2015  # increases by one every calendar year
-    NUM_BUDGET_YEARS = 12  # at least 10 per federal government budgeting rules
-    DEFAULT_NUM_YEARS = NUM_BUDGET_YEARS + FIRST_BUDGET_YEAR - JSON_START_YEAR
+    LAST_BUDGET_YEAR = 2026  # increases by one every calendar year
+    DEFAULT_NUM_YEARS = LAST_BUDGET_YEAR - JSON_START_YEAR + 1
 
     # default price inflation rates by year
     __pirates = {2013: 0.0148, 2014: 0.0159, 2015: 0.0013, 2016: 0.0135,

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -1,3 +1,4 @@
+
 import os
 import sys
 import numpy as np
@@ -89,26 +90,26 @@ def test_default_rates_and_those_implied_by_blowup_factors():
     record = Records(TAXDATA_PATH)  # contains the blowup factors
     policy = Policy()  # contains the default indexing rates
     syr = Policy.JSON_START_YEAR
-    endyr = Policy.FIRST_BUDGET_YEAR + Policy.NUM_BUDGET_YEARS
+    endyr = Policy.LAST_BUDGET_YEAR
     nyrs = endyr - syr
 
     # back out original stage I GDP growth rates from blowup factors
     record.BF.AGDPN[Records.PUF_YEAR] = 1
-    for year in range(Records.PUF_YEAR + 1, endyr):
+    for year in range(Records.PUF_YEAR + 1, endyr + 1):
         record.BF.AGDPN[year] = (record.BF.AGDPN[year] *
                                  record.BF.AGDPN[year - 1] *
                                  record.BF.APOPN[year])
 
     # calculate nominal GDP growth rates from original GDP growth rates
     nominal_rates = np.zeros(nyrs)
-    for year in range(syr, endyr):
+    for year in range(syr + 1, endyr):
         irate = policy._inflation_rates[year - syr]
         nominal_rates[year - syr] = (record.BF.AGDPN[year] /
                                      record.BF.AGDPN[year - 1] - 1 - irate)
 
     # check that nominal_rates are same as default GDP growth rates
     nominal_rates = np.round(nominal_rates, 4)
-    assert_array_equal(nominal_rates, Growth.REAL_GDP_GROWTH_RATES)
+    assert_array_equal(nominal_rates[1:], Growth.REAL_GDP_GROWTH_RATES[1:-1])
 
     # back out stage I inflation rates from blowup factors
     cpi_u = np.zeros(nyrs)
@@ -117,7 +118,7 @@ def test_default_rates_and_those_implied_by_blowup_factors():
 
     # check that blowup rates are same as default inflation rates
     cpi_u = np.round(cpi_u, 4)
-    assert_array_equal(cpi_u, policy._inflation_rates)
+    assert_array_equal(cpi_u, policy._inflation_rates[:-1])
 
     # back out original stage I wage growth rates from blowup factors
     record.BF.AWAGE[Records.PUF_YEAR] = 1
@@ -128,10 +129,10 @@ def test_default_rates_and_those_implied_by_blowup_factors():
 
     # calculate nominal wage growth rates from original wage growth rates
     wage_growth_rates = np.zeros(nyrs)
-    for year in range(syr, endyr):
+    for year in range(syr + 1, endyr):
         wage_growth_rates[year - syr] = (record.BF.AWAGE[year] /
                                          record.BF.AWAGE[year - 1] - 1)
 
     # check that blowup rates are same as default wage growth rates
     wage_growth_rates = np.round(wage_growth_rates, 4)
-    assert_array_equal(wage_growth_rates, policy._wage_growth_rates)
+    assert_array_equal(wage_growth_rates[1:], policy._wage_growth_rates[1:-1])


### PR DESCRIPTION
This pull request simplifies Policy class constants to better match TaxBrain practice of allowing start years back to 2013.  There is no change in tax-calculating logic and no change in any test results.