### PR TITLE
Revise make-in.tcl to generate new d validation samples

### DIFF
--- a/taxcalc/validation/make-in.tcl
+++ b/taxcalc/validation/make-in.tcl
@@ -72,7 +72,8 @@ switch $letter {
         set max_ccexp 12
     }
     d { # assumptions for dYY.in sample:
-        # same as c except add other property income, ivar[10]
+        # same as c except (a) add other property income, ivar[10], and
+        # (b) add some young spouses for checking EITC age eligibility
         set num 100000
         set max_wage_yng 300
         set max_wage_old  20
@@ -198,7 +199,11 @@ for {set id 1} {$id <= $num} {incr id} {
         if { $raw_ms == 1 || $raw_ms == 5 } {
             set young_spouse_age 0
         } elseif { $raw_ms == 2 } {
-            set young_spouse_age 50
+            if { $elders == 1 } {
+                set young_spouse_age 20
+            } else {
+                set young_spouse_age 50
+            }
         } else {
             set young_spouse_age 50
         }

--- a/taxcalc/validation/make-in.tcl
+++ b/taxcalc/validation/make-in.tcl
@@ -37,6 +37,7 @@ switch $letter {
         set max_ided_pref 0
         set max_ided_nopref 0
         set max_ccexp 0
+        set yng_spouses 0
     }
     b { # assumptions for bYY.in sample:
         set num 100000
@@ -53,6 +54,7 @@ switch $letter {
         set max_ided_pref 40
         set max_ided_nopref 40
         set max_ccexp 0
+        set yng_spouses 0
     }
     c { # assumptions for cYY.in sample:
         # same as b except add child care expenses, ivar[17]
@@ -70,6 +72,7 @@ switch $letter {
         set max_ided_pref 40
         set max_ided_nopref 40
         set max_ccexp 12
+        set yng_spouses 0
     }
     d { # assumptions for dYY.in sample:
         # same as c except (a) add other property income, ivar[10], and
@@ -88,6 +91,7 @@ switch $letter {
         set max_ided_pref 40
         set max_ided_nopref 40
         set max_ccexp 12
+        set yng_spouses 1
     }
     default {
         puts stderr "ERROR: undefined letter $letter"
@@ -199,7 +203,7 @@ for {set id 1} {$id <= $num} {incr id} {
         if { $raw_ms == 1 || $raw_ms == 5 } {
             set young_spouse_age 0
         } elseif { $raw_ms == 2 } {
-            if { $elders == 1 } {
+            if { $yng_spouses == 1 && $elders == 1 } {
                 set young_spouse_age 20
             } else {
                 set young_spouse_age 50


### PR DESCRIPTION
These changes to `taxcalc/validation/make-in.tcl` do not change the nature of the `a`, `b`, or `c` samples.  The new generated `d` samples include nonzero property income (TAXSIM input variable 10) and use the new age encoding scheme (TAXSIM input variable 6) so as to test Tax-Calculator against the new (March 2016) version of Internet-TAXSIM9.

The changes in this pull request have no effect on tax-calculation logic and do not change any of the unit or validation test results.