### PR TITLE
Update .gitignore with *.DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ docs/_build/
 # Sublime
 *.sublime-*
 
+# Mac OS X
+*.DS_Store
+
 # ignore puf data files
 puf.csv


### PR DESCRIPTION
We should bless all mac users by having the Tax-Calculator repo ignore <*.DS_Store> files.