### PR TITLE
Charity Contribution Parameter Issue

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1004,8 +1004,8 @@
     },
 
     "_ID_Charity_crt": {
-        "long_name": "Deduction for charitable cash contributions; ceiling as a decimal fraction of AGI",
-        "description": "In general, contributions to charitable organizations may be deducted up to 50 percent of adjusted gross income computed without regard to net operating loss carrybacks.",
+        "long_name": "Deduction for charitable contributions; ceiling as a decimal fraction of AGI",
+        "description": "The deduction for Charity is capped at this fraction of AGI. ",
         "irs_ref": "Pub. 526, Limits on Deductions: 50% Limit Organizations. ",
         "notes": "This rate cannot be increased to higher 0.5 due to lack of data. ",
         "start_year": 2013,

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1003,9 +1003,9 @@
         "value": [0.0]
     },
 
-    "_ID_Charity_crt_Cash": {
+    "_ID_Charity_crt": {
         "long_name": "Deduction for charitable cash contributions; ceiling as a decimal fraction of AGI",
-        "description": "The deduction for Charity in form of cash is capped at this fraction of AGI. ",
+        "description": "In general, contributions to charitable organizations may be deducted up to 50 percent of adjusted gross income computed without regard to net operating loss carrybacks.",
         "irs_ref": "Pub. 526, Limits on Deductions: 50% Limit Organizations. ",
         "notes": "This rate cannot be increased to higher 0.5 due to lack of data. ",
         "start_year": 2013,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -213,7 +213,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
             e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
             MARS, c00100, ID_ps, ID_Medical_frt, ID_Medical_HC,
             ID_Casualty_frt, ID_Casualty_HC, ID_Miscellaneous_frt,
-            ID_Miscellaneous_HC, ID_Charity_crt_Cash, ID_Charity_crt_Asset,
+            ID_Miscellaneous_HC, ID_Charity_crt, ID_Charity_crt_Asset,
             ID_prt, ID_crt, ID_StateLocalTax_HC, ID_Charity_frt,
             ID_Charity_HC, ID_InterestPaid_HC, ID_RealEstate_HC, puf):
     """
@@ -240,7 +240,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
         ID_Miscellaneous_frt : Deduction for miscellaneous expenses;
         floor as a percent of AGI
 
-        ID_Charity_crt_Cash : Deduction for charitable cash contributions;
+        ID_Charity_crt : Deduction for charitable contributions;
         ceiling as a percent of AGI
 
         ID_Charity_crt_Asset : Deduction for charitable asset contributions;
@@ -319,7 +319,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900, e19700,
         c19700 = base_charity
     else:
         lim30 = min(ID_Charity_crt_Asset * _posagi, e20100 + e20200)
-        c19700 = min(ID_Charity_crt_Cash * _posagi, lim30 + e19800)
+        c19700 = min(ID_Charity_crt * _posagi, lim30 + e19800)
     charity_floor = ID_Charity_frt * _posagi  # frt is zero in present law
     c19700 = max(0., c19700 - charity_floor)
     # Gross Itemized Deductions


### PR DESCRIPTION
This PR resolves parameter naming and description issue discussed in #372. 

In particular, both [Pub 526](http://www.irs.gov/pub/irs-pdf/p526.pdf) and [IRS Charitable Contribution Deductions](http://www.irs.gov/Charities-&-Non-Profits/Charitable-Organizations/Charitable-Contribution-Deductions) indicate that there's no particular cap for charity cash contribution, while there is a general 50% cap for total charity contribution. Thus I suggest we remove the cap for cash contribution and parametrize the general 50% cap. This PR makes no change toward any tests, validations or reforms result. 

In the webapp-public page, it seems that we are using the old parameter name [here](https://github.com/OpenSourcePolicyCenter/webapp-public/blob/master/webapp/apps/taxbrain/models.py#L166). We might want to rename in the webapp code as well to prevent any error.


@MattHJensen 