### PR TITLE
Remove aging and improper use of e03260 variable

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -22,7 +22,7 @@ import copy
 @iterate_jit(nopython=True)
 def EI_FICA(SS_Earnings_c, e00200, e00200p, e00200s,
             e11055, e00250, e30100, FICA_ss_trt, FICA_mc_trt,
-            e00900p, e00900s, e02100p, e02100s, e03260, _exact):
+            e00900p, e00900s, e02100p, e02100s):
     """
     EI_FICA function: computes total earned income and regular FICA taxes.
     """
@@ -61,8 +61,6 @@ def EI_FICA(SS_Earnings_c, e00200, e00200p, e00200s,
     # compute AGI deduction for "employer share" of self-employment FICA taxes
     c09400 = fica_ss_sey_p + fica_ss_sey_s + fica_mc_sey_p + fica_mc_sey_s
     c03260 = 0.5 * c09400  # half of c09400 represents the "employer share"
-    if _exact == 1:
-        c03260 = e03260
 
     # compute _earned
     c11055 = e11055

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -358,7 +358,6 @@ class Records(object):
         self.e03210 *= ATXPY
         self.e03220 *= ATXPY
         self.e03230 *= ATXPY
-        self.e03260 *= ASCHCI
         self.e03270 *= ACPIM
         self.e03240 *= AGDPN
         self.e03290 *= ACPIM


### PR DESCRIPTION
Before the changes in this pull request, the `e03260` variable (half of self-employed FICA taxes paid) was being read from the `puf.csv` file and being "aged" in the Records class `_blowup` method. It is conceptually incorrect to blowup this variable because its future value depends, in part, on the social security payroll tax policy parameters, which can change over the course of the tax simulation.  However, the `c03260` variable is begin correctly calculated and correctly used in the income tax calculations (to adjust AGI).  So, this pull request simply removes the "aging" of the `e03260` variable and its incorrect use when `_exact == 1`.

This pull request does not change any tax-calculation logic (because `_exact == 0`) and does not change any test results.

