### PR TITLE
Added Reform Test Based on Calculated Results 

### DIFF
--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -357,6 +357,8 @@ def test_same_reform_expressed_two_ways_result():
     reform2 = {2017: {'_STD': [[0, 0, 0, 0, 0, 0, 0]]},
                2017: {'_EITC_MinEligAge': [26]}
                }
+    print reform1
+    print reform2
     # specify two separate policies
     policy_1 = Policy()
     policy_2 = Policy()

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -345,6 +345,40 @@ def test_Calculator_using_nonstd_input(rawinputfile):
     assert_allclose(mtr_fica, exp_mtr_fica)
 
 
+def test_same_reform_expressed_two_ways_result():
+    """
+    Test that two ways of specifying the same reform produce the same results.
+    """
+    # specify the same reform in two different ways
+    reform1 = {2014: {'_EITC_rt': [[0, 0, 0, 0]], '_EITC_prt': [[0, 0, 0, 0]]}}
+    reform2 = {2014: {'_EITC_rt': [[0, 0, 0, 0]]},
+               2014: {'_EITC_prt': [[0, 0, 0, 0]]}}
+    # specify two separate policies
+    policy_1 = Policy()
+    policy_2 = Policy()
+    # load the input data separately as well
+    TAXDATA_1 = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
+    TAXDATA_2 = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
+
+    # set up two parallel calculators
+    calcX = Calculator(policy=policy_1, records=TAXDATA_1)
+    calcY = Calculator(policy=policy_2, records=TAXDATA_2)
+
+    # implement the same reforms that are expressed in different ways
+    policy_1.implement_reform(reform1)
+    policy_2.implement_reform(reform2)
+
+    calcX.advance_to_year(2014)
+    calcY.advance_to_year(2014)
+
+    # calculate the results for the two calculators
+    calcX.calc_all()
+    calcY.calc_all()
+    # confirm that the two calculators yield the same iitax liability
+    assert (calcX.records._iitax * calcX.records.s006).sum() == \
+        (calcY.records._iitax * calcY.records.s006).sum()
+
+
 class TaxCalcError(Exception):
     '''I've stripped this down to a simple extension of the basic Exception for
     now. We can add functionality later as we see fit.

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -14,6 +14,8 @@ from taxcalc import create_distribution_table, create_difference_table
 # use 1991 PUF-like data to emulate current puf.csv, which is private
 TAXDATA_PATH = os.path.join(CUR_PATH, '..', 'altdata', 'puf91taxdata.csv.gz')
 TAXDATA = pd.read_csv(TAXDATA_PATH, compression='gzip')
+PUF_PATH = os.path.join(CUR_PATH, '..', '..', 'puf.csv')
+PUFDATA = pd.read_csv(PUF_PATH,)
 WEIGHTS_PATH = os.path.join(CUR_PATH, '..', 'altdata', 'puf91weights.csv.gz')
 WEIGHTS = pd.read_csv(WEIGHTS_PATH, compression='gzip')
 
@@ -350,15 +352,17 @@ def test_same_reform_expressed_two_ways_result():
     Test that two ways of specifying the same reform produce the same results.
     """
     # specify the same reform in two different ways
-    reform1 = {2014: {'_EITC_rt': [[0, 0, 0, 0]], '_EITC_prt': [[0, 0, 0, 0]]}}
-    reform2 = {2014: {'_EITC_rt': [[0, 0, 0, 0]]},
-               2014: {'_EITC_prt': [[0, 0, 0, 0]]}}
+    reform1 = {2017: {'_STD': [[0, 0, 0, 0, 0, 0, 0]],
+                      '_EITC_MinEligAge': [26]}}
+    reform2 = {2017: {'_STD': [[0, 0, 0, 0, 0, 0, 0]]},
+               2017: {'_EITC_MinEligAge': [26]}
+               }
     # specify two separate policies
     policy_1 = Policy()
     policy_2 = Policy()
     # load the input data separately as well
-    TAXDATA_1 = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
-    TAXDATA_2 = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
+    TAXDATA_1 = Records(data=PUFDATA, start_year=2009)
+    TAXDATA_2 = Records(data=PUFDATA, start_year=2009)
 
     # set up two parallel calculators
     calcX = Calculator(policy=policy_1, records=TAXDATA_1)
@@ -368,15 +372,15 @@ def test_same_reform_expressed_two_ways_result():
     policy_1.implement_reform(reform1)
     policy_2.implement_reform(reform2)
 
-    calcX.advance_to_year(2014)
-    calcY.advance_to_year(2014)
+    calcX.advance_to_year(2017)
+    calcY.advance_to_year(2017)
 
     # calculate the results for the two calculators
     calcX.calc_all()
     calcY.calc_all()
     # confirm that the two calculators yield the same iitax liability
-    assert (calcX.records._iitax * calcX.records.s006).sum() == \
-        (calcY.records._iitax * calcY.records.s006).sum()
+    assert (calcX.records._combined * calcX.records.s006).sum() == \
+        (calcY.records._combined * calcY.records.s006).sum()
 
 
 class TaxCalcError(Exception):


### PR DESCRIPTION
This PR adds a test unit to verify an issue that has been identified in #710, where reform expressed in two different ways might yield different results. 

Although #711, which added a test unit that examines the consistency of implementing the same reform in two ways, has passed, this PR that carries out the verification based on the weighted sum of calculated individual income tax results of two calculators with essentially the same reform fails to pass. The test failure suggests that we might be not properly implementing the two different expressions of the same reform. 

It is however somewhat confusing that #711 should report no error. Another guess is that there might be something wrong with the calculation part, instead of implementation of the reforms. 

@martinholmer @MattHJensen @Amy-Xu 
Comments, concerns or remarks would be appreciated. 