### PR TITLE
Reformat Taxer_i function

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -876,7 +876,7 @@
 
     "_II_brk7": {
         "long_name": "Extra personal income tax bracket",
-        "description": "Income below this threshold and above tax bracket 6 is taxed at tax rate 7. Default value sets to infinity",
+        "description": "Income below this threshold and above tax bracket 6 is taxed at tax rate 7. Default value is essentially infinity",
         "irs_ref": "Form 1040, line 40, in-line (Formside notes).",
         "notes": "",
         "start_year": 2013,
@@ -888,10 +888,10 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14]],
+        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]],
         "validations": {"min": "_II_brk6"}
     },
 
@@ -987,7 +987,7 @@
 
     "_CG_thd3": {
         "long_name": "Long term capital gain and qualified dividend extra threshold",
-        "description": "The capital gain and dividends (stacked on top of regular income)  above this threshold are taxed at the extra capital gain rate. Default value sets to infinity.",
+        "description": "The capital gain and dividends (stacked on top of regular income)  above this threshold are taxed at the extra capital gain rate. Default value is essentially infinity.",
         "irs_ref": "Form 1040 Schedule D tax worksheet, line 24, in-line. ",
         "start_year": 2013,
         "col_var": "MARS",
@@ -998,10 +998,10 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14]]
+        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]]
     },
     "_KT_c_Age": {
         "long_name": "Maximum age subject to Kiddie Tax",
@@ -1263,7 +1263,7 @@
 
     "_AMT_CG_thd3": {
         "long_name": "Long term capital gain and qualified dividend extra threshold",
-        "description": "The capital gain plus dividends portion, stacked last, of income above this threshold is taxed at the extra capital gain rate. Default value sets to infinity.",
+        "description": "The capital gain plus dividends portion, stacked last, of income above this threshold is taxed at the extra capital gain rate. Default value is essentially infinity.",
         "irs_ref": "Form 6251, line 49, in-line. ",
         "start_year": 2013,
         "col_var": "MARS",
@@ -1274,10 +1274,10 @@
                       "2016"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14],
-                  [1e14, 1e14, 1e14, 1e14, 1e14, 1e14]]
+        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]]
     },
 
     "_NIIT_thd": {

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -654,7 +654,7 @@ def AMTI(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
 
     if ngamty != (amt15pc + line47):
         amt20pc = line46 - amt15pc - line47
-        amtxtrpc = max(0, amt15pc - amt_xtr)
+        amtxtrpc = max(0., amt15pc - amt_xtr)
     else:
         amt20pc = 0.
         amtxtrpc = 0.
@@ -1137,20 +1137,20 @@ def Taxer_i(inc_in, MARS,
     """
     Taxer_i function: ...
     """
-    return (II_rt1 * min(inc_in, II_brk1[MARS - 1]) + II_rt2 *
-            min(II_brk2[MARS - 1] - II_brk1[MARS - 1],
-                max(0., inc_in - II_brk1[MARS - 1])) + II_rt3 *
-            min(II_brk3[MARS - 1] - II_brk2[MARS - 1],
-                max(0., inc_in - II_brk2[MARS - 1])) + II_rt4 *
-            min(II_brk4[MARS - 1] - II_brk3[MARS - 1],
-                max(0., inc_in - II_brk3[MARS - 1])) + II_rt5 *
-            min(II_brk5[MARS - 1] - II_brk4[MARS - 1],
-                max(0., inc_in - II_brk4[MARS - 1])) + II_rt6 *
-            min(II_brk6[MARS - 1] - II_brk5[MARS - 1],
-                max(0., inc_in - II_brk5[MARS - 1])) + II_rt7 *
-            min(II_brk7[MARS - 1] - II_brk6[MARS - 1],
-                max(0., inc_in - II_brk6[MARS - 1])) + II_rt8 *
-            max(0., inc_in - II_brk7[MARS - 1]))
+    return (II_rt1 * min(inc_in, II_brk1[MARS - 1]) +
+            II_rt2 * min(II_brk2[MARS - 1] - II_brk1[MARS - 1],
+                         max(0., inc_in - II_brk1[MARS - 1])) +
+            II_rt3 * min(II_brk3[MARS - 1] - II_brk2[MARS - 1],
+                         max(0., inc_in - II_brk2[MARS - 1])) +
+            II_rt4 * min(II_brk4[MARS - 1] - II_brk3[MARS - 1],
+                         max(0., inc_in - II_brk3[MARS - 1])) +
+            II_rt5 * min(II_brk5[MARS - 1] - II_brk4[MARS - 1],
+                         max(0., inc_in - II_brk4[MARS - 1])) +
+            II_rt6 * min(II_brk6[MARS - 1] - II_brk5[MARS - 1],
+                         max(0., inc_in - II_brk5[MARS - 1])) +
+            II_rt7 * min(II_brk7[MARS - 1] - II_brk6[MARS - 1],
+                         max(0., inc_in - II_brk6[MARS - 1])) +
+            II_rt8 * max(0., inc_in - II_brk7[MARS - 1]))
 
 
 @iterate_jit(nopython=True)


### PR DESCRIPTION
This pull request does a cosmetic reformat of the complex, single-statement Taxer_i() function in order to improve readability.  There is no change in Tax-Calculator logic or results.
