### PR TITLE
Handle non-existence of numba package

### DIFF
--- a/taxcalc/tests/test_decorators.py
+++ b/taxcalc/tests/test_decorators.py
@@ -337,7 +337,7 @@ def test_force_no_numba():
     hasattr(mck, 'jit')
     del mck.jit
     import taxcalc
-    nmba = sys.modules['numba']
+    nmba = sys.modules.get('numba', None)
     sys.modules.update([('numba', mck)])
     # Reload the decorators with faked out numba
     reload_module(taxcalc.decorators)
@@ -360,4 +360,5 @@ def test_force_no_numba():
                     columns=["a", "b"])
     assert_frame_equal(ans, exp)
     # Restore numba module
-    sys.modules['numba'] = nmba
+    if nmba:
+        sys.modules['numba'] = nmba


### PR DESCRIPTION
- `test_force_no_numba` removes the numba module from sys.modules, but
  does so in a way that assumes it exists in the first place. This fix
  handles the case of non-existence of the numba package