### PR TITLE
Added Marginal Tax Rate Plotting Function

### DIFF
--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -283,8 +283,7 @@ def test_add_income_bins_raises():
 
 def test_add_weighted_decile_bins():
     df = DataFrame(data=data, columns=['_expanded_income', 's006', 'label'])
-    num_of_bins = 10
-    df = add_weighted_decile_bins(df, num_of_bins)
+    df = add_weighted_decile_bins(df)
     assert 'bins' in df
     bin_labels = df['bins'].unique()
     default_labels = set(range(1, 11))
@@ -292,7 +291,7 @@ def test_add_weighted_decile_bins():
         assert lab in default_labels
     # Custom labels
     custom_labels = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
-    df = add_weighted_decile_bins(df, num_of_bins, labels=custom_labels)
+    df = add_weighted_decile_bins(df, labels=custom_labels)
     assert 'bins' in df
     bin_labels = df['bins'].unique()
     for lab in bin_labels:

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -13,6 +13,8 @@ CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
 from taxcalc import Policy, Records, Calculator
 from taxcalc.utils import *
+import matplotlib
+import matplotlib.pyplot as plt
 
 # use 1991 PUF-like data to emulate current puf.csv, which is private
 TAXDATA_PATH = os.path.join(CUR_PATH, '..', 'altdata', 'puf91taxdata.csv.gz')

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -283,7 +283,8 @@ def test_add_income_bins_raises():
 
 def test_add_weighted_decile_bins():
     df = DataFrame(data=data, columns=['_expanded_income', 's006', 'label'])
-    df = add_weighted_decile_bins(df)
+    num_of_bins = 10
+    df = add_weighted_decile_bins(df, num_of_bins)
     assert 'bins' in df
     bin_labels = df['bins'].unique()
     default_labels = set(range(1, 11))
@@ -291,7 +292,7 @@ def test_add_weighted_decile_bins():
         assert lab in default_labels
     # Custom labels
     custom_labels = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
-    df = add_weighted_decile_bins(df, labels=custom_labels)
+    df = add_weighted_decile_bins(df, num_of_bins, labels=custom_labels)
     assert 'bins' in df
     bin_labels = df['bins'].unique()
     for lab in bin_labels:

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -311,6 +311,27 @@ def test_add_columns():
     npt.assert_array_equal(df.num_returns_AMT, np.array([0, 20, 30]))
 
 
+def test_mtr_graph():
+    # create a default Policy object
+    policy1 = Policy()
+    records1 = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
+    calc1 = Calculator(policy=policy1, records=records1)
+    calc1.calc_all()
+    # generate a single mtr plot
+    create_mtr_graph(calc1, calc1, MARS=1, weights=weighted_mean,
+                     income_measure='c00100', kid_cap=0)
+    # create a policy-reform Policy object and Calculator calc2
+    reform = {2013: {'_II_rt4': [0.86]}}
+    policy2 = Policy()
+    policy2.implement_reform(reform)
+    records2 = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
+    calc2 = Calculator(policy=policy2, records=records2)
+    calc2.calc_all()
+    # generate a plot that involves two calculator
+    create_mtr_graph(calc1, calc2, MARS=2, weights=weighted_mean,
+                     income_measure='c00100', kid_flo=1, combined_or_IIT='IIT')
+
+
 def test_dist_table_sum_row():
     # Create a default Policy object
     policy1 = Policy()

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -337,11 +337,11 @@ def create_mtr_graph(calcX, calcY, MARS, weights, income_measure='c00100',
     df_filtered_y = df_y[(df_y['MARS'] == MARS) & (df_x['n24'] >= kid_flo) &
                          (df_x['n24'] <= kid_cap)].copy()
 
-    # Create a GroupBy object with 100 groups
+    # create a GroupBy object with 100 groups
     gp_x = df_filtered_x.groupby('bins', as_index=False)
     gp_y = df_filtered_y.groupby('bins', as_index=False)
 
-    # Create a series of size 100
+    # create a series of size 100, and get the desired mtr
     if combined_or_IIT == 'combined':
         wmtr_x = gp_x.apply(weights, 'mtr_combined')
         wmtr_y = gp_y.apply(weights, 'mtr_combined')
@@ -349,26 +349,28 @@ def create_mtr_graph(calcX, calcY, MARS, weights, income_measure='c00100',
         wmtr_x = gp_x.apply(weights, 'mtr_iit')
         wmtr_y = gp_y.apply(weights, 'mtr_iit')
 
-    # Create a DataFrame out of this with a default index
+    # create a DataFrame out of this with a default index
     wmtrx_df = DataFrame(data=wmtr_x, columns=['w_mtr'])
     wmtry_df = DataFrame(data=wmtr_y, columns=['w_mtr'])
 
-    # Add the bin labels
+    # add the bin labels
     wmtrx_df['bins'] = np.arange(1, 101)
     wmtry_df['bins'] = np.arange(1, 101)
 
-    # Join df_x and appld on the bin, carrying along 'w_mtr'
-    # Left join means that 'rslt' is of size len(df_filtered_x)
+    # join df_x and appld on the bin, carrying along 'w_mtr'
+    # left join means that 'rslt' is of size len(df_filtered_x)
     rsltx = pd.merge(df_filtered_x[['bins']], wmtrx_df, how='left')
     rslty = pd.merge(df_filtered_y[['bins']], wmtry_df, how='left')
 
-    # Put that column in df_filtered_x, disregarding index of rslt
+    # put that column in df_filtered_x, disregarding index of rslt
     df_filtered_x['w_mtr'] = rsltx['w_mtr'].values
     df_filtered_y['w_mtr'] = rslty['w_mtr'].values
 
     df_filtered_x.drop_duplicates(subset='bins', inplace=True)
     df_filtered_y.drop_duplicates(subset='bins', inplace=True)
 
+    # plot the mtr against our bins, notice that only one plot will be
+    # generated if two calculators are the same
     plt.plot(df_filtered_x.bins, df_filtered_x.w_mtr)
     if calcX != calcY:
         plt.plot(df_filtered_y.bins.unique(), df_filtered_y.w_mtr.unique())

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -357,8 +357,7 @@ def create_mtr_graph(calcX, calcY, MARS, weights, income_measure='c00100',
     wmtrx_df['bins'] = np.arange(1, 101)
     wmtry_df['bins'] = np.arange(1, 101)
 
-    # join df_x and appld on the bin, carrying along 'w_mtr'
-    # left join means that 'rslt' is of size len(df_filtered_x)
+    # join df_x and apply on the bin, carrying along 'wmtr'
     rsltx = pd.merge(df_filtered_x[['bins']], wmtrx_df, how='left')
     rslty = pd.merge(df_filtered_y[['bins']], wmtry_df, how='left')
 
@@ -369,11 +368,11 @@ def create_mtr_graph(calcX, calcY, MARS, weights, income_measure='c00100',
     df_filtered_x.drop_duplicates(subset='bins', inplace=True)
     df_filtered_y.drop_duplicates(subset='bins', inplace=True)
 
-    # plot the mtr against our bins, notice that only one plot will be
+    # plot the mtr against bins, notice that only one plot will be
     # generated if two calculators are the same
     plt.plot(df_filtered_x.bins, df_filtered_x.w_mtr)
     if calcX != calcY:
-        plt.plot(df_filtered_y.bins.unique(), df_filtered_y.w_mtr.unique())
+        plt.plot(df_filtered_y.bins, df_filtered_y.w_mtr)
         plt.legend(['Baseline', 'Reform'])
 
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -380,7 +380,7 @@ def create_mtr_graph(calcX, calcY, MARS, weights, income_measure='c00100',
     background = layer.add_subplot(111)
     layer.subplots_adjust(top=0.85)
 
-    background.set_xlabel('Income Bins' + '(' + income_measure + ')')
+    background.set_xlabel('Income Percentiles' + '(' + income_measure + ')')
     background.set_ylabel('Marginal Tax Rate' + '(' + combined_or_IIT + ')')
     if calcX != calcY:
         plt.plot(df_filtered_y.bins, df_filtered_y.w_mtr, label="Reform")

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -2,10 +2,13 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame
 from collections import defaultdict
+import matplotlib
+import matplotlib.pyplot as plt
 
 STATS_COLUMNS = ['_expanded_income', 'c00100', '_standard', 'c04470', 'c04600',
                  'c04800', 'c05200', 'c62100', 'c09600', 'c05800', 'c09200',
-                 '_refund', 'c07100', '_iitax', '_fica', '_combined', 's006']
+                 '_refund', 'c07100', '_iitax', '_fica', '_combined', 's006',
+                 'e00200', 'MARS', 'n24']
 
 # each entry in this array corresponds to the same entry in the array
 # TABLE_LABELS below. this allows us to use TABLE_LABELS to map a
@@ -101,7 +104,7 @@ def weighted_share_of_total(agg, col_name, total):
     return float(weighted_sum(agg, col_name)) / (float(total) + EPSILON)
 
 
-def add_weighted_decile_bins(df, income_measure='_expanded_income',
+def add_weighted_decile_bins(df, num_bins, income_measure='_expanded_income',
                              labels=None):
     """
 
@@ -121,9 +124,9 @@ def add_weighted_decile_bins(df, income_measure='_expanded_income',
     # Max value of cum sum of weights
     max_ = df['cumsum_weights'].values[-1]
     # Create 10 bins and labels based on this cumulative weight
-    bins = [0] + list(np.arange(1, 11) * (max_ / 10.0))
+    bins = [0] + list(np.arange(1, (num_bins + 1)) * (max_ / float(num_bins)))
     if not labels:
-        labels = range(1, 11)
+        labels = range(1, (num_bins + 1))
     #  Groupby weighted deciles
     df['bins'] = pd.cut(df['cumsum_weights'], bins, labels=labels)
     return df
@@ -357,7 +360,7 @@ def create_distribution_table(calc, groupby, result_type,
 
     # sorts the data
     if groupby == "weighted_deciles":
-        df = add_weighted_decile_bins(res, income_measure=income_measure)
+        df = add_weighted_decile_bins(res, 10, income_measure=income_measure)
     elif groupby == "small_income_bins":
         df = add_income_bins(res, compare_with="soi",
                              income_measure=income_measure)
@@ -430,7 +433,7 @@ def create_difference_table(calc1, calc2, groupby,
     income_measure = baseline_income_measure
 
     if groupby == "weighted_deciles":
-        df = add_weighted_decile_bins(res2, income_measure=income_measure)
+        df = add_weighted_decile_bins(res2, 10, income_measure=income_measure)
     elif groupby == "small_income_bins":
         df = add_income_bins(res2, compare_with="soi",
                              income_measure=income_measure)

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1,3 +1,4 @@
+import sys
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
@@ -302,7 +303,7 @@ def add_columns(res):
 
 
 def create_mtr_graph(calcX, calcY, MARS, weights, income_measure='c00100',
-                     kid_cap=1000, kid_flo=0, combined_or_IIT='combined'):
+                     kid_cap=1000, kid_flo=0, combined_or_IIT='Combined'):
     """
     The create_mtr_graph function plots the mtr w.r.t different income measure.
 
@@ -342,7 +343,7 @@ def create_mtr_graph(calcX, calcY, MARS, weights, income_measure='c00100',
     gp_y = df_filtered_y.groupby('bins', as_index=False)
 
     # create a series of size 100, and get the desired mtr
-    if combined_or_IIT == 'combined':
+    if combined_or_IIT == 'Combined':
         wmtr_x = gp_x.apply(weights, 'mtr_combined')
         wmtr_y = gp_y.apply(weights, 'mtr_combined')
     elif combined_or_IIT == 'IIT':
@@ -370,10 +371,20 @@ def create_mtr_graph(calcX, calcY, MARS, weights, income_measure='c00100',
 
     # plot the mtr against bins, notice that only one plot will be
     # generated if two calculators are the same
-    plt.plot(df_filtered_x.bins, df_filtered_x.w_mtr)
+    layer = plt.figure()
+    layer.suptitle("MARS = %d, Kid Range: [%d, %d]" % (MARS, kid_cap, kid_flo),
+                   fontsize=12, fontweight='bold')
+
+    plt.plot(df_filtered_x.bins, df_filtered_x.w_mtr, label="Baseline")
+
+    background = layer.add_subplot(111)
+    layer.subplots_adjust(top=0.85)
+
+    background.set_xlabel('Income Bins' + '(' + income_measure + ')')
+    background.set_ylabel('Marginal Tax Rate' + '(' + combined_or_IIT + ')')
     if calcX != calcY:
-        plt.plot(df_filtered_y.bins, df_filtered_y.w_mtr)
-        plt.legend(['Baseline', 'Reform'])
+        plt.plot(df_filtered_y.bins, df_filtered_y.w_mtr, label="Reform")
+        plt.legend(loc='upper left')
 
 
 def create_distribution_table(calc, groupby, result_type,


### PR DESCRIPTION
This PR extracted and modified the mtr plotting function inside a notebook wrote by @MattHJensen. 

The `create_mtr_graph` function allows users to customize the mtr plots with various options: 

1. Plotting one mtr graph or two mtr graphs, where a legend will be created in this case .
2. Choosing from MARS groups.
3. Choosing from weight measures.
4. Choosing from income measures. 
5. Specifying the ceiling of number of kid for each record.
6. Specifying the floor of number of kid for each record.
7. Choosing from mtr measures. 

The following plots show how the graph would look like, with or without a legend: 
![screen shot 2016-03-31 at 2 30 58 pm](https://cloud.githubusercontent.com/assets/13324931/14186671/7355615e-f74d-11e5-85a7-a5f1763c7563.png)
![screen shot 2016-03-31 at 2 30 50 pm](https://cloud.githubusercontent.com/assets/13324931/14186670/7354ac6e-f74d-11e5-8a21-8734fd42b056.png)

Any comments, concerns or remarks would be appreciated. 
@martinholmer @MattHJensen @Amy-Xu @talumbau 
