### PR TITLE
Add exact output logic to simtax.py and inctax.py when using --exact option

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -140,6 +140,7 @@ def main():
         inctax.csv_dump(writing_output_file=True)
     else:
         inctax.calculate(writing_output_file=True,
+                         exact_output=args.exact,
                          output_weights=args.weights)
     # return no-error exit code
     return 0

--- a/inctax.py
+++ b/inctax.py
@@ -139,8 +139,7 @@ def main():
     elif args.csvdump:
         inctax.csv_dump(writing_output_file=True)
     else:
-        inctax.calculate(writing_output_file=True,
-                         exact_output=args.exact,
+        inctax.calculate(writing_output_file=True, exact_output=args.exact,
                          output_weights=args.weights)
     # return no-error exit code
     return 0

--- a/simtax.py
+++ b/simtax.py
@@ -101,8 +101,7 @@ def main():
                          schR_calculations=(args.noschR is False),
                          emulate_taxsim_2441_logic=args.taxsim2441,
                          output_records=args.records)
-    simtax.calculate(writing_output_file=True,
-                     exact_output=args.exact)
+    simtax.calculate(writing_output_file=True, exact_output=args.exact)
     # return no-error exit code
     return 0
 # end of main function code

--- a/simtax.py
+++ b/simtax.py
@@ -101,7 +101,8 @@ def main():
                          schR_calculations=(args.noschR is False),
                          emulate_taxsim_2441_logic=args.taxsim2441,
                          output_records=args.records)
-    simtax.calculate(writing_output_file=True)
+    simtax.calculate(writing_output_file=True,
+                     exact_output=args.exact)
     # return no-error exit code
     return 0
 # end of main function code

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -225,6 +225,7 @@ class IncomeTaxIO(object):
                          float_format='%.4f', index=False)
 
     def calculate(self, writing_output_file=False,
+                  exact_output=False,
                   output_weights=False):
         """
         Calculate taxes for all INPUT lines and write or return OUTPUT lines.
@@ -250,6 +251,7 @@ class IncomeTaxIO(object):
         (mtr_ptax, mtr_itax, _) = self._calc.mtr(wrt_full_compensation=False)
         for idx in range(0, self._calc.records.dim):
             ovar = SimpleTaxIO.extract_output(self._calc.records, idx,
+                                              exact=exact_output,
                                               extract_weight=output_weights)
             ovar[7] = 100 * mtr_itax[idx]
             ovar[9] = 100 * mtr_ptax[idx]
@@ -302,7 +304,9 @@ class IncomeTaxIO(object):
                '[17] itemized deduction after phase-out '
                '(zero for non-itemizer)\n'
                '[18] federal regular taxable income\n'
-               '[19] regular tax on regular taxable income\n'
+               '[19] regular tax on regular taxable income '
+               '(no special capital gains rates)\n'
+               '     EXCEPT use special rates WHEN --exact OPTION SPECIFIED\n'
                '[20] [ALWAYS ZERO]\n'
                '[21] [ALWAYS ZERO]\n'
                '[22] child tax credit (adjusted)\n'

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -146,7 +146,8 @@ def test_1(input_file):  # pylint: disable=redefined-outer-name
     crecs = simtax._calc.records  # pylint: disable=protected-access
     SimpleTaxIO.DVAR_NAMES = ['f2441']
     # pylint: disable=unused-variable
-    ovar = SimpleTaxIO.extract_output(crecs, 0, extract_weight=True)
+    ovar = SimpleTaxIO.extract_output(crecs, 0,
+                                      exact=True, extract_weight=True)
     SimpleTaxIO.DVAR_NAMES = ['badvar']
     with pytest.raises(ValueError):
         ovar = SimpleTaxIO.extract_output(crecs, 0)

--- a/taxcalc/validation/taxdiffs.tcl
+++ b/taxcalc/validation/taxdiffs.tcl
@@ -80,11 +80,7 @@ if { $ovar4 == 0 } {
     taxdiff $awkfilename 16 $out1_filename $out2_filename
     taxdiff $awkfilename 17 $out1_filename $out2_filename
     taxdiff $awkfilename 18 $out1_filename $out2_filename
-    if { $drake == 1 } {
-        # skip 19
-    } else {
-        taxdiff $awkfilename 19 $out1_filename $out2_filename
-    }
+    taxdiff $awkfilename 19 $out1_filename $out2_filename
     taxdiff $awkfilename 22 $out1_filename $out2_filename
     taxdiff $awkfilename 23 $out1_filename $out2_filename
     taxdiff $awkfilename 24 $out1_filename $out2_filename


### PR DESCRIPTION
This pull request adds an option to specify the nature of output variable 19 generated by the simtax.py and inctax.py interfaces to the Tax-Calculator.  There are no changes to the Tax-Calculator itself.  This change allows a more comprehensive comparison of output generated by some other tax models.