### PR TITLE
Add docstring for Calculator constructor

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -1,6 +1,10 @@
 """
 Tax-Calculator federal tax Calculator class.
 """
+# CODING-STYLE CHECKS:
+# pep8 --ignore=E402 calculate.py
+
+
 import math
 import copy
 import numpy as np
@@ -17,6 +21,65 @@ from .consumption import Consumption
 
 
 class Calculator(object):
+    """
+    Constructor for the Calculator class.
+
+    Parameters
+    ----------
+    policy: Policy class object
+        this argument must be specified
+        IMPORTANT NOTE: never pass the same Policy object to more than one
+                        Calculator.  In other words, when specifying more
+                        than one Calculator object, do this:
+                        pol1 = Policy()
+                        rec1 = Records()
+                        calc1 = Calculator(policy=pol1, records=rec1)
+                        pol2 = Policy()
+                        rec2 = Records()
+                        calc2 = Calculator(policy=pol2, records=rec2)
+
+    records: Records class object
+        this argument must be specified
+        IMPORTANT NOTE: never pass the same Records object to more than one
+                        Calculator.  In other words, when specifying more
+                        than one Calculator object, do this:
+                        pol1 = Policy()
+                        rec1 = Records()
+                        calc1 = Calculator(policy=pol1, records=rec1)
+                        pol2 = Policy()
+                        rec2 = Records()
+                        calc2 = Calculator(policy=pol2, records=rec2)
+
+    verbose: boolean
+        specifies whether or not to write to stdout data-loaded and
+        data-extrapolated progress reports; default value is true.
+
+    sync_years: boolean
+        specifies whether or not to syncronize policy year and records year;
+        default value is true.
+
+    behavior: Behavior class object
+        specifies behaviorial responses used by Calculator; default is None,
+        which implies no behavioral responses.
+
+    growth: Growth class object
+        specifies economic growth assumptions used by Calculator; default is
+        None, which implies use of standard economic growth assumptions.
+
+    consumption: Consumption class object
+        specifies consumption response assumptions used to calculate
+        "effective" marginal tax rates; default is None, which implies
+        no consumption responses.
+
+    Raises
+    ------
+    ValueError:
+        if parameters are not the appropriate type.
+
+    Returns
+    -------
+    class instance: Calculator
+    """
 
     def __init__(self, policy=None, records=None, verbose=True,
                  sync_years=True, behavior=None, growth=None,


### PR DESCRIPTION
This pull request adds some documentation about how to instantiate a Calculator object.

This documentation stresses the need to use different Policy and Records objects in different Calculators, as pointed out in issue #304.  That issue suggested making deep copies of the Policy and Records objects passed to the Calculator, but that suggestion has not seemed to elicit any response since it was made in July 2015.  So, the new documentation tries to warn Tax-Calculator users about this potential pitfall.

@MattHJensen @feenberg @talumbau @Amy-Xu @GoFroggyRun @zrisher 
