### PR TITLE
Edit current_law_policy.json to use 'fraction' instead of 'percent'

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -818,8 +818,8 @@
     },
 
     "_SS_percentage1": {
-        "long_name": "Social Security taxable income percentage 1",
-        "description": "Under current law if their provisional income is above the first threshold for Social Security taxability but below the second threshold, taxpayers need to apply this percentage to both the excess of their provisional income over the first threshold and their Social Security benefits, and then include the smaller one in their AGI.",
+        "long_name": "Social Security taxable income decimal fraction 1",
+        "description": "Under current law if their provisional income is above the first threshold for Social Security taxability but below the second threshold, taxpayers need to apply this fraction to both the excess of their provisional income over the first threshold and their Social Security benefits, and then include the smaller one in their AGI.",
         "irs_ref": "Form 1040, line 20b, instructions (Social Security Worksheets, line 2 & 13)",
         "notes": "",
         "start_year": 2013,
@@ -832,8 +832,8 @@
     },
 
     "_SS_percentage2": {
-        "long_name": "Social Security taxable income percentage 2",
-        "description": "Under current law if their provisional income is above the second threshold for Social Security taxability, taxpayers need to apply this percentage to both the excess of their provisional income over the second threshold and their social security benefits, and then include the smaller one in their AGI.",
+        "long_name": "Social Security taxable income decimal fraction 2",
+        "description": "Under current law if their provisional income is above the second threshold for Social Security taxability, taxpayers need to apply this fraction to both the excess of their provisional income over the second threshold and their social security benefits, and then include the smaller one in their AGI.",
         "irs_ref": "Form 1040, line 20b, instructions (Social Security Worksheets, line 15)",
         "notes": "",
         "start_year": 2013,
@@ -860,10 +860,10 @@
     },
 
     "_ID_Medical_frt": {
-        "long_name": "Deduction for medical expenses; floor as a percent of AGI",
-        "description": "Taxpayers are eligible to deduct the portion of their medical expense exceeding this percentage of AGI.",
+        "long_name": "Deduction for medical expenses; floor as a decimal fraction of AGI",
+        "description": "Taxpayers are eligible to deduct the portion of their medical expense exceeding this fraction of AGI.",
         "irs_ref": "Form 1040 Schedule A, line 3, in-line. ",
-        "notes": "This rate cannot be decreased to lower than .1 due to limited data on non-itemizers.",
+        "notes": "This rate cannot be decreased to lower than 0.1 due to limited data on non-itemizers.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
@@ -876,7 +876,7 @@
 
     "_ID_Medical_HC": {
         "long_name": "Medical expense deduction haircut",
-        "description": "This percentage can be applied to limit the amount of medical expense deduction allowed.",
+        "description": "This decimal fraction can be applied to limit the amount of medical expense deduction allowed.",
         "irs_ref": "",
         "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
         "start_year": 2013,
@@ -889,8 +889,8 @@
     },
 
     "_ID_Charity_frt": {
-        "long_name": "Deduction for charitable contributions; floor as a percent of AGI",
-        "description": "Taxpayers are eligible to deduct the portion of their charitable expense exceeding this percentage of AGI.",
+        "long_name": "Deduction for charitable contributions; floor as a decimal fraction of AGI",
+        "description": "Taxpayers are eligible to deduct the portion of their charitable expense exceeding this fraction of AGI.",
         "irs_ref": "",
         "notes": "This parameter allows for implementation of Option 52 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
         "start_year": 2013,
@@ -905,7 +905,7 @@
 
     "_ID_Charity_HC": {
         "long_name": "Charity expense deduction haircut",
-        "description": "This percentage can be applied to limit the amount of charity expense deduction allowed.",
+        "description": "This decimal fraction can be applied to limit the amount of charity expense deduction allowed.",
         "irs_ref": "",
         "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
         "start_year": 2013,
@@ -918,8 +918,8 @@
     },
 
     "_ID_Casualty_frt": {
-        "long_name": "Deduction for casualty loss; floor as a percent of AGI",
-        "description": "Taxpayers are eligible to deduct the portion of their casualty loss exceeding this percentage of AGI.",
+        "long_name": "Deduction for casualty loss; floor as a decimal fraction of AGI",
+        "description": "Taxpayers are eligible to deduct the portion of their casualty loss exceeding this fraction of AGI.",
         "irs_ref": "Form 4684, line 17, in-line.",
         "notes": "This rate cannot be decreased to lower than 0.1 due to lack of data. ",
         "start_year": 2013,
@@ -934,7 +934,7 @@
 
     "_ID_Casualty_HC": {
         "long_name": "Casualty expense deduction haircut",
-        "description": "This percentage can be applied to limit the amount of casualty expense deduction allowed.",
+        "description": "This decimal fraction can be applied to limit the amount of casualty expense deduction allowed.",
         "irs_ref": "",
         "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
         "start_year": 2013,
@@ -947,8 +947,8 @@
     },
 
     "_ID_Miscellaneous_frt": {
-        "long_name": "Deduction for miscellaneous expenses; floor as a percent of AGI",
-        "description": "Taxpayers are eligible to deduct the portion of their miscellaneous expense exceeding this percentage of AGI.",
+        "long_name": "Deduction for miscellaneous expenses; floor as a decimal fraction of AGI",
+        "description": "Taxpayers are eligible to deduct the portion of their miscellaneous expense exceeding this fraction of AGI.",
         "irs_ref": "Form 1040 Schedule A, line 28, instructions. ",
         "notes": "This rate cannot be decreased to lower than 0.02 due to lack of data. ",
         "start_year": 2013,
@@ -963,7 +963,7 @@
 
     "_ID_Miscellaneous_HC": {
         "long_name": "Miscellaneous expense deduction haircut",
-        "description": "This percentage can be applied to limit the amount of miscellaneous expense deduction allowed.",
+        "description": "This decimal fraction can be applied to limit the amount of miscellaneous expense deduction allowed.",
         "irs_ref": "",
         "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
         "start_year": 2013,
@@ -976,8 +976,8 @@
     },
 
     "_ID_Charity_crt_Cash": {
-        "long_name": "Deduction for charitable cash contributions; ceiling as a percent of AGI",
-        "description": "The deduction for Charity in form of cash is capped at this percentage of AGI. ",
+        "long_name": "Deduction for charitable cash contributions; ceiling as a decimal fraction of AGI",
+        "description": "The deduction for Charity in form of cash is capped at this fraction of AGI. ",
         "irs_ref": "Pub. 526, Limits on Deductions: 50% Limit Organizations. ",
         "notes": "This rate cannot be increased to higher 0.5 due to lack of data. ",
         "start_year": 2013,
@@ -991,8 +991,8 @@
     },
 
     "_ID_Charity_crt_Asset": {
-        "long_name": "Deduction for charitable asset contributions; ceiling as a percent of AGI",
-        "description": "The deduction for Charity contributed in the form of assets is capped at this percentage of AGI. ",
+        "long_name": "Deduction for charitable asset contributions; ceiling as a decimal fraction of AGI",
+        "description": "The deduction for Charity contributed in the form of assets is capped at this fraction of AGI. ",
         "irs_ref": "Pub 526, Limits on Deductions: Special 30% Limit for Capital Gain Property.",
         "notes": "This rate cannot be increased to higher than 0.3 due to lack of data. ",
         "start_year": 2013,
@@ -1020,8 +1020,8 @@
     },
 
     "_ID_crt": {
-        "long_name": "Itemized deduction maximum phaseout as a percent of total itemized deductions (Pease)",
-        "description": "The phaseout amount is capped at this percentage of the original total deduction. ",
+        "long_name": "Itemized deduction maximum phaseout as a decimal fraction of total itemized deductions (Pease)",
+        "description": "The phaseout amount is capped at this fraction of the original total deduction. ",
         "irs_ref": "Form 1040 Schedule A, line 29, instructions. ",
         "notes": "The ceiling rate cannot be increased above 0.8 due to limited data on non-itemizers.",
         "start_year": 2013,
@@ -1035,7 +1035,7 @@
 
     "_ID_StateLocalTax_HC": {
         "long_name": "State and local taxes (Income and Sales) deduction haircut.",
-        "description": "This percentage reduces the state and local tax deduction.",
+        "description": "This decimal fraction reduces the state and local tax deduction.",
         "irs_ref": "",
         "notes": "This parameter allows for the implementation of Option 51 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
         "start_year": 2013,
@@ -1049,7 +1049,7 @@
 
     "_ID_RealEstate_HC": {
         "long_name": "Real estate taxes deduction haircut.",
-        "description": "This percentage reduces real estate taxes paid eligible to deduct in itemized deduction.",
+        "description": "This decimal fraction reduces real estate taxes paid eligible to deduct in itemized deduction.",
         "irs_ref": "",
         "notes": "This parameter is currently used to eliminate real estate taxes paid itemized deduction.",
         "start_year": 2013,
@@ -1063,7 +1063,7 @@
 
     "_ID_InterestPaid_HC": {
         "long_name": "Interest deduction haircut",
-        "description": "This percentage can be applied to limit the amount of interest deduction allowed.",
+        "description": "This decimal fraction can be applied to limit the amount of interest deduction allowed.",
         "irs_ref": "",
         "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
         "start_year": 2013,
@@ -1076,8 +1076,8 @@
     },
 
     "_ID_BenefitSurtax_crt": {
-        "long_name": "Credit on itemized deduction benefit surtax (percent of AGI)",
-        "description": "The surtax on specified itemized deductions applies to benefits in excess of this percent of AGI. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
+        "long_name": "Credit on itemized deduction benefit surtax (decimal fraction of AGI)",
+        "description": "The surtax on specified itemized deductions applies to benefits in excess of this fraction of AGI. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -1234,7 +1234,7 @@
 
     "_ALD_Interest_ec": {
         "long_name": "Interest income exclusion",
-        "description": "This percentage can be applied to limit the interest income included in AGI. ",
+        "description": "This decimal fraction can be applied to limit the interest income included in AGI. ",
         "irs_ref": "Form 1040, line 8a",
         "notes": "The final taxable interest amount will be (1- exclusion) * Interest. Even though this portion of interest wouldn't be included in AGI, it still contributes to Net Investment Income Tax and Earned Income Tax Credit.",
         "start_year": 2013,
@@ -1243,12 +1243,12 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0]
+        "value": [0.0]
     },
 
     "_ALD_StudentLoan_HC": {
         "long_name": "Adjustment for student loan interest haircut",
-        "description": "This percentage can be applied to limit the student loan interest adjustment allowed. ",
+        "description": "This decimal fraction can be applied to limit the student loan interest adjustment allowed. ",
         "irs_ref": "Form 1040, line 33",
         "notes": "The final adjustment amount will be (1- Haircut) * Student Loan Interest. ",
         "start_year": 2013,
@@ -1257,12 +1257,12 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0]
+        "value": [0.0]
     },
 
     "_ALD_SelfEmploymentTax_HC": {
         "long_name": "Adjustment for self-employment tax haircut",
-        "description": "This percentage, if greater than zero, reduces the employer equivalent portion of self-employment adjustment. ",
+        "description": "This decimal fraction, if greater than zero, reduces the employer equivalent portion of self-employment adjustment. ",
         "irs_ref": "Form 1040, line 27",
         "notes": "The final adjustment amount would be (1 - Haircut) * Self Employment Tax Adjustment. ",
         "start_year": 2013,
@@ -1271,12 +1271,12 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0]
+        "value": [0.0]
     },
 
     "_ALD_SelfEmp_HealthIns_HC": {
         "long_name": "Adjustment for self employed health insurance haircut",
-        "description": "This percentage, if greater than zero, reduces the health insurance adjustment for self-employed taxpayers. ",
+        "description": "This decimal fraction, if greater than zero, reduces the health insurance adjustment for self-employed taxpayers. ",
         "irs_ref": "Form 1040, line 29",
         "notes": "The final adjustment amount would be (1 - Haircut) * self-employed health insurance adjustment. ",
         "start_year": 2013,
@@ -1285,7 +1285,7 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0]
+        "value": [0.0]
     },
 
     "_ALD_KEOGH_SEP_HC": {


### PR DESCRIPTION
This pull request contains non-substantive changes to the ```current_law_policy.json``` file that are intended to clarify that Tax-Calculator uses decimal fraction parameter values (not percentage parameter values).