### PR TITLE
Revise notes field for _FEI_ec_c policy parameter

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -270,7 +270,7 @@
         "long_name": "Maximum foreign earned income exclusion",
         "description": "This amount is the maximum foreign earned income taxpayers could exclude from gross income.",
         "irs_ref": "Form 2555, line 29b, instruction.",
-        "notes": "This parameter cannot be decreased due to lack of data. ",
+        "notes": "This parameter has no effect on taxes due to lack of data. ",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",


### PR DESCRIPTION
See [TaxBrain issue #285](https://github.com/OpenSourcePolicyCenter/webapp-public/issues/285) for the reason for this change in one notes field in the `current_law_policy.json` file.

@MattHJensen @feenberg @talumbau @Amy-Xu @GoFroggyRun @zrisher 