### PR TITLE
Fix pension-benefit mtr calculations given new SchR credit calculation

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -242,6 +242,8 @@ class Calculator(object):
             seincome_type = self.records.e00900
         elif income_type_str == 'e00650':
             divincome_type = self.records.e00600
+        elif income_type_str == 'e01700':
+            penben_type = self.records.e01500
         # calculate level of taxes after a marginal increase in income
         setattr(self.records, income_type_str, income_type + finite_diff)
         if income_type_str == 'e00200p':
@@ -250,6 +252,8 @@ class Calculator(object):
             self.records.e00900 = seincome_type + finite_diff
         elif income_type_str == 'e00650':
             self.records.e00600 = divincome_type + finite_diff
+        elif income_type_str == 'e01700':
+            self.records.e01500 = penben_type + finite_diff
         if self.consumption.has_response():
             self.consumption.response(self.records, finite_diff)
         self.calc_all()

--- a/taxcalc/tests/pufcsv_mtr_expect.txt
+++ b/taxcalc/tests/pufcsv_mtr_expect.txt
@@ -27,7 +27,7 @@ FICA and IIT mtr histogram bin counts for e01400:
 219814 :      0      0      0      0  60150  62825  47562  26866  21722    689
 FICA and IIT mtr histogram bin counts for e01700:
 219814 : 219814      0      0      0      0      0      0      0      0      0
-219814 :      0      0      0      0  60153  62822  47545  26882  21723    689
+219814 :      0      0      0      0  60146  62828  47545  26883  21723    689
 FICA and IIT mtr histogram bin counts for e02000:
 219814 : 219814      0      0      0      0      0      0      0      0      0
 219814 :      0      0      0      0  60173  62778  44325  26322  25517    699

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -281,6 +281,8 @@ def test_Calculator_mtr():
     assert type(mtr_combined) == np.ndarray
     (_, _, mtr_combined) = calc.mtr(income_type_str='e00900p')
     assert type(mtr_combined) == np.ndarray
+    (_, _, mtr_combined) = calc.mtr(income_type_str='e01700')
+    assert type(mtr_combined) == np.ndarray
 
 
 def test_Calculator_create_difference_table():


### PR DESCRIPTION
Pull request #810 made the calculation of Schedule R credits the default in Tax-Calculator.  The Schedule R credit depends, in part, on the amount of **nontaxable** pension benefits, which is equal to `e01500 - e01700`.  One of the valid income types for which a marginal tax rate (MTR) can be computed is `e01700`, which is **taxable** pension benefits (that is, those included in AGI).  The mtr() method logic has been changed in this pull request to ensure that **nontaxable** pension benefits remain constant (rather than incorrectly declining) when doing MTR calculations for **taxable** pension benefits.

These code changes affect only the `pufcsv_mtr_expected.txt` unit test results, with a few elderly filing units now having somewhat higher marginal tax rates.

If there are no comments, questions, or concerns, this pull request #814 will be merged into the master branch sometime on Friday, July 8th.

@MattHJensen @feenberg @talumbau @Amy-Xu @GoFroggyRun @zrisher