### PR TITLE
Move macro_elasticity test out of test_pufcsv.py file

### DIFF
--- a/taxcalc/macro_elasticity.py
+++ b/taxcalc/macro_elasticity.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def percentage_change_gdp(calc1, calc2, elasticity=0.0):
+def proportional_change_gdp(calc1, calc2, elasticity=0.0):
     '''
     This function harnesses econometric estimates of the historic relationship
     between tax policy and the macroeconomy to predict the effect of tax
@@ -35,24 +35,18 @@ def percentage_change_gdp(calc1, calc2, elasticity=0.0):
 
     Returns
     -------
-    Float estimate of the GDP impact of the reform.
+    Float estimate of proportional GDP impact of the reform.
     '''
-    mtr_fica_x, mtr_iit_x, mtr_combined_x = calc1.mtr()
-    mtr_fica_y, mtr_iit_y, mtr_combined_y = calc2.mtr()
-
-    after_tax_mtr_x = (1 - ((mtr_combined_x) * calc1.records.c00100 *
-                       calc1.records.s006).sum() /
-                       (calc1.records.c00100 * calc1.records.s006).sum())
-
-    after_tax_mtr_y = (1 - ((mtr_combined_y) * calc2.records.c00100 *
-                       calc2.records.s006).sum() /
-                       (calc2.records.c00100 * calc2.records.s006).sum())
-
-    diff_avg_mtr_combined_y = after_tax_mtr_y - after_tax_mtr_x
-    percent_diff_mtr = diff_avg_mtr_combined_y / after_tax_mtr_x
-
-    gdp_effect_y = percent_diff_mtr * elasticity
-
+    _, _, mtr_combined_x = calc1.mtr()
+    _, _, mtr_combined_y = calc2.mtr()
+    avg_one_mtr_x = (1. - (mtr_combined_x * calc1.records.c00100 *
+                           calc1.records.s006).sum() /
+                     (calc1.records.c00100 * calc1.records.s006).sum())
+    avg_one_mtr_y = (1. - (mtr_combined_y * calc2.records.c00100 *
+                           calc2.records.s006).sum() /
+                     (calc2.records.c00100 * calc2.records.s006).sum())
+    diff_avg_one_mtr = avg_one_mtr_y - avg_one_mtr_x
+    proportional_diff_mtr = diff_avg_one_mtr / avg_one_mtr_x
+    gdp_effect_y = proportional_diff_mtr * elasticity
     print(("%.5f" % gdp_effect_y))
-
     return gdp_effect_y

--- a/taxcalc/tests/test_macro_elasticity.py
+++ b/taxcalc/tests/test_macro_elasticity.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pandas as pd
+import pytest
+CUR_PATH = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(CUR_PATH, '..', '..'))
+from taxcalc import Policy, Records, Calculator  # pylint: disable=import-error
+from taxcalc import proportional_change_gdp  # pylint: disable=import-error
+
+# use 1991 PUF-like data to emulate current puf.csv, which is private
+TAXDATA_PATH = os.path.join(CUR_PATH, '..', 'altdata', 'puf91taxdata.csv.gz')
+WEIGHTS_PATH = os.path.join(CUR_PATH, '..', 'altdata', 'puf91weights.csv.gz')
+
+
+def test_proportional_change_gdp():
+    policy1 = Policy()
+    recs1 = Records(data=TAXDATA_PATH, weights=WEIGHTS_PATH, start_year=2009)
+    calc1 = Calculator(policy=policy1, records=recs1)
+    policy2 = Policy()
+    reform = {2013: {'_II_em': [0.0]}}
+    policy2.implement_reform(reform)
+    recs2 = Records(data=TAXDATA_PATH, weights=WEIGHTS_PATH, start_year=2009)
+    calc2 = Calculator(policy=policy2, records=recs2)
+    gdp_diff = proportional_change_gdp(calc1, calc2, elasticity=0.36)
+    assert gdp_diff > 0

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -22,7 +22,6 @@ import sys
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
 from taxcalc import Policy, Records, Calculator  # pylint: disable=import-error
-from taxcalc import percentage_change_gdp  # pylint: disable=import-error
 PUFCSV_PATH = os.path.join(CUR_PATH, '..', '..', 'puf.csv')
 AGGRES_PATH = os.path.join(CUR_PATH, 'pufcsv_agg_expect.txt')
 MTRRES_PATH = os.path.join(CUR_PATH, 'pufcsv_mtr_expect.txt')
@@ -181,22 +180,3 @@ def test_mtr():
         sys.stdout.write('***            and rerun test.                ***\n')
         sys.stdout.write('*************************************************\n')
         assert False
-
-
-@pytest.mark.requires_pufcsv
-def test_percentage_change_gdp():
-    """
-    Test Tax-Calculator macro_elasticity.py capability.
-    """
-    calc1 = Calculator(policy=Policy(), records=Records(data=PUFCSV_PATH))
-    calc1.calc_all()
-    policy2 = Policy()
-    reform = {2013: {"_STD": [[12600, 25200, 12600,
-                               18600, 25300, 12600, 2100]],
-                     "_AMT_trt1": [0.0],
-                     "_AMT_trt2": [0.0]}}
-    policy2.implement_reform(reform)
-    calc2 = Calculator(policy=policy2, records=Records(data=PUFCSV_PATH))
-    calc2.calc_all()
-    gdp_diff = percentage_change_gdp(calc1, calc2, elasticity=0.36)
-    assert gdp_diff > 0


### PR DESCRIPTION
Moving the test increases code coverage because the tests in the `test_pufcsv.py` file are not executed by Travis-CI, and hence, do not contribute to the code-coverage statistics.

Also, made non-substantive changes to code in the `macro_elasticity.py` file in order to clarify that the calculated statistic in not a percentage (but rather a proportional) change in GDP.  But, in order to clarify this fact, the name of the function was changed.  This pull requests makes no changes in tax-calculation logic.