### PR TITLE
Enhancement of `increment year`

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -160,6 +160,27 @@ class Calculator(object):
         self.policy.set_year(self.policy.current_year + 1)
         self.behavior.set_year(self.policy.current_year)
 
+    def year_increment(self, new_current_year):
+        iteration = new_current_year - self.policy.current_year
+        for i in range(iteration):
+            if self.growth.factor_adjustment != 0:
+                if not np.array_equal(self.growth._factor_target,
+                                      Growth.REAL_GDP_GROWTH_RATES):
+                    msg = "adjustment and target factor \
+                        cannot be non-zero at the same time"
+                    raise ValueError(msg)
+                else:
+                    adjustment(self, self.growth.factor_adjustment,
+                               self.policy.current_year + 1)
+            elif not np.array_equal(self.growth._factor_target,
+                                    Growth.REAL_GDP_GROWTH_RATES):
+                target(self, self.growth._factor_target,
+                       self.policy.current_year + 1)
+            self.records.increment_year()
+            self.policy.set_year(self.policy.current_year + 1)
+            self.behavior.set_year(self.policy.current_year)
+        assert self.policy.current_year == new_current_year
+
     @property
     def current_year(self):
         return self.policy.current_year

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -160,19 +160,19 @@ class Calculator(object):
         self.policy.set_year(self.policy.current_year + 1)
         self.behavior.set_year(self.policy.current_year)
 
-    def year_increment(self, advance_to_year):
+    def advance_to_year(self, year):
         '''
         The year_increment function gives an optional way of implementing
         increment year functionality by immediately specifying the year
         as input. New year must be at least the current year.
         '''
-        iteration = advance_to_year - self.records.current_year
+        iteration = year - self.records.current_year
         if iteration < 0:
             raise ValueError("New current year must be " +
                              "greater than current year!")
         for i in range(iteration):
             self.increment_year()
-        assert self.records.current_year == advance_to_year
+        assert self.records.current_year == year
 
     @property
     def current_year(self):

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -160,11 +160,35 @@ class Calculator(object):
         self.policy.set_year(self.policy.current_year + 1)
         self.behavior.set_year(self.policy.current_year)
 
-    def year_increment(self, new_current_year):
-        iteration = new_current_year - self.policy.current_year
-        for i in range(iteration):
-            self.increment_year()
-        assert self.policy.current_year == new_current_year
+    def year_increment(self, advance_to_year):
+        '''
+        The year_increment function gives an optional way of implementing
+        increment year functionality by immediately specifying the year
+        as input. Robustness has been added to ensure input is of good shape.
+        '''
+        if isinstance(advance_to_year, int):
+            iteration = advance_to_year - self.records.current_year
+            if iteration > 0:
+                if iteration > 3:
+                    for i in range(iteration):
+                        self.increment_year()
+                    assert self.records.current_year == advance_to_year
+                    print("Your data and policy have been further extrapolated"
+                          " to " + str(self.records.current_year) + ".")
+                else:
+                    for i in range(iteration):
+                        self.increment_year()
+                    assert self.records.current_year == advance_to_year
+                    print("Your data have been further extrapolated to " +
+                          str(self.records.current_year) + ".")
+            elif iteration == 0:
+                print("You are already in " +
+                      str(self.records.current_year) + ".")
+            else:
+                print(str(self.records.current_year) + " is the earliest " +
+                      "possible year to perform any tax calculation.")
+        else:
+            print("Integer input is expected!")
 
     @property
     def current_year(self):

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -164,31 +164,15 @@ class Calculator(object):
         '''
         The year_increment function gives an optional way of implementing
         increment year functionality by immediately specifying the year
-        as input. Robustness has been added to ensure input is of good shape.
+        as input. New year must be at least the current year.
         '''
-        if isinstance(advance_to_year, int):
-            iteration = advance_to_year - self.records.current_year
-            if iteration > 0:
-                if iteration > 3:
-                    for i in range(iteration):
-                        self.increment_year()
-                    assert self.records.current_year == advance_to_year
-                    print("Your data and policy have been further extrapolated"
-                          " to " + str(self.records.current_year) + ".")
-                else:
-                    for i in range(iteration):
-                        self.increment_year()
-                    assert self.records.current_year == advance_to_year
-                    print("Your data have been further extrapolated to " +
-                          str(self.records.current_year) + ".")
-            elif iteration == 0:
-                print("You are already in " +
-                      str(self.records.current_year) + ".")
-            else:
-                print(str(self.records.current_year) + " is the earliest " +
-                      "possible year to perform any tax calculation.")
-        else:
-            print("Integer input is expected!")
+        iteration = advance_to_year - self.records.current_year
+        if iteration < 0:
+            raise ValueError("New current year must be " +
+                             "greater than current year!")
+        for i in range(iteration):
+            self.increment_year()
+        assert self.records.current_year == advance_to_year
 
     @property
     def current_year(self):

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -162,7 +162,7 @@ class Calculator(object):
 
     def advance_to_year(self, year):
         '''
-        The year_increment function gives an optional way of implementing
+        The advance_to_year function gives an optional way of implementing
         increment year functionality by immediately specifying the year
         as input. New year must be at least the current year.
         '''

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -163,22 +163,7 @@ class Calculator(object):
     def year_increment(self, new_current_year):
         iteration = new_current_year - self.policy.current_year
         for i in range(iteration):
-            if self.growth.factor_adjustment != 0:
-                if not np.array_equal(self.growth._factor_target,
-                                      Growth.REAL_GDP_GROWTH_RATES):
-                    msg = "adjustment and target factor \
-                        cannot be non-zero at the same time"
-                    raise ValueError(msg)
-                else:
-                    adjustment(self, self.growth.factor_adjustment,
-                               self.policy.current_year + 1)
-            elif not np.array_equal(self.growth._factor_target,
-                                    Growth.REAL_GDP_GROWTH_RATES):
-                target(self, self.growth._factor_target,
-                       self.policy.current_year + 1)
-            self.records.increment_year()
-            self.policy.set_year(self.policy.current_year + 1)
-            self.behavior.set_year(self.policy.current_year)
+            self.increment_year()
         assert self.policy.current_year == new_current_year
 
     @property

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -160,9 +160,7 @@ def test_make_Calculator_with_reform_after_start_year():
     assert_allclose(calc.policy._STD_Aged, exp_STD_Aged, atol=0.5, rtol=0.0)
     assert_allclose(calc.policy._II_em, exp_II_em, atol=0.001, rtol=0.0)
     # compare actual and expected values for 2015
-    calc.increment_year()
-    calc.increment_year()
-    assert calc.current_year == 2015
+    calc.year_increment(2015)
     exp_2015_II_em = 5000
     assert_allclose(calc.policy.II_em, exp_2015_II_em,
                     atol=0.0, rtol=0.0)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -160,13 +160,25 @@ def test_make_Calculator_with_reform_after_start_year():
     assert_allclose(calc.policy._STD_Aged, exp_STD_Aged, atol=0.5, rtol=0.0)
     assert_allclose(calc.policy._II_em, exp_II_em, atol=0.001, rtol=0.0)
     # compare actual and expected values for 2015
-    calc.year_increment(2015)
+    calc.increment_year()
+    calc.increment_year()
+    assert calc.current_year == 2015
     exp_2015_II_em = 5000
     assert_allclose(calc.policy.II_em, exp_2015_II_em,
                     atol=0.0, rtol=0.0)
     exp_2015_STD_Aged = np.array([1600, 1300, 1600, 1300, 1600, 1300])
     assert_allclose(calc.policy.STD_Aged, exp_2015_STD_Aged,
                     atol=0.0, rtol=0.0)
+
+
+def test_Calculator_advance_to_year():
+    policy = Policy()
+    puf = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
+    calc = Calculator(policy=policy, records=puf)
+    calc.advance_to_year(2016)
+    assert calc.current_year == 2016
+    with pytest.raises(ValueError):
+        calc.advance_to_year(2015)
 
 
 def test_make_Calculator_user_mods_with_cpi_flags(policyfile):


### PR DESCRIPTION
This PR adds an optional way of doing increment year. Previously, increment year could be achieved by 
```
for i in range(4):
    calc.increment_year()
assert calc.current_year == 2017
```

Right now, alternatively, we could use
```
calc.year_increment(2017)
```
to specify the desired tax year. Iteration and assertion will be automatically made. 

Previous `increment_year()` option was still retained, as it was excessively used in testing suite.

@Amy-Xu @MattHJensen @martinholmer 
Please take a look, any comments, concerns or remarks would be appreciated.