### PR TITLE
Add --csvdump option to inctax.py script

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -72,7 +72,8 @@ def main():
                               '--blowup option is used'),
                         default=False,
                         action="store_true")
-    parser.add_argument('--records',
+    output = parser.add_mutually_exclusive_group(required=False)
+    output.add_argument('--records',
                         help=('optional flag that causes the output file to '
                               'be a CSV-formatted file containing for each '
                               'INPUT filing unit the TAXYEAR values of each '
@@ -81,6 +82,18 @@ def main():
                               'output file name will be the same as if the '
                               'option was not specified, except that the '
                               '".out-inctax" part is replaced by ".records"'),
+                        default=False,
+                        action="store_true")
+    output.add_argument('--csvdump',
+                        help=('optional flag that causes the output file to '
+                              'be a CSV-formatted file containing for each '
+                              'INPUT filing unit the TAXYEAR values of each '
+                              'variable in the Records.VALID_READ_VARS set '
+                              'and in the Records.CALCULATED_VARS set. '
+                              'If the --csvdump option is specified, the '
+                              'output file name will be the same as if the '
+                              'option was not specified, except that the '
+                              '".out-inctax" part is replaced by ".csvdump"'),
                         default=False,
                         action="store_true")
     parser.add_argument('INPUT',
@@ -102,9 +115,12 @@ def main():
                          tax_year=args.TAXYEAR,
                          policy_reform=args.reform,
                          blowup_input_data=args.blowup,
-                         output_records=args.records)
+                         output_records=args.records,
+                         csv_dump=args.csvdump)
     if args.records:
         inctax.output_records(writing_output_file=True)
+    elif args.csvdump:
+        inctax.csv_dump(writing_output_file=True)
     else:
         inctax.calculate(writing_output_file=True,
                          output_weights=args.weights)

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -93,7 +93,8 @@ def test_1():
                          tax_year=2015,
                          policy_reform=reform,
                          blowup_input_data=False,
-                         output_records=False)
+                         output_records=False,
+                         csv_dump=False)
     output = inctax.calculate()
     output_lines_list = output.split('\n')
     output_vars_list = output_lines_list[0].split()
@@ -140,7 +141,8 @@ def test_2():
                          tax_year=2015,
                          policy_reform=reform,
                          blowup_input_data=False,
-                         output_records=False)
+                         output_records=False,
+                         csv_dump=False)
     output = inctax.calculate()
     output_vars_list = output.split()
     ctc = output_vars_list[ctc_ovar_num - 1]

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -62,7 +62,8 @@ def test_1(rawinputfile):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=None,
                          blowup_input_data=True,
-                         output_records=False)
+                         output_records=False,
+                         csv_dump=False)
     assert inctax.tax_year() == taxyear
 
 
@@ -80,7 +81,8 @@ def test_2(rawinputfile):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=reform_dict,
                          blowup_input_data=False,
-                         output_records=False)
+                         output_records=False,
+                         csv_dump=False)
     output = inctax.calculate()
     assert output == EXPECTED_OUTPUT
 
@@ -167,7 +169,8 @@ def test_3(rawinputfile, reformfile1):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=reformfile1.name,
                          blowup_input_data=False,
-                         output_records=False)
+                         output_records=False,
+                         csv_dump=False)
     output = inctax.calculate()
     assert output == EXPECTED_OUTPUT
 
@@ -184,7 +187,8 @@ def test_4(reformfile2):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=reformfile2.name,
                          blowup_input_data=False,
-                         output_records=False)
+                         output_records=False,
+                         csv_dump=False)
     output = inctax.calculate()
     assert output == EXPECTED_OUTPUT
 
@@ -199,6 +203,23 @@ def test_5(rawinputfile):  # pylint: disable=redefined-outer-name
                          tax_year=taxyear,
                          policy_reform=None,
                          blowup_input_data=False,
-                         output_records=True)
+                         output_records=True,
+                         csv_dump=False)
     inctax.output_records(writing_output_file=False)
+    assert inctax.tax_year() == taxyear
+
+
+def test_6(rawinputfile):  # pylint: disable=redefined-outer-name
+    """
+    Test IncomeTaxIO calculate method with no output writing and no blowup and
+    no reform, using the csv_dump option.
+    """
+    taxyear = 2021
+    inctax = IncomeTaxIO(input_data=rawinputfile.name,
+                         tax_year=taxyear,
+                         policy_reform=None,
+                         blowup_input_data=False,
+                         output_records=False,
+                         csv_dump=True)
+    inctax.csv_dump(writing_output_file=False)
     assert inctax.tax_year() == taxyear


### PR DESCRIPTION
This pull request does not have any effect on tax-calculation logic and has no effect on any test results.

This enhancement allows the inctax.py script to write a CSV-formatted output file containing for each input record the value in the tax year of every Records.VALID_READ_VARS variable and every Records.CALCULATED_VARS variable.  This enhancement may be useful in debugging the logic of Tax-Calculator.