### PR TITLE
Fix bug in CTC phaseout calculations when _exact==1

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1077,14 +1077,10 @@ def ChildTaxCredit(n24, MARS, CTC_c, c00100, _feided, CTC_ps, _exact,
     _precrd = CTC_c * _nctcr
     _ctcagi = c00100 + _feided
     if _ctcagi > CTC_ps[MARS - 1]:
+        excess = _ctcagi - CTC_ps[MARS - 1]
         if _exact == 1:
-            # round _ctcagi-CTC_ps amount up to nearest whole $1000
-            _precrd = max(0., _precrd - CTC_prt * 1000. *
-                          math.ceil((_ctcagi - CTC_ps[MARS - 1]) / 1000.))
-        else:
-            # ignore rounding logic if _exact != 1
-            _precrd = max(0., _precrd - CTC_prt *
-                          (_ctcagi - CTC_ps[MARS - 1]))
+            excess = 1000. * math.ceil(excess / 1000.)
+        _precrd = max(0., _precrd - CTC_prt * excess)
     return (_nctcr, _precrd, _ctcagi)
 
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1076,12 +1076,15 @@ def ChildTaxCredit(n24, MARS, CTC_c, c00100, _feided, CTC_ps, _exact,
     _nctcr = n24
     _precrd = CTC_c * _nctcr
     _ctcagi = c00100 + _feided
-    if _ctcagi > CTC_ps[MARS - 1] and _exact == 1:
-        _precrd = max(0., _precrd - CTC_prt *
-                      math.ceil(_ctcagi - CTC_ps[MARS - 1]))
-    if _ctcagi > CTC_ps[MARS - 1] and _exact != 1:
-        _precrd = max(0., _precrd - CTC_prt *
-                      max(0., _ctcagi - CTC_ps[MARS - 1]))
+    if _ctcagi > CTC_ps[MARS - 1]:
+        if _exact == 1:
+            # round _ctcagi-CTC_ps amount up to nearest whole $1000
+            _precrd = max(0., _precrd - CTC_prt * 1000. *
+                          math.ceil((_ctcagi - CTC_ps[MARS - 1]) / 1000.))
+        else:
+            # ignore rounding logic if _exact != 1
+            _precrd = max(0., _precrd - CTC_prt *
+                          (_ctcagi - CTC_ps[MARS - 1]))
     return (_nctcr, _precrd, _ctcagi)
 
 


### PR DESCRIPTION
This pull request does not cause any changes in test results because all tests are run with _exact==0.

The former, buggy logic rounded up the amount of MAGI above the phaseout threshold to the next highest dollar (not the next highest whole thousands of dollars).  This bug was introduced into the code in pull request #143, which was merged into master branch on March 4, 2015.