### PR TITLE
Add comments on using debugger to trace tax calculations

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -13,7 +13,6 @@ from .records import Records
 from .behavior import Behavior
 from .growth import Growth
 from .consumption import Consumption
-from .decorators import DEBUGGING
 # import pdb
 
 

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -13,6 +13,9 @@ from .records import Records
 from .behavior import Behavior
 from .growth import Growth
 from .consumption import Consumption
+from .decorators import DEBUGGING
+if DEBUGGING:
+    import pdb
 
 
 class Calculator(object):
@@ -74,6 +77,8 @@ class Calculator(object):
         AMTI(self.policy, self.records)
 
     def calc_one_year(self):
+        if DEBUGGING:
+            pdb.set_trace()
         EI_FICA(self.policy, self.records)
         Adj(self.policy, self.records)
         CapGains(self.policy, self.records)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -14,8 +14,7 @@ from .behavior import Behavior
 from .growth import Growth
 from .consumption import Consumption
 from .decorators import DEBUGGING
-if DEBUGGING:
-    import pdb
+# import pdb
 
 
 class Calculator(object):
@@ -77,8 +76,7 @@ class Calculator(object):
         AMTI(self.policy, self.records)
 
     def calc_one_year(self):
-        if DEBUGGING:
-            pdb.set_trace()
+        # pdb.set_trace()
         EI_FICA(self.policy, self.records)
         Adj(self.policy, self.records)
         CapGains(self.policy, self.records)

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -14,10 +14,9 @@ import ast
 import toolz
 
 
-# pylint: disable=invalid-name
 def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
     """
-    Function wrapper when numba package is not available or when DEBUGGING
+    Function wrapper when numba package is not available or when debugging
     """
     def wrap(fnc):
         """
@@ -32,6 +31,7 @@ def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
     return wrap
 
 
+# pylint: disable=invalid-name
 try:
     import numba
     jit = numba.jit
@@ -39,9 +39,9 @@ try:
 except (ImportError, AttributeError):
     jit = id_wrapper
     DO_JIT = False
-# In order to use Python debugger, you can do these two things:
-#   (a) uncomment the two lines below item (b) in this comment, and
-#   (b) import pdb package and call pdb.set_trace() in calculator.py
+# One way to use the Python debugger is to do these two things:
+#    (a) uncomment the two lines below item (b) in this comment, and
+#    (b) import pdb package and call pdb.set_trace() in calculator.py
 # jit = id_wrapper  # uncomment this and next line to use debugger
 # DO_JIT = False  # uncomment this and prior line to use debugger
 

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -14,7 +14,9 @@ import ast
 import toolz
 
 
-DEBUGGING = False  # set to True to allow use of Python debugger
+# set DEBUGGING to True to allow use of Python debugger, but would also
+# need to import pdb package and call pdb.set_trace() in calculator.py
+DEBUGGING = False
 
 
 # pylint: disable=invalid-name

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -14,11 +14,6 @@ import ast
 import toolz
 
 
-# set DEBUGGING to True to allow use of Python debugger, but would also
-# need to import pdb package and call pdb.set_trace() in calculator.py
-DEBUGGING = False
-
-
 # pylint: disable=invalid-name
 def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
     """
@@ -37,18 +32,18 @@ def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
     return wrap
 
 
-if DEBUGGING:
-    # don't use jit even if numba package is installed
+try:
+    import numba
+    jit = numba.jit
+    DO_JIT = True
+except (ImportError, AttributeError):
     jit = id_wrapper
     DO_JIT = False
-else:  # try to import numba package
-    try:
-        import numba
-        jit = numba.jit
-        DO_JIT = True
-    except (ImportError, AttributeError):
-        jit = id_wrapper
-        DO_JIT = False
+# In order to use Python debugger, you can do these two things:
+#   (a) uncomment the two lines below item (b) in this comment, and
+#   (b) import pdb package and call pdb.set_trace() in calculator.py
+# jit = id_wrapper  # uncomment this and next line to use debugger
+# DO_JIT = False  # uncomment this and prior line to use debugger
 
 
 class GetReturnNode(ast.NodeVisitor):


### PR DESCRIPTION
This pull request does what the title says.  The new DEBUGGING variable in decorators.py is False, so that normally there is no change in the operation of Tax-Calculator.  When DEBUGGING is temporarily set to True, the debugger will stop execution and begin an interactive debugging session at the start of the Calculator.calc_one_year() method.  The most effective way to use this option is to use an input file (via the inctax.py interface to Tax-Calculator) that contains only one or just a few filing units.

@MattHJensen @feenberg @talumbau @Amy-Xu @GoFroggyRun @zrisher 
 