### PR TITLE
Remove itemized-deduction logic from Behavior response method

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -182,33 +182,19 @@ class Behavior(ParametersBase):
         Implement total taxable income change induced by behavioral response.
         """
         # Assume no behv response for filing units with no, or negative, AGI
-        delta_income = np.where(calc.records.c00100 > 0., taxinc_change, 0.)
-        # Compute itemized deductions, ided
-        # pylint: disable=protected-access
-        ided = np.where(calc.records.c04470 < calc.records._standard,
-                        0.,
-                        calc.records.c04470)
-        # Compute AGI plus itemized deductions, agi_ided
-        agi_ided = calc.records.c00100 + ided
+        agi = calc.records.c00100
+        delta_income = np.where(agi > 0., taxinc_change, 0.)
         # Allocate delta_income
-        delta_wage = np.where(agi_ided > 0.,
-                              delta_income * calc.records.e00200 / agi_ided,
+        delta_wage = np.where(agi > 0.,
+                              delta_income * calc.records.e00200 / agi,
                               0.)
-        oinc = calc.records.c00100 - calc.records.e00200
-        delta_oinc = np.where(agi_ided > 0.,
-                              delta_income * oinc / agi_ided,
-                              0.)
-        delta_ided = np.where(agi_ided > 0.,
-                              delta_income * ided / agi_ided,
+        other_income = agi - calc.records.e00200
+        delta_oinc = np.where(agi > 0.,
+                              delta_income * other_income / agi,
                               0.)
         calc.records.e00200 = calc.records.e00200 + delta_wage
         calc.records.e00200p = calc.records.e00200p + delta_wage
         calc.records.e00300 = calc.records.e00300 + delta_oinc
-        calc.records.e19570 = np.where(ided > 0.,
-                                       calc.records.e19570 + delta_ided,
-                                       0.)
-        # TODO, we should create a behavioral modification
-        # variable instead of using e19570
         return calc
 
     @staticmethod


### PR DESCRIPTION
This pull request was prepared at the request of Matt Jensen.  The idea is to remove the itemized-deduction logic in the Behavior class response method until the problems identified in issue #789 can be resolved.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun 