### PR TITLE
Enter reform parameters in sorted order

### DIFF
--- a/taxcalc/taxbrain/reforms.py
+++ b/taxcalc/taxbrain/reforms.py
@@ -252,7 +252,7 @@ def taxbrain_param_values_insert(driver, start_year, reform_spec):
     or more year:value pairs, and the specified start_year.
     Function returns nothing.
     """
-    for param in reform_spec:
+    for param in sorted(reform_spec.keys()):
         if TRACING:
             sys.stdout.write('==> PARAM {}\n'.format(param))
             sys.stdout.flush()


### PR DESCRIPTION
this keeps the page from jumping around frequently when selenium enters
values into TaxBrain. This change prevents the unintentional 'double
click' of the _AMT_CG_thd2_cpi flag