### PR TITLE
Refine EITC_M??EligAge documentation

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -369,7 +369,7 @@
     },
 
     "_EITC_MinEligAge": {
-        "long_name": "EITC Minimum Age for Childless Eligibility",
+        "long_name": "Minimum Age for Childless EITC Eligibility",
         "description": "For a childless filling unit, at least one individual's age needs to be no less than this age (but no greater than the EITC_MaxEligAge) in order to be eligible for an earned income tax credit.",
         "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
         "notes": "",
@@ -383,7 +383,7 @@
     },
 
     "_EITC_MaxEligAge": {
-        "long_name": "EITC Maximum Age for Childless Eligibility",
+        "long_name": "Maximum Age for Childless EITC Eligibility",
         "description": "For a childless filling unit, at least one individual's age needs to be no greater than this age (but no less than the EITC_MinEligAge) in order to be eligible for an earned income tax credit.",
         "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
         "notes": "",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -369,8 +369,8 @@
     },
 
     "_EITC_MinEligAge": {
-        "long_name": "Earned Income Credit Minimum Age Eligibility Threshold",
-        "description": "Among a childless filling unit, at least one individual's age needs to be no less than this threshold (but no greater than the EITC_MaxEligAge threshold) in order to claim earned income credit.",
+        "long_name": "EITC Minimum Age for Childless Eligibility",
+        "description": "For a childless filling unit, at least one individual's age needs to be no less than this age (but no greater than the EITC_MaxEligAge) in order to be eligible for an earned income tax credit.",
         "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
         "notes": "",
         "start_year": 2013,
@@ -383,8 +383,8 @@
     },
 
     "_EITC_MaxEligAge": {
-        "long_name": "Earned Income Credit Maximum Age Eligibility Threshold",
-        "description": "Among a childless filling unit, at least one individual's age needs to be no greater than this threshold (but no less than the EITC_MinEligAge threshold) in order to claim earned income credit.",
+        "long_name": "EITC Maximum Age for Childless Eligibility",
+        "description": "For a childless filling unit, at least one individual's age needs to be no greater than this age (but no less than the EITC_MinEligAge) in order to be eligible for an earned income tax credit.",
         "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
         "notes": "",
         "start_year": 2013,


### PR DESCRIPTION
Clarify that these two parameters are ages.  These non-substantive edits do not change any tax-calculation logic or any test results, but they should (eventually) be reflected in TaxBrain's reform box titles.

@talumbau 