### PR TITLE
Format .json files to meet PEP8 standards

### DIFF
--- a/taxcalc/comparison/reform_results.txt
+++ b/taxcalc/comparison/reform_results.txt
@@ -2,10 +2,10 @@
 PAYROLL TAXES
 ""
 Increase the Social Security payroll tax rate by 1pts
-Tax-Calculator,62.6,65.1,68.2,71.2
+Tax-Calculator,62.6,65.1,68.1,71.1
 ""
 Increase the maximum taxable earnings (177500) for the social security payroll tax
-Tax-Calculator,52.2,62.1,63.5,65.1
+Tax-Calculator,52.2,62.2,63.8,65.9
 Budget Options,40,46,49,51
 ""
 Increase the Payroll tax rate for medicare hospital insurance by 1pts
@@ -21,7 +21,7 @@ Tax-Calculator,0.8,0.8,0.9,1.0
 SOCIAL SECURITY TAXABILITY
 ""
 Exclusion of untaxed social security and railroad retirement
-Tax-Calculator,39.0,40.7,43.1,45.6
+Tax-Calculator,39.1,40.9,43.5,45.9
 Tax Expenditure,39,42,44,47
 Budget Options,35,37,38,40
 ""
@@ -32,17 +32,17 @@ Tax-Calculator,6.9,7.2,7.5,7.9
 Tax Expenditure,9,10,11,16
 ""
 Deduction for student loans
-Tax-Calculator,1.7,1.8,1.9,2.0
+Tax-Calculator,1.7,1.8,2.0,2.1
 Tax Expenditure,2,2,2,2
 ""
 Eliminate adjustment for self-employment tax
-Tax-Calculator,4.2,4.4,4.6,4.9
+Tax-Calculator,4.2,4.4,4.7,4.9
 ""
 Eliminate adjustment for self-employed health insurance
-Tax-Calculator,6.0,6.3,6.5,6.8
+Tax-Calculator,6.0,6.3,6.6,6.9
 ""
 Eliminate adjustment for alimony payments
-Tax-Calculator,1.9,2.0,2.1,2.3
+Tax-Calculator,1.9,2.0,2.2,2.3
 ""
 Eliminate adjustment for forfeited interest penalty
 Tax-Calculator,0.1,0.1,0.1,0.1
@@ -50,7 +50,7 @@ Tax-Calculator,0.1,0.1,0.1,0.1
 EXEMPTION
 ""
 Increase personal and dependent exemption amount by 1000
-Tax-Calculator,-32.9,-35.5,-36.8,-38.1
+Tax-Calculator,-33.0,-32.4,-33.4,-34.6
 ""
 Increase personal exemption phaseout starting AGI by 10,000
 Tax-Calculator,-0.1,-0.1,-0.1,-0.1
@@ -61,31 +61,31 @@ Tax-Calculator,0.2,0.2,0.2,0.2
 STANDARD DEDUCTION
 ""
 Increase standard deduction by 100
-Tax-Calculator,-1.0,-2.8,-2.9,-3.1
+Tax-Calculator,-1.0,-1.1,-1.1,-1.1
 ""
 Increase additional standard deduction for aged and blind by 100
-Tax-Calculator,-0.4,-0.5,-0.6,-0.6
+Tax-Calculator,-0.2,-0.2,-0.3,-0.3
 ""
 ITEMIZED DEDUCTION
 ""
 Real Estate
-Tax-Calculator,35.6,37.7,39.7,41.8
+Tax-Calculator,35.6,37.8,39.9,41.9
 Tax Expenditure,34,36,39,41
 ""
 Home Mortgage
-Tax-Calculator,80.4,87.6,94.1,101.0
+Tax-Calculator,80.5,87.7,94.6,101.4
 Tax Expenditure,75,82,88,93
 ""
 Both real estate and state and local
-Tax-Calculator,99.0,105.3,111.0,117.3
+Tax-Calculator,99.2,105.5,111.5,117.7
 Tax Expenditure,75,82,88,93
 ""
 State & Local
-Tax-Calculator,64.2,67.8,71.2,74.9
+Tax-Calculator,64.3,67.9,71.4,75.0
 Tax Expenditure,59,63,67,71
 ""
 Medical
-Tax-Calculator,8.4,9.2,9.9,10.6
+Tax-Calculator,8.4,9.2,9.9,10.7
 Tax Expenditure,11,12,13,14
 ""
 Casualty
@@ -93,7 +93,7 @@ Tax-Calculator,0.4,0.5,0.5,0.5
 Tax Expenditure,0,0,0,0
 ""
 Charitable
-Tax-Calculator,44.4,47.0,49.5,52.3
+Tax-Calculator,44.4,47.1,49.8,52.5
 Tax Expenditure,46,47,48,50
 ""
 Decrease AGI floor for miscellaneous expenses by 1 pts
@@ -103,13 +103,13 @@ Increase Itemized deduction maximum phaseout by 10%
 Tax-Calculator,0.1,0.1,0.1,0.1
 ""
 Increase Itemized Deduction phaseout starting AGI by 10,000
-Tax-Calculator,0.1,0.1,0.1,0.1
+Tax-Calculator,0.1,0.1,0.2,0.2
 ""
 Increase Itemized Deduction phaseout rate by 1 pts
-Tax-Calculator,3.6,3.8,3.9,4.1
+Tax-Calculator,3.6,3.8,4.0,4.1
 ""
 limit the tax value of ID to 6% of AGI
-Tax-Calculator,19.9,21.4,22.7,24.3
+Tax-Calculator,20.0,21.4,22.8,24.4
 Budget Options,11,9,8,7
 ""
 CAPITAL GAIN
@@ -118,7 +118,7 @@ Increase long term cap gain and dividends tax rates by 2 percentage, no behavior
 Tax-Calculator,13.2,13.5,13.7,13.9
 ""
 Increase long term cap gain and dividends tax rates by 2 percentage, elasticity assumed to be 0.78
-Tax-Calculator,10.3,10.6,10.8,11.0
+Tax-Calculator,10.4,10.6,10.8,11.0
 ""
 Increase long term cap gain and dividends tax rates by 2 percentage, elasticity assumed to be 1.2
 Tax-Calculator,8.8,9.0,9.2,9.4
@@ -127,11 +127,11 @@ Budget Options,5,5,5,6
 REGULAR TAXES
 ""
 Increase each bracket rate by 1%
-Tax-Calculator,56.2,58.7,61.4,63.9
+Tax-Calculator,56.3,58.8,61.5,64.0
 Budget Options,56,60,65,69
 ""
 Increase top 4 rates by 1%
-Tax-Calculator,11.8,12.3,12.9,13.3
+Tax-Calculator,11.8,12.3,12.9,13.4
 Budget Options,11,12,14,15
 ""
 Increase top 2 rates by 1%
@@ -141,12 +141,12 @@ Budget Options,7,8,9,10
 Alternative Minimum Tax
 ""
 Increase exemption amount by 1000
-Tax-Calculator,-1.0,-2.4,-2.5,-2.7
+Tax-Calculator,-1.0,-0.8,-0.9,-0.9
 ""
 Alternative Minimum Tax
 ""
 Increase exemption phaseout starting AMTI by 10,000
-Tax-Calculator,-2.3,-3.1,-3.2,-3.4
+Tax-Calculator,-2.3,-2.4,-2.5,-2.6
 ""
 Alternative Minimum Tax
 ""
@@ -156,7 +156,7 @@ Tax-Calculator,2.4,2.6,2.7,2.9
 Alternative Minimum Tax
 ""
 Increase AMT rate under the surtax threshold by 2 pts
-Tax-Calculator,24.8,26.6,28.1,29.7
+Tax-Calculator,24.7,26.6,28.2,29.9
 ""
 Alternative Minimum Tax
 ""
@@ -164,7 +164,7 @@ Increase AMT rate above the surtax threshold by 2 pts
 Tax-Calculator,8.1,8.7,9.2,9.7
 ""
 Increase AMT surtax threshold by 10,000
-Tax-Calculator,-0.4,-0.6,-0.7,-0.7
+Tax-Calculator,-0.4,-0.5,-0.5,-0.5
 ""
 NONREFUNDABLE CREDIT
 ""
@@ -181,17 +181,17 @@ Tax-Calculator,-0.2,-0.2,-0.2,-0.2
 REFUNDABLE CREDIT
 ""
 Earned income tax credit, total
-Tax-Calculator,71.4,70.7,71.8,72.6
+Tax-Calculator,71.5,70.8,71.1,72.1
 Tax Expenditure,70,71,72,70
 ""
 Increase EITC phaseout rate by 1 pts
 Tax-Calculator,1.3,1.3,1.3,1.4
 ""
 Increase EITC phaseout starting AGI by 1000
-Tax-Calculator,-2.5,-3.2,-3.2,-3.3
+Tax-Calculator,-2.4,-2.4,-2.4,-2.5
 ""
 Increase Maximum EITC allowed by 100
-Tax-Calculator,-2.6,-3.9,-4.0,-4.1
+Tax-Calculator,-2.6,-2.3,-2.3,-2.4
 ""
 Increase additional child tax credit rate by 2 pts
 Tax-Calculator,-0.7,-0.7,-0.6,-0.6
@@ -211,7 +211,7 @@ Tax-Calculator,-0.3,-0.3,-0.3,-0.3
 PERSONAL REFUNDABLE CREDIT
 ""
 Increase Personal Refundable credit amount to 1000
-Tax-Calculator,-167.7,-173.5,-179.5,-185.1
+Tax-Calculator,-167.7,-170.3,-175.0,-180.8
 ""
 Increase Personal Refundable credit amount to 1000, with phaseout starting AGI 10,000 and phaseout rate at 0.01
-Tax-Calculator,-167.7,-146.6,-151.5,-155.9
+Tax-Calculator,-167.7,-160.7,-164.8,-170.1

--- a/taxcalc/comparison/reforms.json
+++ b/taxcalc/comparison/reforms.json
@@ -474,7 +474,7 @@
 
     "r53": {
         "start_year": 2015,
-        "value": {"_II_credit": [[1000, 1000, 1000, 1000]]},
+        "value": {"_II_credit": [[1000, 1000, 1000, 1000, 1000, 1000]]},
         "section_name": "PERSONAL REFUNDABLE CREDIT",
         "name": "Increase Personal Refundable credit amount to 1000",
         "output_type": "_iitax",
@@ -483,8 +483,8 @@
 
     "r54": {
         "start_year": 2015,
-        "value": {"_II_credit": [[1000, 1000, 1000, 1000]],
-                  "_II_credit_ps": [[100000, 100000, 100000, 100000]],
+        "value": {"_II_credit": [[1000, 1000, 1000, 1000, 1000, 1000]],
+                  "_II_credit_ps": [[100000, 100000, 100000, 100000, 100000, 100000]],
                   "_II_credit_prt": [0.01]},
         "name": "Increase Personal Refundable credit amount to 1000, with phaseout starting AGI 10,000 and phaseout rate at 0.01",
         "output_type": "_iitax",

--- a/taxcalc/comparison/reforms.json
+++ b/taxcalc/comparison/reforms.json
@@ -1,258 +1,291 @@
-{   "r1":{
+{
+    "r1": {
         "start_year": 2015,
         "value": {"_FICA_ss_trt": [0.134]},
         "section_name": "PAYROLL TAXES",
         "name": "Increase the Social Security payroll tax rate by 1pts",
         "output_type": "_fica",
         "compare_with": {}
-     },
-    "r2":{
+    },
+
+    "r2": {
         "start_year": 2015,
         "value": {"_SS_Earnings_c": [177500]},
         "name": "Increase the maximum taxable earnings (177500) for the social security payroll tax",
         "output_type": "_fica",
         "compare_with": {"Budget Options": [40, 46, 49, 51]}
-     },
-     "r3":{
+    },
+
+    "r3": {
         "start_year": 2015,
         "value": {"_FICA_mc_trt": [0.039]},
         "name": "Increase the Payroll tax rate for medicare hospital insurance by 1pts",
         "output_type": "_fica",
         "compare_with": {"Budget Options": [73, 77, 82, 87]}
-     },
-    "r4":{
+    },
+
+    "r4": {
         "start_year": 2015,
-        "value": {"_AMED_thd":[[210000, 260000, 135000, 210000, 210000, 135000]]},
+        "value": {"_AMED_thd": [[210000, 260000, 135000, 210000, 210000, 135000]]},
         "name": "Increase the Additional Medicare threshold by 10,000",
         "output_type": "_fica",
         "compare_with": {}
-     },
-    "r5":{
+    },
+
+    "r5": {
         "start_year": 2015,
-        "value": {"_AMED_trt":[0.01]},
+        "value": {"_AMED_trt": [0.01]},
         "name": "Increase the Additional Medicare tax rate by 0.1 pts",
         "output_type": "_fica",
         "compare_with": {}
-     },
-    "r6":{
+    },
+
+    "r6": {
         "start_year": 2015,
-        "value":{"_SS_thd50": [[0,0,0,0,0,0]],
-                 "_SS_thd85": [[0,0,0,0,0,0]],
-                 "_SS_percentage1": [1],
-                 "_SS_percentage2": [1]},
+        "value": {"_SS_thd50": [[0, 0, 0, 0, 0, 0]],
+                  "_SS_thd85": [[0, 0, 0, 0, 0, 0]],
+                  "_SS_percentage1": [1],
+                  "_SS_percentage2": [1]},
         "section_name": "SOCIAL SECURITY TAXABILITY",
         "name": "Exclusion of untaxed social security and railroad retirement",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [39.3, 41.5, 44.1, 46.8],
                          "Budget Options": [35, 37, 38, 40]}
     },
-    "r7":{
+
+    "r7": {
         "start_year": 2015,
         "value": {"_ALD_KEOGH_SEP_HC": [1]},
         "section_name": "ADJUSTMENTS",
         "name": "Net exclusion of KEOGH plan",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [8.7, 10.0, 11.4, 16.2]}
-     },
-    "r8":{
+    },
+
+    "r8": {
         "start_year": 2015,
         "value": {"_ALD_StudentLoan_HC": [1]},
         "name": "Deduction for student loans",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [1.8, 1.9, 1.9, 2.1]}
-     },
-    "r9":{
+    },
+
+    "r9": {
         "start_year": 2015,
         "value": {"_ALD_SelfEmploymentTax_HC": [1]},
         "name": "Eliminate adjustment for self-employment tax",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r10":{
+    },
+
+    "r10": {
         "start_year": 2015,
         "value": {"_ALD_SelfEmp_HealthIns_HC": [1]},
         "name": "Eliminate adjustment for self-employed health insurance",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r11":{
+    },
+
+    "r11": {
         "start_year": 2015,
         "value": {"_ALD_Alimony_HC": [1]},
         "name": "Eliminate adjustment for alimony payments",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r12":{
+    },
+
+    "r12": {
         "start_year": 2015,
         "value": {"_ALD_EarlyWithdraw_HC": [1]},
         "name": "Eliminate adjustment for forfeited interest penalty",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r13":{
+    },
+
+    "r13": {
         "start_year": 2015,
         "value": {"_II_em": [5000]},
         "section_name": "EXEMPTION",
         "name": "Increase personal and dependent exemption amount by 1000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r14":{
+    },
+
+    "r14": {
         "start_year": 2015,
         "value": {"_II_em_ps": [[268250, 319900, 164950, 294040, 319900, 164950]]},
         "name": "Increase personal exemption phaseout starting AGI by 10,000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r15":{
+    },
+
+    "r15": {
         "start_year": 2015,
         "value": {"_II_prt": [0.03]},
         "name": "Increase personal exemption phaseout rate by 1 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r16":{
+    },
+
+    "r16": {
         "start_year": 2015,
         "value": {"_STD": [[6400, 12700, 6400, 9350, 12700, 6400, 1150]]},
         "section_name": "STANDARD DEDUCTION",
         "name": "Increase standard deduction by 100",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r17":{
+    },
+
+    "r17": {
         "start_year": 2015,
         "value": {"_STD_Aged": [[1650, 1350, 1350, 1650, 1650, 1350]]},
         "name": "Increase additional standard deduction for aged and blind by 100",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r18":{
+    },
+
+    "r18": {
         "start_year": 2015,
         "value": {"_ID_RealEstate_HC": [1]},
         "section_name": "ITEMIZED DEDUCTION",
         "name": "Real Estate",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [34.0, 36.4, 38.8, 41.0]}
-     },
-     "r19":{
+    },
+
+    "r19": {
         "start_year": 2015,
         "value": {"_ID_InterestPaid_HC": [1]},
         "name": "Home Mortgage",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [74.8, 81.6, 87.8, 93.2]}
-     },
-     "r20":{
+    },
+
+    "r20": {
         "start_year": 2015,
         "value": {"_ID_StateLocalTax_HC": [1],
                   "_ID_RealEstate_HC": [1]},
         "name": "Both real estate and state and local",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [74.8, 81.6, 87.8, 93.2]}
-     },
-     "r21":{
+    },
+
+    "r21": {
         "start_year": 2015,
         "value": {"_ID_StateLocalTax_HC": [1]},
         "name": "State & Local",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [59.2, 63.0, 66.9, 70.7]}
-     },
-     "r22":{
+    },
+
+    "r22": {
         "start_year": 2015,
         "value": {"_ID_Medical_HC": [1]},
         "name": "Medical",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [11.0, 12.4, 12.7, 13.9]}
-     },
-     "r23":{
+    },
+
+    "r23": {
         "start_year": 2015,
         "value": {"_ID_Casualty_HC": [1]},
         "name": "Casualty",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [0.4, 0.5, 0.5, 0.5]}
-     },
-     "r24":{
+    },
+
+    "r24": {
         "start_year": 2015,
         "value": {"_ID_Charity_HC": [1]},
         "name": "Charitable",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [45.6, 47.0, 48.5, 50.1]}
-     },
-     "r25":{
+    },
+
+    "r25": {
         "start_year": 2015,
         "value": {"_ID_Miscellaneous_frt": [0.01]},
         "name": "Decrease AGI floor for miscellaneous expenses by 1 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r26":{
+    },
+
+    "r26": {
         "start_year": 2015,
         "value": {"_ID_crt": [0.9]},
         "name": "Increase Itemized deduction maximum phaseout by 10%",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r27":{
+    },
+
+    "r27": {
         "start_year": 2015,
         "value": {"_ID_ps": [[248250, 299900, 144950, 274050, 299900, 144950]]},
         "name": "Increase Itemized Deduction phaseout starting AGI by 10,000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r28":{
+    },
+
+    "r28": {
         "start_year": 2015,
         "value": {"_ID_prt": [0.04]},
         "name": "Increase Itemized Deduction phaseout rate by 1 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r29":{
+    },
+
+    "r29": {
         "start_year": 2015,
         "value": {"_ID_BenefitSurtax_crt": [0.06],
                   "_ID_BenefitSurtax_trt": [1]},
         "name": "limit the tax value of ID to 6% of AGI",
         "output_type": "_iitax",
         "compare_with": {"Budget Options": [11, 9, 8, 7]}
-     },
-     "r30":{
+    },
+
+    "r30": {
         "start_year": 2015,
         "value": {"_CG_rt1": [0.02],
-                 "_CG_rt2": [0.17],
-                 "_CG_rt3": [0.22],
-                 "_AMT_CG_rt1": [0.02],
-                 "_AMT_CG_rt2": [0.17],
-                 "_AMT_CG_rt3": [0.22]},
+                  "_CG_rt2": [0.17],
+                  "_CG_rt3": [0.22],
+                  "_AMT_CG_rt1": [0.02],
+                  "_AMT_CG_rt2": [0.17],
+                  "_AMT_CG_rt3": [0.22]},
         "section_name": "CAPITAL GAIN",
         "name": "Increase long term cap gain and dividends tax rates by 2 percentage, no behavior",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r31":{
+    },
+
+    "r31": {
         "start_year": 2015,
         "value": {"_CG_rt1": [0.02],
-                 "_CG_rt2": [0.17],
-                 "_CG_rt3": [0.22],
-                 "_AMT_CG_rt1": [0.02],
-                 "_AMT_CG_rt2": [0.17],
-                 "_AMT_CG_rt3": [0.22],
-                 "_BE_CG_per": [0.78]},
+                  "_CG_rt2": [0.17],
+                  "_CG_rt3": [0.22],
+                  "_AMT_CG_rt1": [0.02],
+                  "_AMT_CG_rt2": [0.17],
+                  "_AMT_CG_rt3": [0.22],
+                  "_BE_CG_per": [0.78]},
         "name": "Increase long term cap gain and dividends tax rates by 2 percentage, elasticity assumed to be 0.78",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r32":{
+    },
+
+    "r32": {
         "start_year": 2015,
         "value": {"_CG_rt1": [0.02],
-                 "_CG_rt2": [0.17],
-                 "_CG_rt3": [0.22],
-                 "_AMT_CG_rt1": [0.02],
-                 "_AMT_CG_rt2": [0.17],
-                 "_AMT_CG_rt3": [0.22],
-                 "_BE_CG_per": [1.2]},
+                  "_CG_rt2": [0.17],
+                  "_CG_rt3": [0.22],
+                  "_AMT_CG_rt1": [0.02],
+                  "_AMT_CG_rt2": [0.17],
+                  "_AMT_CG_rt3": [0.22],
+                  "_BE_CG_per": [1.2]},
         "name": "Increase long term cap gain and dividends tax rates by 2 percentage, elasticity assumed to be 1.2",
         "output_type": "_iitax",
         "compare_with": {"Budget Options": [4.6, 5, 5.3, 5.6]}
-     },
-     "r33":{
+    },
+
+    "r33": {
         "start_year": 2015,
         "value": {"_II_rt1": [0.11],
                   "_II_rt2": [0.16],
@@ -265,8 +298,9 @@
         "name": "Increase each bracket rate by 1%",
         "output_type": "_iitax",
         "compare_with": {"Budget Options": [56, 60, 65, 69]}
-     },
-     "r34":{
+    },
+
+    "r34": {
         "start_year": 2015,
         "value": {"_II_rt1": [0.10],
                   "_II_rt2": [0.15],
@@ -278,8 +312,9 @@
         "name": "Increase top 4 rates by 1%",
         "output_type": "_iitax",
         "compare_with": {"Budget Options": [11, 12, 14, 15]}
-     },
-     "r35":{
+    },
+
+    "r35": {
         "start_year": 2015,
         "value": {"_II_rt1": [0.10],
                   "_II_rt2": [0.15],
@@ -291,143 +326,162 @@
         "name": "Increase top 2 rates by 1%",
         "output_type": "_iitax",
         "compare_with": {"Budget Options": [7, 8, 9, 10]}
-     },
-    "r36":{
+    },
+
+    "r36": {
         "start_year": 2015,
         "value": {"_AMT_em": [[54600, 84400, 42700, 54600, 84400, 42700]]},
         "section_name": "Alternative Minimum Tax",
         "name": "Increase exemption amount by 1000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r37":{
+    },
+
+    "r37": {
         "start_year": 2015,
         "value": {"_AMT_em_ps": [[129200, 168900, 89450, 129200, 168900, 89450]]},
         "section_name": "Alternative Minimum Tax",
         "name": "Increase exemption phaseout starting AMTI by 10,000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r38":{
+    },
+
+    "r38": {
         "start_year": 2015,
         "value": {"_AMT_prt": [0.27]},
         "section_name": "Alternative Minimum Tax",
         "name": "Increase exemption phaseout rate by 2 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r39":{
+    },
+
+    "r39": {
         "start_year": 2015,
         "value": {"_AMT_trt1": [0.28]},
         "section_name": "Alternative Minimum Tax",
         "name": "Increase AMT rate under the surtax threshold by 2 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r40":{
+    },
+
+    "r40": {
         "start_year": 2015,
         "value": {"_AMT_trt2": [0.04]},
         "section_name": "Alternative Minimum Tax",
         "name": "Increase AMT rate above the surtax threshold by 2 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r41":{
+    },
+
+    "r41": {
         "start_year": 2015,
         "value": {"_AMT_tthd": [195400]},
         "name": "Increase AMT surtax threshold by 10,000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r42":{
+    },
+
+    "r42": {
         "start_year": 2015,
-        "value": {"_CTC_c": [0,0,0,0,0,0,0,0,0]},
+        "value": {"_CTC_c": [0, 0, 0, 0, 0, 0, 0, 0, 0]},
         "section_name": "NONREFUNDABLE CREDIT",
         "name": "Total expenditure from child tax credit",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [57.3, 57.0, 57.1, 56.8]}
-     },
-    "r43":{
+    },
+
+    "r43": {
         "start_year": 2015,
         "value": {"_CTC_prt": [0.06]},
         "name": "Increase Child Tax Credit phaseout rate by 1 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r44":{
+    },
+
+    "r44": {
         "start_year": 2015,
         "value": {"_CTC_ps": [[76000, 111000, 56000, 76000, 76000, 56000]]},
         "name": "Increase Child Tax Credit phaseout starting MAGI by 1000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r45":{
+    },
+
+    "r45": {
         "start_year": 2015,
-        "value": {"_EITC_rt": [[0,0,0,0]]},
+        "value": {"_EITC_rt": [[0, 0, 0, 0]]},
         "section_name": "REFUNDABLE CREDIT",
         "name": "Earned income tax credit, total",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [70.4, 71.1, 72.2, 69.9]}
-     },
-    "r46":{
+    },
+
+    "r46": {
         "start_year": 2015,
         "value": {"_EITC_prt": [[0.0865, 0.1698, 0.2206, 0.2206]]},
         "name": "Increase EITC phaseout rate by 1 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r47":{
+    },
+
+    "r47": {
         "start_year": 2015,
         "value": {"_EITC_ps": [[9240, 19110, 19110, 19110]]},
         "name": "Increase EITC phaseout starting AGI by 1000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r48":{
+    },
+
+    "r48": {
         "start_year": 2015,
         "value": {"_EITC_c": [[603, 3459, 5648, 6342]]},
         "name": "Increase Maximum EITC allowed by 100",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r49":{
+    },
+
+    "r49": {
         "start_year": 2015,
         "value": {"_ACTC_rt": [0.17]},
         "name": "Increase additional child tax credit rate by 2 pts",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r50":{
+    },
+
+    "r50": {
         "start_year": 2015,
         "value": {"_ACTC_ChildNum": [2]},
         "name": "Decrease additional child tax credit minimum number of child to two",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-     "r51":{
+    },
+
+    "r51": {
         "start_year": 2015,
         "value": {"_NIIT_trt": [0]},
         "section_name": "OTHER TAXES",
         "name": "Net investment income tax, total",
         "output_type": "_iitax",
         "compare_with": {"Tax Expenditure": [-32.6, -34.7, -36.6, -38.9]}
-     },
-    "r52":{
+    },
+
+    "r52": {
         "start_year": 2015,
         "value": {"_NIIT_thd": [[210000, 260000, 135000, 210000, 260000, 135000]]},
         "name": "Increase Net Investment Income Tax threshold by 10,000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r53":{
+    },
+
+    "r53": {
         "start_year": 2015,
         "value": {"_II_credit": [[1000, 1000, 1000, 1000]]},
         "section_name": "PERSONAL REFUNDABLE CREDIT",
         "name": "Increase Personal Refundable credit amount to 1000",
         "output_type": "_iitax",
         "compare_with": {}
-     },
-    "r54":{
+    },
+
+    "r54": {
         "start_year": 2015,
         "value": {"_II_credit": [[1000, 1000, 1000, 1000]],
                   "_II_credit_ps": [[100000, 100000, 100000, 100000]],
@@ -435,5 +489,5 @@
         "name": "Increase Personal Refundable credit amount to 1000, with phaseout starting AGI 10,000 and phaseout rate at 0.01",
         "output_type": "_iitax",
         "compare_with": {}
-     }
-}     
+    }
+}

--- a/taxcalc/validation/reform-50_1.json
+++ b/taxcalc/validation/reform-50_1.json
@@ -1,6 +1,6 @@
-// REFORM: Suppress AMT 
+// REFORM: Suppress AMT
 // (same as Internet-TAXSIM reform option "50 1")
-{    
+{
     "_AMT_prt": {
         "2013": [0] // set AMT exemption phaseout rate to zero
     },

--- a/taxcalc/validation/reform-75_500.json
+++ b/taxcalc/validation/reform-75_500.json
@@ -1,8 +1,10 @@
-// REFORM: raise std deduction over current-law by $500 in both 2013 and 2014 
+// REFORM: raise std deduction over current-law by $500 in both 2013 and 2014
 // (same as Internet-TAXSIM reform option "75 500")
 {
-    "_STD": { // standard deduction is indexed by filing-unit type
+    "_STD":
+    {
+        // standard deduction is indexed by filing-unit type
         "2013": [[6600, 12700, 6600, 9450, 12700, 6600, 1500]], // up by $500
-        "2014": [[6700, 12900, 6700, 9600, 12900, 6700, 1500]]  // up by $500
+        "2014": [[6700, 12900, 6700, 9600, 12900, 6700, 1500]] // up by $500
     }
 }


### PR DESCRIPTION
This pull request standardizes the format of JSON files (other than current_law_policy.json) in a way that meets PEP8 formatting standards.

The taxcalc/comparison/reforms.json file now passes this test:
```
pep8 --ignore=E501 reforms.json
```
where E501 is the line-too-long warning.

The taxcalc/validation/reform-*.json files now pass this test:
```
pep8 --ignore=E501,E226,E701 reform*json
```
where E266 and E701 suppress warnings generated by the inclusion of //-comments in the files.

Also, two ```II_credit``` arrays were lengthened in reforms.json to include six MARS-indexed values, and therefore, avoid a fatal error in the execution of the reform_results.py script.
