### PR TITLE
Fix two bugs in Behavior._update_ordinary_income method

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -181,15 +181,15 @@ class Behavior(ParametersBase):
         """
         Implement total taxable income change induced by behavioral response.
         """
-        # assume no behv response for filing units with no, or negative, AGI
-        agi = calc.records.c00100
-        delta_income = np.where(agi > 0., taxinc_change, 0.)
         # compute AGI minus itemized deductions, agi_m_ided
+        agi = calc.records.c00100
         # pylint: disable=protected-access
         ided = np.where(calc.records.c04470 < calc.records._standard,
                         0.,
                         calc.records.c04470)
         agi_m_ided = agi - ided
+        # assume behv response only for filing units with positive agi_m_ided
+        delta_income = np.where(agi_m_ided > 0., taxinc_change, 0.)
         # allocate delta_income into three parts
         delta_wage = np.where(agi_m_ided > 0.,
                               delta_income * calc.records.e00200 / agi_m_ided,
@@ -201,8 +201,8 @@ class Behavior(ParametersBase):
         delta_ided = np.where(agi_m_ided > 0.,
                               delta_income * ided / agi_m_ided,
                               0.)
-        # confirm that the three parts add up to delta_income
-        assert np.allclose(delta_income, delta_wage + delta_oinc + delta_ided)
+        # confirm that the three parts are consistent with delta_income
+        assert np.allclose(delta_income, delta_wage + delta_oinc - delta_ided)
         # add the three parts to different calc.records variables
         calc.records.e00200 = calc.records.e00200 + delta_wage
         calc.records.e00200p = calc.records.e00200p + delta_wage


### PR DESCRIPTION
This pull request fixes two bugs found in the Behavior class _update_ordinary_income method by @codykallen in pull request #824.  These bug fixes have been moved out of pull request #824 for two reasons.  First, #824 contains a massive number of changes to an iPython notebook that has nothing to do with fixing the bugs.  And second, the proposed fix of the bugs in #824 was confusing because the documentation was not changed to reflect the new logic and because the #824 code caused a pylint error.

Thanks to @codykallen for finding these bugs and suggesting sensible logic changes to fix them.

It should be noted the one of the two bugs (the incorrect assert test) was my own and the other (the agi>0 but agi-ided<0 case) dated back to the original implementation of the method.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @zrisher 
