### PR TITLE
Fix to better support policy reforms with 'None'

### DIFF
--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -436,6 +436,17 @@ def test_expand_2D_accept_None():
                               num_years=4)
     npt.assert_array_equal(res, exp)
 
+    user_mods = {2016: {u'_II_brk2': _II_brk2}}
+    pol = Policy(start_year=2013)
+    pol.implement_reform(user_mods)
+    pol.set_year(2019)
+    irates = Policy.default_inflation_rates()
+    # The 2019 policy should be the combination of the user-defined
+    # value and CPI-inflated values from 2018
+    exp_2019 = [41000.] + [(1 + irates[2018]) * i for i in _II_brk2[2][1:]]
+    exp_2019 = np.array(exp_2019)
+    npt.assert_array_equal(pol.II_brk2, exp_2019)
+
 
 def test_expand_2D_accept_None_additional_row():
     _II_brk2 = [[36000, 72250, 36500, 48600, 72500, 36250],
@@ -462,6 +473,18 @@ def test_expand_2D_accept_None_additional_row():
     res = Policy.expand_array(_II_brk2, inflate=True,
                               inflation_rates=inflation_rates, num_years=5)
     npt.assert_array_equal(res, exp)
+
+    user_mods = {2016: {u'_II_brk2': _II_brk2}}
+    pol = Policy(start_year=2013)
+    pol.implement_reform(user_mods)
+    pol.set_year(2020)
+    irates = Policy.default_inflation_rates()
+    # The 2020 policy should be the combination of the user-defined
+    # value and CPI-inflated values from 2018
+    exp_2020 = [43000.] + [(1 + irates[2019]) * (1 + irates[2018]) * i
+                           for i in _II_brk2[2][1:]]
+    exp_2020 = np.array(exp_2020)
+    npt.assert_allclose(pol.II_brk2, exp_2020)
 
 
 @pytest.yield_fixture


### PR DESCRIPTION
- For multi-valued policy parameters, it is sometimes desirable to only
  specify a few of the values of the reform for a given year. A user may
  specify 'None' for the other values, which indicates that current
  policy would be followed for the unspecified value for that year.