### PR TITLE
Use sampling seed to standardize records subsample in test_pufcsv.py

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -213,14 +213,15 @@ class Records(object):
                            rtol=0.0, atol=0.001):
             raise ValueError(msg.format('e02100'))
         # read extrapolation blowup factors and sample weights
+        self.BF = None
         self._read_blowup(blowup_factors)
+        self.WT = None
         self._read_weights(weights)
         # weights must be same size as tax record data
         if not self.WT.empty and self.dim != len(self.WT):
             frac = float(self.dim) / len(self.WT)
             self.WT = self.WT.iloc[self.index]
             self.WT = self.WT / frac
-
         # specify current_year and FLPDYR values
         if isinstance(start_year, int):
             self._current_year = start_year
@@ -229,7 +230,7 @@ class Records(object):
             msg = 'start_year is not an integer'
             raise ValueError(msg)
         # consider applying initial-year blowup factors
-        if self.BF.empty is False and self.current_year == Records.PUF_YEAR:
+        if not self.BF.empty and self.current_year == Records.PUF_YEAR:
             self._extrapolate_in_puf_year()
         # construct sample weights for current_year
         wt_colname = 'WT{}'.format(self.current_year)


### PR DESCRIPTION
This pull request eliminates randomness in the sub sample selected in the sampling test added in pull request #844 (as fixed in #864).  It also does two other things.  First, it moves the comparison of combined tax liabilities generated by the sub-sample and the full-sample into the test_agg() function in order to reduce test execution time.  Second, it uses a sampling random-number seed that produces a relatively small difference under current-law policy between the sub-sample and full-sample combined tax liability.  Below is the maximum (among the ten years of results from 2013 to 2022) relative difference between the sub-sample combined tax liability and the full-sample combined tax liability for each of nine tested sampling random-number seeds:
```
SEED  MAX RELATIVE DIFFERENCE (%)
---------------------------------
  10  -1.66 %
  20  -2.65
  30  +3.18
  40  -5.90
  50  +2.20
  60  -2.77
  70  +3.81
  80  +0.61
  90  -2.41
---------------------------------
```
These results show that picking the "right" sampling seed will make a big difference in user satisfaction.

@MattHJensen @feenberg @talumbau @Amy-Xu @GoFroggyRun @zrisher @codykallen 
