### PR TITLE
Add and optionally use Records.zero_out_changing_calculated_vars() method

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -73,8 +73,9 @@ class Calculator(object):
         MUI(self.policy, self.records)
         AMTI(self.policy, self.records)
 
-    def calc_one_year(self):
-        self.records.zero_out_changing_calculated_vars()
+    def calc_one_year(self, zero_out_calc_vars=False):
+        if zero_out_calc_vars:
+            self.records.zero_out_changing_calculated_vars()
         # pdb.set_trace()
         EI_FICA(self.policy, self.records)
         Adj(self.policy, self.records)
@@ -130,8 +131,8 @@ class Calculator(object):
         IITAX(self.policy, self.records)
         ExpandIncome(self.policy, self.records)
 
-    def calc_all(self):
-        self.calc_one_year()
+    def calc_all(self, zero_out_calc_vars=False):
+        self.calc_one_year(zero_out_calc_vars)
         BenefitSurtax(self)
 
     def increment_year(self):
@@ -170,6 +171,7 @@ class Calculator(object):
 
     def mtr(self, income_type_str='e00200p',
             negative_finite_diff=False,
+            zero_out_calculated_vars=False,
             wrt_full_compensation=True):
         """
         Calculates the marginal FICA, individual income, and combined
@@ -195,6 +197,10 @@ class Calculator(object):
             specifies whether or not marginal tax rates are computed by
             subtracting (rather than adding) a small finite_diff amount
             to the specified income type.
+
+        zero_out_calculated_vars: boolean
+            specifies value of zero_out_calc_vars parameter used in calls
+            of Calculator.calc_all() method.
 
         wrt_full_compensation: boolean
             specifies whether or not marginal tax rates on earned income
@@ -255,13 +261,13 @@ class Calculator(object):
             self.records.e01500 = penben_type + finite_diff
         if self.consumption.has_response():
             self.consumption.response(self.records, finite_diff)
-        self.calc_all()
+        self.calc_all(zero_out_calc_vars=zero_out_calculated_vars)
         fica_chng = copy.deepcopy(self.records._fica)
         iitax_chng = copy.deepcopy(self.records._iitax)
         combined_taxes_chng = iitax_chng + fica_chng
         # calculate base level of taxes after restoring records object
         setattr(self, '_records', recs0)
-        self.calc_all()
+        self.calc_all(zero_out_calc_vars=zero_out_calculated_vars)
         fica_base = copy.deepcopy(self.records._fica)
         iitax_base = copy.deepcopy(self.records._iitax)
         combined_taxes_base = iitax_base + fica_base

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -74,6 +74,7 @@ class Calculator(object):
         AMTI(self.policy, self.records)
 
     def calc_one_year(self):
+        self.records.zero_out_changing_calculated_vars()
         # pdb.set_trace()
         EI_FICA(self.policy, self.records)
         Adj(self.policy, self.records)

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -185,6 +185,9 @@ class Records(object):
     INTEGER_CALCULATED_VARS = set([
         '_num', '_sep', '_exact', '_calc_schR', 'f2555'])
 
+    CHANGING_CALCULATED_VARS = (CALCULATED_VARS - INTEGER_CALCULATED_VARS -
+                                set(['ID_Casualty_frt_in_pufcsv_year']))
+
     def __init__(self,
                  data='puf.csv',
                  exact_calculations=False,
@@ -427,7 +430,7 @@ class Records(object):
     def _read_egg_csv(vname, fpath, **kwargs):
         """
         Read csv file with fpath containing vname data from EGG;
-        return dict of vname data
+        return dict of vname data.
         """
         try:
             # grab vname data from EGG distribution
@@ -439,6 +442,14 @@ class Records(object):
             msg = 'could not read {} file from EGG'
             raise ValueError(msg.format(vname))
         return vname_dict
+
+    def zero_out_changing_calculated_vars(self):
+        """
+        Set all CHANGING_CALCULATED_VARS to zero.
+        """
+        for varname in Records.CHANGING_CALCULATED_VARS:
+            var = getattr(self, varname)
+            var.fill(0.)
 
     def _read_weights(self, weights):
         """

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -268,7 +268,8 @@ def test_Calculator_mtr():
     puf = Records(TAXDATA, weights=WEIGHTS, start_year=2009)
     calc = Calculator(policy=Policy(), records=puf)
     recs_pre_e00200p = copy.deepcopy(calc.records.e00200p)
-    (mtr_FICA, mtr_IIT, mtr_combined) = calc.mtr(income_type_str='e00200p')
+    (mtr_FICA, mtr_IIT, mtr_combined) = calc.mtr(income_type_str='e00200p',
+                                                 zero_out_calculated_vars=True)
     recs_post_e00200p = copy.deepcopy(calc.records.e00200p)
     assert np.allclose(recs_post_e00200p, recs_pre_e00200p)
     assert type(mtr_combined) == np.ndarray

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -152,8 +152,13 @@ def test_mtr():
     inctype_header = 'FICA and IIT mtr histogram bin counts for'
     # compute marginal tax rate (mtr) histograms for each mtr income type
     for inctype in Calculator.MTR_VALID_INCOME_TYPES:
+        if inctype == 'e01400':
+            zero_out = True
+        else:
+            zero_out = False
         (mtr_fica, mtr_iit, _) = calc.mtr(income_type_str=inctype,
                                           negative_finite_diff=MTR_NEG_DIFF,
+                                          zero_out_calculated_vars=zero_out,
                                           wrt_full_compensation=False)
         res += '{} {}:\n'.format(inctype_header, inctype)
         res += mtr_bin_counts(mtr_fica, FICA_MTR_BIN_EDGES, recid)


### PR DESCRIPTION
This pull request explores issue #272 (May 2015).  The first commit of this pull request adds a new Records method called zero_out_changing_calculated_vars() and calls it at the beginning of the Calculator.calc_one_year() method.  All the unit and validation test results are unchanged by this first commit, which confirms that the tax-calculating functions are handling all the calculated variables correctly.  An average of four execution times for the `requires_pufcsv` tests before and after the first commit show that zeroing out these calculated variables increase execution time by about 1.1 percent.  In order to avoid this increase in execution time, the call of the zero_out_changing_calculated_vars() method is made optional in the second commit of this pull request, and a test is added to check that results are the same with and without the call to the Records.zero_out_changing_calculated_vars() method.

@MattHJensen @feenberg @talumbau @Amy-Xu @GoFroggyRun @zrisher 