### PR TITLE
Update TaxBrain-vs-taxcalc results after TaxBrain bug fix

### DIFF
--- a/taxcalc/comparison/stats_summary.py
+++ b/taxcalc/comparison/stats_summary.py
@@ -29,7 +29,7 @@ def main():
                      'on a 10-year span or correlation matrix of current'
                      'tax year. Adding either sum-stats or correlation'
                      'as an argument after python Stats_Summary.py --output')
-                    )
+    )
     parser.add_argument('--output',
                         default='sum-stats')
 

--- a/taxcalc/taxbrain/README.md
+++ b/taxcalc/taxbrain/README.md
@@ -1,9 +1,41 @@
-Cross-Checking Tax-Calculator Reform Results from TaxBrain and taxcalc
-======================================================================
+Cross-Checking Reform Results from TaxBrain
+===========================================
 
 The contents of this taxcalc/taxbrain directory are for use by the
 core development team only and require software that is not described
 elsewhere.  The purpose of the capabilities in this directory is to
-test that Tax-Calculator produces essentially the same results when
-accessed in two different ways: (1) via the TaxBrain webapp running
-in the cloud and (2) via the taxcalc package running on this computer.
+test that Tax-Calculator produces essentially the same reform results
+when accessed in two different ways: (1) via the TaxBrain webapp
+running in the cloud and (2) via the taxcalc package running on this
+computer.
+
+
+Software and Data Requirements
+------------------------------
+
+In order to execute the ```reforms.py``` script in this directory, you
+need to have the Python ```selenium``` package and the Python
+```pyperclip``` package installed on your local computer.  Also, you
+need the Chrome browser installed on you local computer.  The
+```reforms.py``` script looks in the top directory of your local code
+tree (the directory above taxcalc) for two things: the
+selenium-compatible ```chromedriver``` program that automates the
+manipulation of the TaxBrain webapp and the ```puf.csv``` data file
+that is read by the taxcalc package.
+
+
+Getting Started
+---------------
+
+Look at the help for the ```make_reforms.py``` and ```reforms.py```
+scripts by executing the following commands:
+
+```
+$ python make_reforms.py --help
+```
+
+and
+
+```
+$ python reforms.py --help
+```

--- a/taxcalc/taxbrain/all-together.results
+++ b/taxcalc/taxbrain/all-together.results
@@ -1,16 +1,8 @@
-STARTING WITH TAXBRAINTEST : Thu Mar 17 04:11:30 EDT 2016
-1-000	ITAX	2016	82.3	37.16	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2017	82.6	36.21	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2018	83.9	35.89	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2019	85.2	35.53	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2020	86.5	35.35	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2021	87.8	34.44	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2022	89.2	33.47	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2023	90.3	32.45	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2024	91.4	31.33	www.ospc.org/taxbrain/1728/
-1-000	ITAX	2025	92.3	30.13	www.ospc.org/taxbrain/1728/
-1-000	FICA	2018	-0.1	-0.08	www.ospc.org/taxbrain/1728/
-1-000	FICA	2021	-0.1	-0.07	www.ospc.org/taxbrain/1728/
-1-000	FICA	2024	-0.1	-0.06	www.ospc.org/taxbrain/1728/
-1-000	FICA	2025	-0.1	-0.06	www.ospc.org/taxbrain/1728/
-FINISHED WITH TAXBRAINTEST : Thu Mar 17 04:15:36 EDT 2016
+STARTING WITH TAXBRAINTEST : Thu Mar 17 17:10:51 EDT 2016
+1-000	ITAX	2022	0.1	0.04	www.ospc.org/taxbrain/1818/
+1-000	ITAX	2025	0.1	0.03	www.ospc.org/taxbrain/1818/
+1-000	FICA	2018	-0.1	-0.08	www.ospc.org/taxbrain/1818/
+1-000	FICA	2021	-0.1	-0.07	www.ospc.org/taxbrain/1818/
+1-000	FICA	2024	-0.1	-0.06	www.ospc.org/taxbrain/1818/
+1-000	FICA	2025	-0.1	-0.06	www.ospc.org/taxbrain/1818/
+FINISHED WITH TAXBRAINTEST : Thu Mar 17 17:15:02 EDT 2016

--- a/taxcalc/taxbrain/each-separate.results
+++ b/taxcalc/taxbrain/each-separate.results
@@ -1,29 +1,9 @@
-STARTING WITH TAXBRAINTEST : Thu Mar 17 04:41:40 EDT 2016
-10-000	ITAX	2019	-0.1	-0.33	www.ospc.org/taxbrain/1730/
-16-000	ITAX	2023	-0.1	-0.06	www.ospc.org/taxbrain/1736/
-16-000	ITAX	2025	-0.1	-0.06	www.ospc.org/taxbrain/1736/
-3-000	ITAX	2016	72.2	5157.14	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2017	72.4	5569.23	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2018	73.4	5646.15	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2019	74.5	5730.77	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2020	75.7	5407.14	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2021	76.7	5478.57	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2022	77.8	5557.14	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2023	78.7	5621.43	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2024	79.6	5685.71	www.ospc.org/taxbrain/1751/
-3-000	ITAX	2025	80.2	5728.57	www.ospc.org/taxbrain/1751/
-45-000	FICA	2023	-0.1	-0.09	www.ospc.org/taxbrain/1768/
-47-000	ITAX	2020	0.1	1.18	www.ospc.org/taxbrain/1770/
-56-000	ITAX	2016	-67.0	-3045.45	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2017	-69.7	-3168.18	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2018	-72.4	-3147.83	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2019	-74.7	-3247.83	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2020	-77.5	-3229.17	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2021	-80.3	-3212.00	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2022	-83.2	-3328.00	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2023	-86.5	-3326.92	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2024	-89.9	-3329.63	www.ospc.org/taxbrain/1780/
-56-000	ITAX	2025	-93.4	-3459.26	www.ospc.org/taxbrain/1780/
+STARTING WITH TAXBRAINTEST : Thu Mar 17 18:56:46 EDT 2016
+10-000	ITAX	2019	-0.1	-0.33	www.ospc.org/taxbrain/1847/
+16-000	ITAX	2023	-0.1	-0.06	www.ospc.org/taxbrain/1853/
+16-000	ITAX	2025	-0.1	-0.06	www.ospc.org/taxbrain/1853/
+45-000	FICA	2023	-0.1	-0.09	www.ospc.org/taxbrain/1885/
+47-000	ITAX	2020	0.1	1.18	www.ospc.org/taxbrain/1887/
 72-000	TaxBrain-input-error
-75-000	ITAX	2019	0.1	1.64	www.ospc.org/taxbrain/1800/
-FINISHED WITH TAXBRAINTEST : Thu Mar 17 06:29:02 EDT 2016
+75-000	ITAX	2019	0.1	1.64	www.ospc.org/taxbrain/1917/
+FINISHED WITH TAXBRAINTEST : Thu Mar 17 20:46:48 EDT 2016


### PR DESCRIPTION
This pull request updates the ```all-together.results``` and ```each-separate.results``` files to reflect the effect of TaxBrain bug fix in (webapp pull request #)[github.com/OpenSourcePolicyCenter/webapp-public/pull/203], which eliminates all the differences in the test (apart from rounding-error differences).  This pull request also adds to the documentation in the ```README.md``` file.

The changes in this pull request do not effect the tax-calculation logic or the py.test results.

@MattHJensen @talumbau @Amy-Xu 