### PR TITLE
Add delta_wages to e00200p in behavior.py update_ordinary_income()

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -32,6 +32,7 @@ def update_ordinary_income(behavioral_effect, calc_y):
                               0.)
 
     calc_y.records.e00200 = calc_y.records.e00200 + delta_wages
+    calc_y.records.e00200p = calc_y.records.e00200p + delta_wages
 
     calc_y.records.e00300 = calc_y.records.e00300 + delta_other_inc
 


### PR DESCRIPTION
While I was not involved in the original development of the `Behavior` class and `behavior` function (which implement the behavioral-response logic in the TaxBrain partial-equilibrium dynamic analysis), and therefore, could be missing something, it seems as if the change in wage-and-salary income induced by the behavioral responses to a tax reform should be added to the `e00200p` variable as well as being added to the `e00200` variable.  Neglecting to add the change to the `e00200p` variable means that the change in earnings caused by the behavioral response to a tax reform is not being used to calculate a change in payroll taxes.

We can assess the implications of this single-line change in the code by using the following script:
```
taxcalc/taxbrain$ python behavior.py --help
usage: python behavior.py [-h] REFORM_YEAR CALC_YEAR SUB_ELAST INC_ELAST

Writes to stdout behavioral-response results produced by Tax-Calculator via
the taxcalc package running on this computer.  These results can be compared
with hand-generated results produced by TaxBrain running in the cloud.

positional arguments:
  REFORM_YEAR  calendar year of pop-the-cap reform
  CALC_YEAR    calendar year of calculation results
  SUB_ELAST    substitution elasticity of behavior
  INC_ELAST    income elasticity of behavior

optional arguments:
  -h, --help   show this help message and exit
```
Before the one-line code change, we have these results:
```
taxcalc/taxbrain$ python behavior.py 2020 2020 0.25 0.0
REFORM: pop-the-cap in 2020
SUB_ELASTICITY,INC_ELASTICITY= 0.25 0.0
2020,ITAX,REV_STATIC(S),REV_DYNAMIC(D),D-S= 1737.5 1703.9 -33.6
2020,FICA,REV_STATIC(S),REV_DYNAMIC(D),D-S= 1416.7 1416.3 -0.5
```
After the one-line code change in this pull request, we have these results:
```
taxcalc/taxbrain$ python behavior.py 2020 2020 0.25 0.0
REFORM: pop-the-cap in 2020
SUB_ELASTICITY,INC_ELASTICITY= 0.25 0.0
2020,ITAX,REV_STATIC(S),REV_DYNAMIC(D),D-S= 1737.5 1703.9 -33.6
2020,FICA,REV_STATIC(S),REV_DYNAMIC(D),D-S= 1416.7 1405.7 -11.0
```
Notice that the behavioral responses to this reform induce a decline in income tax revenue that is unchanged by the code revision: -33.6 billion 2020 dollars.  But the decline in payroll taxes is now much larger and more reasonable for this policy reform: -11.0 billion versus -0.5 billion 2020 dollars.

Any thoughts or comments?

@MattHJensen @talumbau @Amy-Xu 
