### PR TITLE
Add tax year to pufcsv_mtr output for clarity

### DIFF
--- a/taxcalc/tests/pufcsv_mtr_expect.txt
+++ b/taxcalc/tests/pufcsv_mtr_expect.txt
@@ -1,4 +1,4 @@
-MTR computed using POSITIVE finite_diff.
+MTR computed using POSITIVE finite_diff for tax year 2013
 Total number of data records = 219814
 FICA mtr histogram bin edges:
      [0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.12, 0.14, 0.16, 0.18, 1.0]

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -130,9 +130,10 @@ def test_mtr():
     # construct actual results string, res
     res = ''
     if MTR_NEG_DIFF:
-        res += 'MTR computed using NEGATIVE finite_diff.\n'
+        res += 'MTR computed using NEGATIVE finite_diff '
     else:
-        res += 'MTR computed using POSITIVE finite_diff.\n'
+        res += 'MTR computed using POSITIVE finite_diff '
+    res += 'for tax year {}\n'.format(MTR_TAX_YEAR)
     # create a Policy object (clp) containing current-law policy parameters
     clp = Policy()
     clp.set_year(MTR_TAX_YEAR)


### PR DESCRIPTION
This cosmetic change in test_pufcsv.py mtr output simply clarifies for which tax year the marginal tax rates are being computed.