### PR TITLE
Improve readability of unit-test-failure messages

### DIFF
--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -111,15 +111,18 @@ def test_function_args_usage():
     fcontent = re.sub('#.*', '', fcontent)  # remove all '#...' comments
     fcontent = re.sub('\n', ' ', fcontent)  # replace EOL character with space
     funcs = fcontent.split('def ')  # list of function text
+    msg = 'FUNCTION ARGUMENT(S) NEVER USED:\n'
+    found_error = False
     for func in funcs[1:]:  # skip first item in list, which is imports, etc.
         fcode = func.split('return ')[0]  # fcode is between def and return
         match = re.search(r'^(.+?)\((.*?)\):(.*)$', fcode)
         if match is None:
             msg = ('Could not find function name, arguments, '
-                   'and code portions in the following text:')
-            line = '====================================================='
-            sys.stdout.write('{}\n{}\n{}\n{}\n'.format(msg, line, fcode, line))
-            assert False
+                   'and code portions in the following text:\n')
+            msg += '--------------------------------------------------------\n'
+            msg += '{}\n'.format(fcode)
+            msg += '--------------------------------------------------------\n'
+            raise ValueError(msg)
         else:
             fname = match.group(1)
             fargs = match.group(2).split(',')  # list of function arguments
@@ -127,9 +130,10 @@ def test_function_args_usage():
         for farg in fargs:
             arg = farg.strip()
             if fbody.find(arg) < 0:
-                msg = '{} function argument {} never used\n'.format(fname, arg)
-                sys.stdout.write(msg)
-                assert 'argument' == 'UNUSED'
+                found_error = True
+                msg += 'FUNCTION,ARGUMENT= {} {}\n'.format(fname, arg)
+    if found_error:
+        raise ValueError(msg)
 
 
 def test_1():

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -35,6 +35,7 @@ def test_agg():
     """
     Test Tax-Calculator aggregate taxes with no policy reform using puf.csv
     """
+    # pylint: disable=too-many-locals
     # create a Policy object (clp) containing current-law policy parameters
     clp = Policy()
     # create a Records object (puf) containing puf.csv input records
@@ -62,13 +63,14 @@ def test_agg():
         new_filename = '{}{}'.format(AGGRES_PATH[:-10], 'actual.txt')
         with open(new_filename, 'w') as new_file:
             new_file.write(adtstr)
-        sys.stdout.write('*************************************************\n')
-        sys.stdout.write('*** NEW RESULTS IN pufcsv_agg_actual.txt FILE ***\n')
-        sys.stdout.write('*** if new OK, copy pufcsv_agg_actual.txt to  ***\n')
-        sys.stdout.write('***                 pufcsv_agg_expect.txt     ***\n')
-        sys.stdout.write('***            and rerun test.                ***\n')
-        sys.stdout.write('*************************************************\n')
-        assert False
+        msg = 'PUFCSV AGG RESULTS DIFFER\n'
+        msg += '-------------------------------------------------\n'
+        msg += '--- NEW RESULTS IN pufcsv_agg_actual.txt FILE ---\n'
+        msg += '--- if new OK, copy pufcsv_agg_actual.txt to  ---\n'
+        msg += '---                 pufcsv_agg_expect.txt     ---\n'
+        msg += '---            and rerun test.                ---\n'
+        msg += '-------------------------------------------------\n'
+        raise ValueError(msg)
 
 
 MTR_TAX_YEAR = 2013
@@ -173,10 +175,11 @@ def test_mtr():
         new_filename = '{}{}'.format(MTRRES_PATH[:-10], 'actual.txt')
         with open(new_filename, 'w') as new_file:
             new_file.write(res)
-        sys.stdout.write('*************************************************\n')
-        sys.stdout.write('*** NEW RESULTS IN pufcsv_mtr_actual.txt FILE ***\n')
-        sys.stdout.write('*** if new OK, copy pufcsv_mtr_actual.txt to  ***\n')
-        sys.stdout.write('***                 pufcsv_mtr_expect.txt     ***\n')
-        sys.stdout.write('***            and rerun test.                ***\n')
-        sys.stdout.write('*************************************************\n')
-        assert False
+        msg = 'PUFCSV MTR RESULTS DIFFER\n'
+        msg += '-------------------------------------------------\n'
+        msg += '--- NEW RESULTS IN pufcsv_mtr_actual.txt FILE ---\n'
+        msg += '--- if new OK, copy pufcsv_mtr_actual.txt to  ---\n'
+        msg += '---                 pufcsv_mtr_expect.txt     ---\n'
+        msg += '---            and rerun test.                ---\n'
+        msg += '-------------------------------------------------\n'
+        raise ValueError(msg)

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -185,22 +185,33 @@ def test_var_labels_txt_contents():
     # read variables in var_labels.txt file (checking for duplicates)
     var_labels_path = os.path.join(CUR_PATH, '..', 'var_labels.txt')
     var_labels_set = set()
-    with open(var_labels_path, 'r') as input:
-        for line in input:
+    with open(var_labels_path, 'r') as varlabels:
+        msg = 'DUPLICATE VARIABLE(S) IN VAR_LABELS.TXT:\n'
+        found_duplicates = False
+        for line in varlabels:
             var = (line.split())[0]
             if var in var_labels_set:
-                msg = 'DUPLICATE_IN_VAR_LABELS.TXT: {}\n'.format(var)
-                sys.stdout.write(msg)
-                assert False
+                found_duplicates = True
+                msg += 'VARIABLE= {}\n'.format(var)
             else:
                 var_labels_set.add(var)
-    # change all VALID variables to uppercase
-    var_used_set = set()
+        if found_duplicates:
+            raise ValueError(msg)
+    # change all Records.VALID_READ_VARS variables to uppercase
+    var_valid_set = set()
     for var in Records.VALID_READ_VARS:
-        var_used_set.add(var.upper())
-    # check for no extra var_used variables
-    used_less_labels = var_used_set - var_labels_set
-    assert len(used_less_labels) == 0
+        var_valid_set.add(var.upper())
+    # check for no extra var_valid variables
+    valid_less_labels = var_valid_set - var_labels_set
+    if len(valid_less_labels) > 0:
+        msg = 'VARIABLE(S) IN VALID_READ_VARS BUT NOT VAR_LABELS.TXT:\n'
+        for var in valid_less_labels:
+            msg += 'VARIABLE= {}\n'.format(var)
+        raise ValueError(msg)
     # check for no extra var_labels variables
-    labels_less_used = var_labels_set - var_used_set
-    assert len(labels_less_used) == 0
+    labels_less_valid = var_labels_set - var_valid_set
+    if len(labels_less_valid) > 0:
+        msg = 'VARIABLE(S) IN VAR_LABELS.TXT BUT NOT VALID_READ_VARS:\n'
+        for var in labels_less_valid:
+            msg += 'VARIABLE= {}\n'.format(var)
+        raise ValueError(msg)


### PR DESCRIPTION
This pull request implements in several unit tests easier-to-read error messages as suggested by T.J. Alumbaugh.  There is no change in tax-calculation or unit-test logic, and therefore, no change in results generated by the unit tests, validation tests, or reform comparisons.

@MattHJensen @talumbau 
