### PR TITLE
Add mtr calculation for two itemized-deduction-expense variables

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -231,7 +231,8 @@ class Calculator(object):
                            'e00600', 'e00650',
                            'e01400', 'e01700',
                            'e02000', 'e02400',
-                           'p22250', 'p23250']
+                           'p22250', 'p23250',
+                           'e18500', 'e19200']
 
     def mtr(self, variable_str='e00200p',
             negative_finite_diff=False,
@@ -248,8 +249,8 @@ class Calculator(object):
         are computed as the change in tax liability divided by the change
         in total compensation caused by the small increase in the variable
         (where the change in total compensation is the sum of the small
-        increase in income and any increase in the employer share of payroll
-        taxes caused by the small increase in income).
+        increase in the variable and any increase in the employer share of
+        payroll taxes caused by the small increase in the variable).
 
         Parameters
         ----------
@@ -292,7 +293,9 @@ class Calculator(object):
         'e02000',  Schedule E net income/loss
         'e02400',  all social security (OASDI) benefits;
         'p22250',  short-term capital gains;
-        'p23250',  long-term capital gains.
+        'p23250',  long-term capital gains;
+        'e18500',  Schedule A real-estate-tax deduction;
+        'e19200',  Schedule A total-interest deduction.
         """
         # check validity of variable_str parameter
         if variable_str not in Calculator.MTR_VALID_VARIABLES:

--- a/taxcalc/taxbrain/consumption.py
+++ b/taxcalc/taxbrain/consumption.py
@@ -42,7 +42,7 @@ def main(mpc_e17500, mpc_e18400, mpc_e19800, mpc_e20400):
                        consumption=None, verbose=False)
     calc0.advance_to_year(cyr)
     wghts = calc0.records.s006
-    (mtr0_ptax, mtr0_itax, _) = calc0.mtr(income_type_str='e00200p',
+    (mtr0_ptax, mtr0_itax, _) = calc0.mtr(variable_str='e00200p',
                                           wrt_full_compensation=False)
     # compute mtr under current-law policy with specified consumption response
     consump = Consumption()
@@ -56,7 +56,7 @@ def main(mpc_e17500, mpc_e18400, mpc_e19800, mpc_e20400):
                        consumption=consump, verbose=False)
     calc1.advance_to_year(cyr)
     assert calc1.consumption.current_year == cyr
-    (mtr1_ptax, mtr1_itax, _) = calc1.mtr(income_type_str='e00200p',
+    (mtr1_ptax, mtr1_itax, _) = calc1.mtr(variable_str='e00200p',
                                           wrt_full_compensation=False)
     # compare unweighted mtr results with and without consumption response
     epsilon = 1.0e-6  # this would represent a mtr of 0.0001 percent

--- a/taxcalc/tests/pufcsv_mtr_expect.txt
+++ b/taxcalc/tests/pufcsv_mtr_expect.txt
@@ -40,3 +40,9 @@ PTAX and ITAX mtr histogram bin counts for p22250:
 PTAX and ITAX mtr histogram bin counts for p23250:
 219814 : 219814      0      0      0      0      0      0      0      0      0
 219814 :      0      0      2  17042 124993  38593  33976   2134   3027     47
+PTAX and ITAX mtr histogram bin counts for e18500:
+219814 : 219814      0      0      0      0      0      0      0      0      0
+219814 :  22930  23256  20769   5934 146925      0      0      0      0      0
+PTAX and ITAX mtr histogram bin counts for e19200:
+219814 : 219814      0      0      0      0      0      0      0      0      0
+219814 :  32342  27690  20736   3130 135916      0      0      0      0      0

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -276,7 +276,7 @@ def test_Calculator_mtr():
     puf = Records(TAXDATA, weights=WEIGHTS, start_year=2009)
     calc = Calculator(policy=Policy(), records=puf)
     recs_pre_e00200p = copy.deepcopy(calc.records.e00200p)
-    (mtr_ptx, mtr_itx, mtr_combined) = calc.mtr(income_type_str='e00200p',
+    (mtr_ptx, mtr_itx, mtr_combined) = calc.mtr(variable_str='e00200p',
                                                 zero_out_calculated_vars=True)
     recs_post_e00200p = copy.deepcopy(calc.records.e00200p)
     assert np.allclose(recs_post_e00200p, recs_pre_e00200p)
@@ -284,13 +284,13 @@ def test_Calculator_mtr():
     assert np.array_equal(mtr_combined, mtr_ptx) is False
     assert np.array_equal(mtr_ptx, mtr_itx) is False
     with pytest.raises(ValueError):
-        (_, _, mtr_combined) = calc.mtr(income_type_str='bad_income_type')
-    (_, _, mtr_combined) = calc.mtr(income_type_str='e00650',
+        (_, _, mtr_combined) = calc.mtr(variable_str='bad_income_type')
+    (_, _, mtr_combined) = calc.mtr(variable_str='e00650',
                                     negative_finite_diff=True)
     assert type(mtr_combined) == np.ndarray
-    (_, _, mtr_combined) = calc.mtr(income_type_str='e00900p')
+    (_, _, mtr_combined) = calc.mtr(variable_str='e00900p')
     assert type(mtr_combined) == np.ndarray
-    (_, _, mtr_combined) = calc.mtr(income_type_str='e01700')
+    (_, _, mtr_combined) = calc.mtr(variable_str='e01700')
     assert type(mtr_combined) == np.ndarray
 
 

--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -89,7 +89,7 @@ def test_consumption_response():
     recs0 = Records(data=TAXDATA, weights=WEIGHTS, start_year=2009)
     calc0 = Calculator(policy=Policy(), records=recs0, consumption=None)
     ided0 = copy.deepcopy(recs0.e20400)
-    (mtr0_ptax, mtr0_itax, _) = calc0.mtr(income_type_str='e00200p',
+    (mtr0_ptax, mtr0_itax, _) = calc0.mtr(variable_str='e00200p',
                                           wrt_full_compensation=False)
     assert np.allclose(calc0.records.e20400, ided0)
     # compute earnings mtr with consumption response
@@ -97,7 +97,7 @@ def test_consumption_response():
     calc1 = Calculator(policy=Policy(), records=recs1, consumption=None)
     assert np.allclose(calc1.records.e20400, ided0)
     calc1.consumption.update_consumption(consumption_response)
-    (mtr1_ptax, mtr1_itax, _) = calc1.mtr(income_type_str='e00200p',
+    (mtr1_ptax, mtr1_itax, _) = calc1.mtr(variable_str='e00200p',
                                           wrt_full_compensation=False)
     assert np.allclose(calc1.records.e20400, ided0)
     # confirm that payroll mtr values are no different

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -182,18 +182,18 @@ def test_mtr():
     res += '     {}\n'.format(PTAX_MTR_BIN_EDGES)
     res += 'ITAX mtr histogram bin edges:\n'
     res += '     {}\n'.format(ITAX_MTR_BIN_EDGES)
-    inctype_header = 'PTAX and ITAX mtr histogram bin counts for'
-    # compute marginal tax rate (mtr) histograms for each mtr income type
-    for inctype in Calculator.MTR_VALID_INCOME_TYPES:
-        if inctype == 'e01400':
+    variable_header = 'PTAX and ITAX mtr histogram bin counts for'
+    # compute marginal tax rate (mtr) histograms for each mtr variable
+    for var_str in Calculator.MTR_VALID_VARIABLES:
+        if var_str == 'e01400':
             zero_out = True
         else:
             zero_out = False
-        (mtr_ptax, mtr_itax, _) = calc.mtr(income_type_str=inctype,
+        (mtr_ptax, mtr_itax, _) = calc.mtr(variable_str=var_str,
                                            negative_finite_diff=MTR_NEG_DIFF,
                                            zero_out_calculated_vars=zero_out,
                                            wrt_full_compensation=False)
-        res += '{} {}:\n'.format(inctype_header, inctype)
+        res += '{} {}:\n'.format(variable_header, var_str)
         res += mtr_bin_counts(mtr_ptax, PTAX_MTR_BIN_EDGES, recid)
         res += mtr_bin_counts(mtr_itax, ITAX_MTR_BIN_EDGES, recid)
     # generate differences between actual and expected results


### PR DESCRIPTION
This pull request resolves issue #880, which requests the ability to compute marginal tax rates with respect to two itemized-deduction-expense variables (rather than with respect to a particular income type.)  Adding this capability made the `Calculator.VALID_MTR_INCOME_TYPES` a misnomer, so it has been changed to the more general `Calculator.VALID_MTR_VARIABLES`.  In a similar fashion, the first parameter of the `Calculator.mtr()` method has been changed from `income_type_str` to `variable_str`.  Those calling the `Calculator.mtr()` method in their own package or notebook may need to revise the call if they are using the named parameter.

There is no change in Tax-Calculator logic (other than the two new variables for which marginal tax rates can be computed) or results (other than the two new sets of results in the `pufcsv_mtr_expected.txt` file).

@jdebacker @Amy-Xu @MattHJensen @feenberg @GoFroggyRun @zrisher @codykallen 