### PR TITLE
Remove puf variable from decorators logic and tests

### DIFF
--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -234,13 +234,12 @@ def iterate_jit(parameters=None, **kwargs):
         kwargs_for_func = toolz.keyfilter(in_args.__contains__, kwargs)
         kwargs_for_jit = toolz.keyfilter(jit_args.__contains__, kwargs)
 
-        # Any name that is a parameter (or the special case 'puf')
+        # Any name that is a parameter
         # Boolean flag is given special treatment.
         # Identify those names here
         dd_key_list = list(Policy.default_data(metadata=True).keys())
         allowed_parameters = dd_key_list
         allowed_parameters += list(arg[1:] for arg in dd_key_list)
-        allowed_parameters.append("puf")
         additional_parameters = [arg for arg in in_args if
                                  arg in allowed_parameters]
         additional_parameters += parameters

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -19,7 +19,7 @@ try:
     jit = numba.jit  # pylint: disable=invalid-name
     DO_JIT = True
 except (ImportError, AttributeError):
-    def id_wrapper(*dec_args, **dec_kwargs):
+    def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
         """
         Function wrapper when numba package is not available.
         """

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -1,8 +1,18 @@
+"""
+Implement JIT-related decorators used to speed-up tax-calculating functions.
+"""
+# CODING-STYLE CHECKS:
+# pep8 --ignore=E402 decorators.py
+# pylint --disable=locally-disabled decorators.py
+# (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
+
+
 import inspect
 from .policy import Policy
 from six import StringIO
 import ast
 import toolz
+
 
 try:
     import numba
@@ -10,12 +20,20 @@ try:
     DO_JIT = True
 except (ImportError, AttributeError):
     def id_wrapper(*dec_args, **dec_kwargs):
-        def wrap(f):
+        """
+        Function wrapper when numba package is not available.
+        """
+        def wrap(fnc):
+            """
+            wrap function nested in id_wrapper function.
+            """
             def wrapped_f(*args, **kwargs):
-                return f(*args, **kwargs)
+                """
+                wrapped_f function nested in wrap function.
+                """
+                return fnc(*args, **kwargs)
             return wrapped_f
         return wrap
-
     jit = id_wrapper
     DO_JIT = False
 
@@ -25,6 +43,9 @@ class GetReturnNode(ast.NodeVisitor):
     A Visitor to get the return tuple names from a calc-style function
     """
     def visit_Return(self, node):
+        """
+        visit_Return method in GetReturnNode class.
+        """
         if isinstance(node.value, ast.Tuple):
             return [e.id for e in node.value.elts]
         else:
@@ -172,11 +193,17 @@ def apply_jit(dtype_sig_out, dtype_sig_in, parameters=None, **kwargs):
         parameters = []
 
     def make_wrapper(func):
+        """
+        make_wrapper function nested in apply_jit function.
+        """
         theargs = inspect.getargspec(func).args
         jitted_apply = make_apply_function(func, dtype_sig_out,
                                            dtype_sig_in, parameters, **kwargs)
 
         def wrapper(*args):
+            """
+            wrapper function nested in make_wrapper function.
+            """
             in_arrays = []
             out_arrays = []
             for farg in theargs:
@@ -209,8 +236,10 @@ def iterate_jit(parameters=None, **kwargs):
         parameters = []
 
     def make_wrapper(func):
-        # Wrap this function in apply_jit from apply_jit
-
+        """
+        make_wrapper function nested in iterate_jit decorator
+        wraps specified func using apply_jit.
+        """
         # Get the input arguments from the function
         in_args = inspect.getargspec(func).args
         try:
@@ -255,6 +284,10 @@ def iterate_jit(parameters=None, **kwargs):
                                                **kwargs_for_jit)
 
         def wrapper(*args, **kwargs):
+            """
+            wrapper function nested in make_wrapper function nested
+            in iterate_jit decorator.
+            """
             in_arrays = []
             pm_or_pf = []
             for farg in all_out_args + in_args:
@@ -276,4 +309,5 @@ def iterate_jit(parameters=None, **kwargs):
             return ans
 
         return wrapper
+
     return make_wrapper

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -40,11 +40,11 @@ except (ImportError, AttributeError):
 
 class GetReturnNode(ast.NodeVisitor):
     """
-    A Visitor to get the return tuple names from a calc-style function
+    A NodeVisitor to get the return tuple names from a calc-style function.
     """
-    def visit_Return(self, node):
+    def visit_Return(self, node):  # pylint: disable=invalid-name,no-self-use
         """
-        visit_Return method in GetReturnNode class.
+        visit_Return is used by NodeVisitor.visit method.
         """
         if isinstance(node.value, ast.Tuple):
             return [e.id for e in node.value.elts]

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -16,7 +16,7 @@ import toolz
 
 try:
     import numba
-    jit = numba.jit
+    jit = numba.jit  # pylint: disable=invalid-name
     DO_JIT = True
 except (ImportError, AttributeError):
     def id_wrapper(*dec_args, **dec_kwargs):
@@ -34,7 +34,7 @@ except (ImportError, AttributeError):
                 return fnc(*args, **kwargs)
             return wrapped_f
         return wrap
-    jit = id_wrapper
+    jit = id_wrapper  # pylint: disable=invalid-name
     DO_JIT = False
 
 
@@ -54,7 +54,7 @@ class GetReturnNode(ast.NodeVisitor):
 
 def create_apply_function_string(sigout, sigin, parameters):
     """
-    Create a string for a function of the form::
+    Create a string for a function of the form:
 
         def ap_fuc(x_0, x_1, x_2, ...):
             for i in range(len(x_0)):
@@ -62,7 +62,7 @@ def create_apply_function_string(sigout, sigin, parameters):
             return x_0[i], ...
 
     where the specific args to jitted_f and the number of
-    values to return is determined by sigout and sigin
+    values to return is determined by sigout and sigin.
 
     Parameters
     ----------
@@ -97,15 +97,12 @@ def create_apply_function_string(sigout, sigin, parameters):
 
 def create_toplevel_function_string(args_out, args_in, pm_or_pf):
     """
-    Create a string for a function of the form::
+    Create a string for a function of the form:
 
         def hl_func(x_0, x_1, x_2, ...):
             outputs = (...) = calc_func(...)
             header = [...]
             return DataFrame(data, columns=header)
-
-    where the specific args to jitted_f and the number of
-    values to return is destermined by sigout and sigin
 
     Parameters
     ----------
@@ -126,13 +123,13 @@ def create_toplevel_function_string(args_out, args_in, pm_or_pf):
     fstr.write("    import numpy as np\n")
     fstr.write("    outputs = \\\n")
     outs = []
-    for p, attr in zip(pm_or_pf, args_out + args_in):
-        outs.append(p + "." + attr + ", ")
+    for ppp, attr in zip(pm_or_pf, args_out + args_in):
+        outs.append(ppp + "." + attr + ", ")
     outs = [m_or_f + "." + arg for m_or_f, arg in zip(pm_or_pf, args_out)]
     fstr.write("        (" + ", ".join(outs) + ") = \\\n")
     fstr.write("        " + "applied_f(")
-    for p, attr in zip(pm_or_pf, args_out + args_in):
-        fstr.write(p + "." + attr + ", ")
+    for ppp, attr in zip(pm_or_pf, args_out + args_in):
+        fstr.write(ppp + "." + attr + ", ")
     fstr.write(")\n")
     fstr.write("    header = [")
     col_headers = ["'" + out + "'" for out in args_out]
@@ -178,7 +175,8 @@ def make_apply_function(func, out_args, in_args, parameters,
     apfunc = create_apply_function_string(out_args, in_args, parameters)
     func_code = compile(apfunc, "<string>", "exec")
     fakeglobals = {}
-    eval(func_code, {"jitted_f": jitted_f}, fakeglobals)
+    eval(func_code,  # pylint: disable=eval-used
+         {"jitted_f": jitted_f}, fakeglobals)
     if do_jit:
         return jit(**kwargs)(fakeglobals['ap_func'])
     else:
@@ -266,10 +264,10 @@ def iterate_jit(parameters=None, **kwargs):
 
         # Discover the return arguments by walking
         # the AST of the function
-        gnr = GetReturnNode()
+        grn = GetReturnNode()
         all_out_args = None
         for node in ast.walk(ast.parse(''.join(src))):
-            all_out_args = gnr.visit(node)
+            all_out_args = grn.visit(node)
             if all_out_args:
                 break
         if not all_out_args:
@@ -303,7 +301,8 @@ def iterate_jit(parameters=None, **kwargs):
                                                               pm_or_pf)
             func_code = compile(high_level_func, "<string>", "exec")
             fakeglobals = {}
-            eval(func_code, {"applied_f": applied_jitted_f}, fakeglobals)
+            eval(func_code,  # pylint: disable=eval-used
+                 {"applied_f": applied_jitted_f}, fakeglobals)
             high_level_fn = fakeglobals['hl_func']
             ans = high_level_fn(*args, **kwargs)
             return ans

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -241,12 +241,8 @@ def iterate_jit(parameters=None, **kwargs):
         """
         # Get the input arguments from the function
         in_args = inspect.getargspec(func).args
-        try:
-            jit_args = inspect.getargspec(jit).args + ['nopython']
-        except TypeError:
-            # print ("This should only be seen in RTD, if not install numba!")
-            return func
-
+        # Get the numba.jit arguments
+        jit_args = inspect.getargspec(jit).args + ['nopython']
         kwargs_for_jit = toolz.keyfilter(jit_args.__contains__, kwargs)
 
         # Any name that is a parameter

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -1,5 +1,5 @@
 """
-Implement JIT-related decorators used to speed-up tax-calculating functions.
+Implement Numba JIT decorators used to speed-up tax-calculating functions.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 decorators.py
@@ -195,6 +195,7 @@ def apply_jit(dtype_sig_out, dtype_sig_in, parameters=None, **kwargs):
         make_wrapper function nested in apply_jit function.
         """
         theargs = inspect.getargspec(func).args
+        # pylint: disable=star-args
         jitted_apply = make_apply_function(func, dtype_sig_out,
                                            dtype_sig_in, parameters, **kwargs)
 
@@ -274,6 +275,7 @@ def iterate_jit(parameters=None, **kwargs):
             raise ValueError("Can't find return statement in function!")
 
         # Now create the apply-style possibly-jitted function
+        # pylint: disable=star-args
         applied_jitted_f = make_apply_function(func,
                                                list(reversed(all_out_args)),
                                                in_args,

--- a/taxcalc/tests/test_decorators.py
+++ b/taxcalc/tests/test_decorators.py
@@ -191,13 +191,10 @@ def test_ret_everything_iterate_jit():
     assert_frame_equal(ans, exp)
 
 
-@iterate_jit(parameters=['puf'], nopython=True, puf=True)
-def Magic_calc3(x, y, z, puf):
+@iterate_jit(nopython=True)
+def Magic_calc3(x, y, z):
     a = x + y
-    if (puf):
-        b = x + y + z
-    else:
-        b = 42
+    b = a + z
     return (a, b)
 
 
@@ -215,27 +212,10 @@ def test_function_takes_kwarg():
     assert_frame_equal(ans, exp)
 
 
-def test_function_takes_kwarg_nondefault_value():
-    pm = Foo()
-    pf = Foo()
-    pm.a = np.ones((5,))
-    pm.b = np.ones((5,))
-    pf.x = np.ones((5,))
-    pf.y = np.ones((5,))
-    pf.z = np.ones((5,))
-    ans = Magic_calc3(pm, pf, puf=False)
-    exp = DataFrame(data=[[2.0, 42.0]] * 5,
-                    columns=["a", "b"])
-    assert_frame_equal(ans, exp)
-
-
-@iterate_jit(nopython=True, puf=True)
-def Magic_calc4(x, y, z, puf):
+@iterate_jit(nopython=True)
+def Magic_calc4(x, y, z):
     a = x + y
-    if (puf):
-        b = x + y + z
-    else:
-        b = 42
+    b = a + z
     return (a, b)
 
 
@@ -253,13 +233,10 @@ def test_function_no_parameters_listed():
     assert_frame_equal(ans, exp)
 
 
-@iterate_jit(parameters=['w'], nopython=True, puf=True)
-def Magic_calc5(w, x, y, z, puf):
+@iterate_jit(parameters=['w'], nopython=True)
+def Magic_calc5(w, x, y, z):
     a = x + y
-    if (puf):
-        b = w[0] + x + y + z
-    else:
-        b = 42
+    b = w[0] + x + y + z
     return (a, b)
 
 
@@ -278,31 +255,25 @@ def test_function_parameters_optional():
     assert_frame_equal(ans, exp)
 
 
-def unjittable_function(w, x, y, z, puf):
+def unjittable_function(w, x, y, z):
     a = x + y
-    if (puf):
-        b = w[0] + x + y + z
-    else:
-        b = 42
+    b = w[0] + x + y + z
 
 
-def unjittable_function2(w, x, y, z, puf):
+def unjittable_function2(w, x, y, z):
     a = x + y
-    if (puf):
-        b = w[0] + x + y + z
-    else:
-        b = 42
+    b = w[0] + x + y + z
     return (a, b, c)
 
 
 def test_iterate_jit_raises_on_no_return():
     with pytest.raises(ValueError):
-        ij = iterate_jit(parameters=['w'], nopython=True, puf=True)
+        ij = iterate_jit(parameters=['w'], nopython=True)
         ij(unjittable_function)
 
 
 def test_iterate_jit_raises_on_unknown_return_argument():
-    ij = iterate_jit(parameters=['w'], nopython=True, puf=True)
+    ij = iterate_jit(parameters=['w'], nopython=True)
     uf2 = ij(unjittable_function2)
     pm = Foo()
     pf = Foo()
@@ -316,12 +287,9 @@ def test_iterate_jit_raises_on_unknown_return_argument():
         ans = uf2(pm, pf)
 
 
-def Magic_calc6(w, x, y, z, puf):
+def Magic_calc6(w, x, y, z):
     a = x + y
-    if (puf):
-        b = w[0] + x + y + z
-    else:
-        b = 42
+    b = w[0] + x + y + z
     return (a, b)
 
 
@@ -345,7 +313,7 @@ def test_force_no_numba():
     ij = taxcalc.decorators.iterate_jit
     taxcalc.decorators.DO_JIT = True
     # Now use iterate_jit on a dummy function
-    Magic_calc6 = ij(parameters=['w'], nopython=True, puf=True)(Magic_calc6)
+    Magic_calc6 = ij(parameters=['w'], nopython=True)(Magic_calc6)
     # Do work and verify function works as expected
     pm = Foo()
     pf = Foo()

--- a/taxcalc/tests/test_decorators.py
+++ b/taxcalc/tests/test_decorators.py
@@ -255,7 +255,7 @@ def test_function_parameters_optional():
     assert_frame_equal(ans, exp)
 
 
-def unjittable_function(w, x, y, z):
+def unjittable_function1(w, x, y, z):
     a = x + y
     b = w[0] + x + y + z
 
@@ -269,7 +269,7 @@ def unjittable_function2(w, x, y, z):
 def test_iterate_jit_raises_on_no_return():
     with pytest.raises(ValueError):
         ij = iterate_jit(parameters=['w'], nopython=True)
-        ij(unjittable_function)
+        ij(unjittable_function1)
 
 
 def test_iterate_jit_raises_on_unknown_return_argument():
@@ -283,7 +283,7 @@ def test_iterate_jit_raises_on_unknown_return_argument():
     pf.x = np.ones((5,))
     pf.y = np.ones((5,))
     pf.z = np.ones((5,))
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         ans = uf2(pm, pf)
 
 


### PR DESCRIPTION
Merged pull requests #805, #806, #808, and #809, taken together, remove the usage of the `puf` variable in the `iterate_jit` decorator in the `functions.py` file.  As a result, logic in the `decorators.py` file and tests in the `test_decorators.py` file can be simplified.  This pull request contains some simplifications, but it may be possible to simplify the logic and/or the tests even more.  Suggestions for further simplifications are welcome.  If no concerns are raised or addition simplifications are suggested, it is anticipated that this pull request will be merged into the master branch sometime on Friday, July 8th.

@MattHJensen @feenberg @talumbau @Amy-Xu @GoFroggyRun @zrisher 


