### PR TITLE
Correct EITC age-eligibility logic to handle missing age_spouse

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1035,14 +1035,15 @@ def NumDep(EIC, c00100, c01000, e00400, MARS, EITC_ps, EITC_MinEligAge,
 
     if EIC == 0:
         # enforce age eligibility rule for those with no EITC-eligible children
-        # (assume that an unknown age_head value implies EITC age eligibility)
+        # (assume that an unknown age_* value implies EITC age eligibility)
         # pylint: disable=bad-continuation
         if MARS == 2:
             if (age_head >= EITC_MinEligAge and
                 age_head <= EITC_MaxEligAge) or \
                (age_spouse >= EITC_MinEligAge and
                 age_spouse <= EITC_MaxEligAge) or \
-               age_head == 0:
+               age_head == 0 or \
+               age_spouse == 0:
                 c59660 = _preeitc
             else:
                 c59660 = 0.


### PR DESCRIPTION
This pull request fully implements the assumption that missing ages are assumed to meet the EITC age-eligibility test.  Because the `puf.csv` file contains no missing ages (that is, age_head or age_spouse equal to zero) this change in logic has no effect on any test results.