### PR TITLE
Eliminate PEP8 warnings from current_law_policy.json

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -368,7 +368,7 @@
                   [8270, 18190, 18190, 18190]]
     },
 
-       "_EITC_MinEligAge":{
+    "_EITC_MinEligAge": {
         "long_name": "Earned Income Credit Minimal Age Eligibility Threshold",
         "description": "Among a childless filling unit, at least one individual's age needs to be no less than this threshold (but no greater than the EITC_MaxEligAge threshold) in order to claim earned income credit.",
         "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
@@ -379,10 +379,10 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value":     [25]
+        "value": [25]
     },
 
-    "_EITC_MaxEligAge":{
+    "_EITC_MaxEligAge": {
         "long_name": "Earned Income Credit Maximal Age Eligibility Threshold",
         "description": "Among a childless filling unit, at least one individual's age needs to be no greater than this threshold (but no less than the EITC_MinEligAge threshold) in order to claim earned income credit.",
         "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
@@ -390,10 +390,10 @@
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
-         "row_label": ["2013"],
+        "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value":     [64]
+        "value": [64]
     },
 
     "_EITC_ps_MarriedJ": {


### PR DESCRIPTION
Reformat JSON statements so as to eliminate PEP8 warnings generated by this command:
```pep8 --ignore=E501,E226,E701 current_law_policy.json```


