### PR TITLE
multiyear_diagnostic_table utils function in test_pufcsv.py

### DIFF
--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -42,7 +42,7 @@ def test_sample():
     clp = Policy()
     puf = Records(data=PUFCSV_PATH)
     calc = Calculator(policy=clp, records=puf)
-    adt = calc.diagnostic_table(num_years=10)
+    adt = multiyear_diagnostic_table(calc, num_years=10)
 
     # Sample sample dataset
     clp2 = Policy()
@@ -50,7 +50,7 @@ def test_sample():
     tax_data = tax_data_full.sample(frac=0.02)
     puf_sample = Records(data=tax_data)
     calc_sample = Calculator(policy=clp2, records=puf_sample)
-    adt_sample = calc_sample.diagnostic_table(num_years=10)
+    adt_sample = multiyear_diagnostic_table(calc_sample, num_years=10)
 
     # Get the final combined tax liability for the budget period
     # in the sample and the full dataset and make sure they are close


### PR DESCRIPTION
#848 and #852 moved diagnostic table capabilities from calculator methods to utils functions. 

#844 added a new test `test_sample.py`, which called the old calculator methods. 

Due to timing issues of when the PRs were merged, the changes from #848 and #852 weren't incorporated into #844. 

@talumbau, could you please merge if everything looks good to you. 