### PR TITLE
Revise Calculator.calc_all() so it does only static analysis

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -98,8 +98,7 @@ class Behavior(ParametersBase):
           calc_y.policy.  Neither calc_x nor calc_y need to have had calc_all()
           executed before calling the Behavior.response(calc_x, calc_y) method.
         Returns new Calculator object --- a deepcopy of calc_y --- that
-          incorporates behavioral responses to the reform, but has called
-          NEITHER the BenefitsSurtax() NOR the ExpandIncome() functions.
+          incorporates behavioral responses to the reform.
         Note: the use here of a dollar-change income elasticity (rather than
           a proportional-change elasticity) is consistent with Feldstein and
           Feenberg, "The Taxation of Two Earner Families", NBER Working Paper
@@ -153,7 +152,7 @@ class Behavior(ParametersBase):
                 inc = calc_y.behavior.BE_inc * dch
         taxinc_chg = sub + inc
         # calculate long-term capital-gains effect
-        if calc_y.behavior.BE_inc == 0.0:
+        if calc_y.behavior.BE_cg == 0.0:
             ltcg_chg = np.zeros(calc_x.records.dim)
         else:
             # calculate marginal tax rates on long-term capital gains
@@ -170,7 +169,7 @@ class Behavior(ParametersBase):
         calc_y_behv = Behavior._update_ordinary_income(taxinc_chg, calc_y_behv)
         calc_y_behv = Behavior._update_cap_gain_income(ltcg_chg, calc_y_behv)
         # Recalculate post-reform taxes incorporating behavioral responses
-        calc_y_behv.calc_one_year()
+        calc_y_behv.calc_all()
         return calc_y_behv
 
     # ----- begin private methods of Behavior class -----

--- a/taxcalc/comparison/reform_results.py
+++ b/taxcalc/comparison/reform_results.py
@@ -66,8 +66,13 @@ for i in range(1, NUM_REFORMS + 1):
     for _ in range(0, NUM_YEARS):
         calc1.calc_all()
         prereform = getattr(calc1.records, output_type)
-        calc2.calc_all()
-        postreform = getattr(calc2.records, output_type)
+        if calc2.behavior.has_response():
+            calc_clp = calc2.current_law_version()
+            calc2_br = Behavior.response(calc_clp, calc2)
+            postreform = getattr(calc2_br.records, output_type)
+        else:
+            calc2.calc_all()
+            postreform = getattr(calc2.records, output_type)
         diff = postreform - prereform
         weighted_sum_diff = (diff * calc1.records.s006).sum() * 1.0e-9
         reform_results.append(weighted_sum_diff)

--- a/taxcalc/comparison/reform_results.txt
+++ b/taxcalc/comparison/reform_results.txt
@@ -114,14 +114,11 @@ Budget Options,11,9,8,7
 ""
 CAPITAL GAIN
 ""
-Increase long term cap gain and dividends tax rates by 2 percentage, no behavior
+Increase long term cap gain and dividends tax rates by 2 percentage, no behavioral response
 Tax-Calculator,13.2,13.5,13.7,14.0
 ""
-Increase long term cap gain and dividends tax rates by 2 percentage, elasticity assumed to be 0.78
-Tax-Calculator,10.3,10.6,10.8,11.0
-""
-Increase long term cap gain and dividends tax rates by 2 percentage, elasticity assumed to be 1.2
-Tax-Calculator,8.8,9.0,9.2,9.4
+Increase long term cap gain and dividends tax rates by 2 percentage, BE_cg elasticity assumed to be -3.67
+Tax-Calculator,3.3,3.4,3.5,3.7
 Budget Options,5,5,5,6
 ""
 REGULAR TAXES

--- a/taxcalc/comparison/reforms.json
+++ b/taxcalc/comparison/reforms.json
@@ -252,7 +252,7 @@
                   "_AMT_CG_rt2": [0.17],
                   "_AMT_CG_rt3": [0.22]},
         "section_name": "CAPITAL GAIN",
-        "name": "Increase long term cap gain and dividends tax rates by 2 percentage, no behavior",
+        "name": "Increase long term cap gain and dividends tax rates by 2 percentage, no behavioral response",
         "output_type": "_iitax",
         "compare_with": {}
     },
@@ -266,26 +266,12 @@
                   "_AMT_CG_rt2": [0.17],
                   "_AMT_CG_rt3": [0.22],
                   "_BE_cg": [-3.67]},
-        "name": "Increase long term cap gain and dividends tax rates by 2 percentage, CBO-JCT elasticity assumed to be -0.792, which translates to a _BE_cg value of about -3.67",
-        "output_type": "_iitax",
-        "compare_with": {}
-    },
-
-    "r32": {
-        "start_year": 2015,
-        "value": {"_CG_rt1": [0.02],
-                  "_CG_rt2": [0.17],
-                  "_CG_rt3": [0.22],
-                  "_AMT_CG_rt1": [0.02],
-                  "_AMT_CG_rt2": [0.17],
-                  "_AMT_CG_rt3": [0.22],
-                  "_BE_cg": [-5.56]},
-        "name": "Increase long term cap gain and dividends tax rates by 2 percentage, JCT-CBO elasticity assumed to be -1.2, which translates to a _BE_cg value of about -5.56",
+        "name": "Increase long term cap gain and dividends tax rates by 2 percentage, BE_cg elasticity assumed to be -3.67",
         "output_type": "_iitax",
         "compare_with": {"Budget Options": [4.6, 5, 5.3, 5.6]}
     },
 
-    "r33": {
+    "r32": {
         "start_year": 2015,
         "value": {"_II_rt1": [0.11],
                   "_II_rt2": [0.16],
@@ -300,7 +286,7 @@
         "compare_with": {"Budget Options": [56, 60, 65, 69]}
     },
 
-    "r34": {
+    "r33": {
         "start_year": 2015,
         "value": {"_II_rt1": [0.10],
                   "_II_rt2": [0.15],
@@ -314,7 +300,7 @@
         "compare_with": {"Budget Options": [11, 12, 14, 15]}
     },
 
-    "r35": {
+    "r34": {
         "start_year": 2015,
         "value": {"_II_rt1": [0.10],
                   "_II_rt2": [0.15],
@@ -328,7 +314,7 @@
         "compare_with": {"Budget Options": [7, 8, 9, 10]}
     },
 
-    "r36": {
+    "r35": {
         "start_year": 2015,
         "value": {"_AMT_em": [[54600, 84400, 42700, 54600, 84400, 42700]]},
         "section_name": "Alternative Minimum Tax",
@@ -337,7 +323,7 @@
         "compare_with": {}
     },
 
-    "r37": {
+    "r36": {
         "start_year": 2015,
         "value": {"_AMT_em_ps": [[129200, 168900, 89450, 129200, 168900, 89450]]},
         "section_name": "Alternative Minimum Tax",
@@ -346,7 +332,7 @@
         "compare_with": {}
     },
 
-    "r38": {
+    "r37": {
         "start_year": 2015,
         "value": {"_AMT_prt": [0.27]},
         "section_name": "Alternative Minimum Tax",
@@ -355,7 +341,7 @@
         "compare_with": {}
     },
 
-    "r39": {
+    "r38": {
         "start_year": 2015,
         "value": {"_AMT_trt1": [0.28]},
         "section_name": "Alternative Minimum Tax",
@@ -364,7 +350,7 @@
         "compare_with": {}
     },
 
-    "r40": {
+    "r39": {
         "start_year": 2015,
         "value": {"_AMT_trt2": [0.04]},
         "section_name": "Alternative Minimum Tax",
@@ -373,7 +359,7 @@
         "compare_with": {}
     },
 
-    "r41": {
+    "r40": {
         "start_year": 2015,
         "value": {"_AMT_tthd": [195400]},
         "name": "Increase AMT surtax threshold by 10,000",
@@ -381,7 +367,7 @@
         "compare_with": {}
     },
 
-    "r42": {
+    "r41": {
         "start_year": 2015,
         "value": {"_CTC_c": [0, 0, 0, 0, 0, 0, 0, 0, 0]},
         "section_name": "NONREFUNDABLE CREDIT",
@@ -390,7 +376,7 @@
         "compare_with": {"Tax Expenditure": [57.3, 57.0, 57.1, 56.8]}
     },
 
-    "r43": {
+    "r42": {
         "start_year": 2015,
         "value": {"_CTC_prt": [0.06]},
         "name": "Increase Child Tax Credit phaseout rate by 1 pts",
@@ -398,7 +384,7 @@
         "compare_with": {}
     },
 
-    "r44": {
+    "r43": {
         "start_year": 2015,
         "value": {"_CTC_ps": [[76000, 111000, 56000, 76000, 76000, 56000]]},
         "name": "Increase Child Tax Credit phaseout starting MAGI by 1000",
@@ -406,7 +392,7 @@
         "compare_with": {}
     },
 
-    "r45": {
+    "r44": {
         "start_year": 2015,
         "value": {"_EITC_rt": [[0, 0, 0, 0]]},
         "section_name": "REFUNDABLE CREDIT",
@@ -415,7 +401,7 @@
         "compare_with": {"Tax Expenditure": [70.4, 71.1, 72.2, 69.9]}
     },
 
-    "r46": {
+    "r45": {
         "start_year": 2015,
         "value": {"_EITC_prt": [[0.0865, 0.1698, 0.2206, 0.2206]]},
         "name": "Increase EITC phaseout rate by 1 pts",
@@ -423,7 +409,7 @@
         "compare_with": {}
     },
 
-    "r47": {
+    "r46": {
         "start_year": 2015,
         "value": {"_EITC_ps": [[9240, 19110, 19110, 19110]]},
         "name": "Increase EITC phaseout starting AGI by 1000",
@@ -431,7 +417,7 @@
         "compare_with": {}
     },
 
-    "r48": {
+    "r47": {
         "start_year": 2015,
         "value": {"_EITC_c": [[603, 3459, 5648, 6342]]},
         "name": "Increase Maximum EITC allowed by 100",
@@ -439,7 +425,7 @@
         "compare_with": {}
     },
 
-    "r49": {
+    "r48": {
         "start_year": 2015,
         "value": {"_ACTC_rt": [0.17]},
         "name": "Increase additional child tax credit rate by 2 pts",
@@ -447,7 +433,7 @@
         "compare_with": {}
     },
 
-    "r50": {
+    "r49": {
         "start_year": 2015,
         "value": {"_ACTC_ChildNum": [2]},
         "name": "Decrease additional child tax credit minimum number of child to two",
@@ -455,7 +441,7 @@
         "compare_with": {}
     },
 
-    "r51": {
+    "r50": {
         "start_year": 2015,
         "value": {"_NIIT_trt": [0]},
         "section_name": "OTHER TAXES",
@@ -464,7 +450,7 @@
         "compare_with": {"Tax Expenditure": [-32.6, -34.7, -36.6, -38.9]}
     },
 
-    "r52": {
+    "r51": {
         "start_year": 2015,
         "value": {"_NIIT_thd": [[210000, 260000, 135000, 210000, 260000, 135000]]},
         "name": "Increase Net Investment Income Tax threshold by 10,000",
@@ -472,7 +458,7 @@
         "compare_with": {}
     },
 
-    "r53": {
+    "r52": {
         "start_year": 2015,
         "value": {"_II_credit": [[1000, 1000, 1000, 1000, 1000, 1000]]},
         "section_name": "PERSONAL REFUNDABLE CREDIT",
@@ -481,7 +467,7 @@
         "compare_with": {}
     },
 
-    "r54": {
+    "r53": {
         "start_year": 2015,
         "value": {"_II_credit": [[1000, 1000, 1000, 1000, 1000, 1000]],
                   "_II_credit_ps": [[100000, 100000, 100000, 100000, 100000, 100000]],

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -343,7 +343,7 @@ class Policy(ParametersBase):
 
     def current_law_version(self):
         """
-        Return Policy object the same as self except with current-law policy.
+        Return Policy object same as self except with current-law policy.
         """
         startyear = self.start_year
         numyears = self.num_years

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -50,12 +50,12 @@ def test_behavioral_response_Calculator():
                                 mtr_of='e00200p',
                                 tax_type='nonsense')
     # vary substitution and income effects in calc_y
-    behavior1 = {2013: {'_BE_sub': [0.0], '_BE_cg': [-0.8]}}
+    behavior1 = {2013: {'_BE_sub': [0.3], '_BE_cg': [0.0]}}
     behavior_y.update_behavior(behavior1)
     assert behavior_y.has_response() is True
-    assert behavior_y.BE_sub == 0.0
+    assert behavior_y.BE_sub == 0.3
     assert behavior_y.BE_inc == 0.0
-    assert behavior_y.BE_cg == -0.8
+    assert behavior_y.BE_cg == 0.0
     calc_y_behavior1 = Behavior.response(calc_x, calc_y)
     behavior2 = {2013: {'_BE_sub': [0.5], '_BE_cg': [-0.8]}}
     behavior_y.update_behavior(behavior2)

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -63,11 +63,15 @@ def test_behavioral_response_Calculator():
     behavior3 = {2013: {'_BE_inc': [-0.2], '_BE_cg': [-0.8]}}
     behavior_y.update_behavior(behavior3)
     calc_y_behavior3 = Behavior.response(calc_x, calc_y)
+    behavior4 = {2013: {'_BE_cg': [-0.8]}}
+    behavior_y.update_behavior(behavior4)
+    calc_y_behavior4 = Behavior.response(calc_x, calc_y)
     # check that total income tax liability differs across the
-    # three sets of behavioral-response elasticities
+    # four sets of behavioral-response elasticities
     assert (calc_y_behavior1.records._iitax.sum() !=
             calc_y_behavior2.records._iitax.sum() !=
-            calc_y_behavior3.records._iitax.sum())
+            calc_y_behavior3.records._iitax.sum() !=
+            calc_y_behavior4.records._iitax.sum())
     # test incorrect _mtr_xy() usage
     with pytest.raises(ValueError):
         Behavior._mtr_xy(calc_x, calc_y, mtr_of='e00200p', tax_type='?')

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -235,6 +235,18 @@ def test_Calculator_attr_access_to_policy():
     assert hasattr(calc, 'policy')
 
 
+def test_Calculator_current_law_version():
+    policy = Policy()
+    reform = {2013: {'_II_rt7': [0.45]}}
+    policy.implement_reform(reform)
+    puf = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
+    calc = Calculator(policy=policy, records=puf)
+    calc_clp = calc.current_law_version()
+    assert isinstance(calc_clp, Calculator)
+    assert calc.policy.II_rt6 == calc_clp.policy.II_rt6
+    assert calc.policy.II_rt7 != calc_clp.policy.II_rt7
+
+
 def test_Calculator_create_distribution_table():
     policy = Policy()
     puf = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -308,46 +308,6 @@ def test_Calculator_create_diagnostic_table():
     assert isinstance(adt, pd.DataFrame)
 
 
-def test_Calculator_behavioral_response_with_reform():
-    tax_rate_reform = {2013: {'_II_rt7': [0.50]}}
-    # calculate AGI under reform without behavioral response
-    pol1 = Policy()
-    pol1.implement_reform(tax_rate_reform)
-    puf1 = Records(data=TAXDATA, weights=WEIGHTS, start_year=Records.PUF_YEAR)
-    beh1 = Behavior()
-    calc1 = Calculator(policy=pol1, records=puf1, behavior=beh1)
-    calc1.calc_all()
-    agi1 = calc1.records.c00100
-    # calculate AGI under reform with behavioral response
-    pol2 = Policy()
-    pol2.implement_reform(tax_rate_reform)
-    puf2 = Records(data=TAXDATA, weights=WEIGHTS, start_year=Records.PUF_YEAR)
-    beh2 = Behavior()
-    beh2.update_behavior({2013: {'_BE_sub': [0.4]}})
-    assert beh2.has_response()
-    calc2 = Calculator(policy=pol2, records=puf2, behavior=beh2)
-    calc2.calc_all()
-    agi2 = calc2.records.c00100
-    # check that AGI amounts differ after reform-with-behavioral-response
-    assert not np.allclose(agi1, agi2)
-
-
-def test_Calculator_behavioral_response_with_no_reform():
-    # check that current-law-policy results are same with and without behavior
-    beh1 = Behavior()
-    puf1 = Records(data=TAXDATA, weights=WEIGHTS, start_year=Records.PUF_YEAR)
-    calc1 = Calculator(policy=Policy(), records=puf1, behavior=beh1)
-    calc1.calc_all()
-    agi1 = calc1.records.c00100
-    beh2 = Behavior()
-    beh2.update_behavior({2013: {'_BE_sub': [0.4]}})
-    puf2 = Records(data=TAXDATA, weights=WEIGHTS, start_year=Records.PUF_YEAR)
-    calc2 = Calculator(policy=Policy(), records=puf2, behavior=beh2)
-    calc2.calc_all()
-    agi2 = calc2.records.c00100
-    assert np.allclose(agi1, agi2)
-
-
 def test_make_Calculator_increment_years_first():
     # create Policy object with custom indexing rates and policy reform
     irates = {2013: 0.01, 2014: 0.01, 2015: 0.02, 2016: 0.01, 2017: 0.03}

--- a/taxcalc/tests/test_growth.py
+++ b/taxcalc/tests/test_growth.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-from taxcalc import Policy, Records, Calculator, Behavior, Growth
+from taxcalc import Policy, Records, Calculator, Growth
 
 # use 1991 PUF-like data to emulate current puf.csv, which is private
 TAXDATA_PATH = os.path.join(CUR_PATH, '..', 'altdata', 'puf91taxdata.csv.gz')

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -11,7 +11,7 @@ from pandas import DataFrame, Series
 from pandas.util.testing import assert_series_equal
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-from taxcalc import Policy, Records, Calculator
+from taxcalc import Policy, Records, Behavior, Calculator
 from taxcalc.utils import *
 
 # use 1991 PUF-like data to emulate current puf.csv, which is private
@@ -528,11 +528,16 @@ def test_expand_2D_accept_None_additional_row():
 def test_multiyear_diagnostic_table():
     pol = Policy()
     recs = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
-    calc = Calculator(policy=pol, records=recs)
+    behv = Behavior()
+    calc = Calculator(policy=pol, records=recs, behavior=behv)
     with pytest.raises(ValueError):
         adt = multiyear_diagnostic_table(calc, 0)
     with pytest.raises(ValueError):
         adt = multiyear_diagnostic_table(calc, 20)
+    adt = multiyear_diagnostic_table(calc, 3)
+    assert isinstance(adt, DataFrame)
+    behv.update_behavior({2013: {'_BE_sub': [0.3]}})
+    assert calc.behavior.has_response()
     adt = multiyear_diagnostic_table(calc, 3)
     assert isinstance(adt, DataFrame)
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -555,8 +555,13 @@ def multiyear_diagnostic_table(calc, num_years=0):
     cal = copy.deepcopy(calc)
     dtlist = list()
     for iyr in range(1, num_years + 1):
-        cal.calc_all()
-        dtlist.append(create_diagnostic_table(cal))
+        if cal.behavior.has_response():
+            cal_clp = cal.current_law_version()
+            cal_br = Behavior.response(cal_clp, cal)
+            dtlist.append(create_diagnostic_table(cal_br))
+        else:
+            cal.calc_all()
+            dtlist.append(create_diagnostic_table(cal))
         if iyr < num_years:
             cal.increment_year()
     return pd.concat(dtlist, axis=1)

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -557,7 +557,7 @@ def multiyear_diagnostic_table(calc, num_years=0):
     for iyr in range(1, num_years + 1):
         if cal.behavior.has_response():
             cal_clp = cal.current_law_version()
-            cal_br = Behavior.response(cal_clp, cal)
+            cal_br = cal.behavior.response(cal_clp, cal)
             dtlist.append(create_diagnostic_table(cal_br))
         else:
             cal.calc_all()


### PR DESCRIPTION
This pull request removes the faulty 'Calculator.call_all()' logic introduced a day ago in pull request #849.  Now the `calc_all()` method does what it has always done: static analysis only.  The idiom for conducting dynamic analysis with behavioral responses is illustrated in the revised `taxcalc/comparion/reform_results.py` and `taxcalc/taxbrain/behavior.py` scripts and in the revised `multiyear_diagnostic_table()` utility function.

@MattHJensen @feenberg @codykallen @Amy-Xu @GoFroggyRun 