### PR TITLE
Make F5405 function logic more clear and consistent

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -12,7 +12,6 @@ Tax-Calculator functions that calculate FICA and individual income taxes.
 # pylint: disable=too-many-locals
 
 
-import pandas as pd
 import math
 import numpy as np
 from .decorators import iterate_jit, jit
@@ -1154,13 +1153,13 @@ def AddCTC(_nctcr, _precrd, _earned, c07220, _fica_was,
             _othadd)
 
 
-def F5405(pol, rec):
+@iterate_jit(nopython=True)
+def F5405(e11580, c11580):
     """
-    F5405 function: Form 5405 First-Time Homebuyer Credit is not needed
+    Form 5405, First-Time Homebuyer Credit
     """
-    if pol.current_year > 0:  # meaningless use of required first argument
-        c64450 = np.zeros((rec.dim,))
-    return pd.DataFrame(data=np.column_stack((c64450,)), columns=['c64450'])
+    c11580 = e11580
+    return c11580
 
 
 @iterate_jit(nopython=True)
@@ -1211,14 +1210,14 @@ def DEITC(c59660, c07100, c08800, c05800, _avail, e11601, e07170, _othertax):
 
 
 @iterate_jit(nopython=True)
-def IITAX(c09200, c59660, c11070, c10960, c11600, c10950, _eitc, e11580,
+def IITAX(c09200, c59660, c11070, c10960, c11600, c10950, _eitc, c11580,
           e11450, e11500, e82040, e11550, e10000, _fica, _personal_credit, n24,
           CTC_additional, CTC_additional_ps, CTC_additional_prt, c00100,
           _sep, MARS):
     """
     IITAX function: ...
     """
-    _refund = (c59660 + c11070 + c10960 + c10950 + c11600 + e11580 + e11450 +
+    _refund = (c59660 + c11070 + c10960 + c10950 + c11600 + c11580 + e11450 +
                e11500 + _personal_credit)
     _iitax = c09200 - _refund - e82040
     _combined = _iitax + _fica

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -165,7 +165,7 @@ class Records(object):
         'e07500', 'e08001',
         'e07980', 'e10000', 'e10100', 'e10050', 'e10075',
         'e09805', 'e09710', 'e09720',
-        'e11601',
+        'e11601', 'c11580',
         'e40223', '_sey', '_earned', '_earned_p', '_earned_s',
         'c09400', '_feided', '_ymod', '_ymod1', '_posagi',
         '_xyztax', '_avail', 'e85070',


### PR DESCRIPTION
Revise F5405 function to make it clear that Tax-Calculator is not computing the First-Time Homebuyer Credit, but rather using the blown-up `e11580` variable as the calculated variable for that credit.

No change in any results from the unit tests, validation tests, or reform comparisons.
