### PR TITLE
Add --ovar4-eitc option to taxcalc/validation/taxdiffs.tcl script

### DIFF
--- a/taxcalc/validation/taxdiff.awk
+++ b/taxcalc/validation/taxdiff.awk
@@ -12,15 +12,22 @@
 BEGIN {
     DUMP_OUT = 0 # set to 1 for dump of ovar4 differences greater than DUMP_MIN
     DUMP_MIN = 0 # minimum absolute value of ovar4 difference to dump
+    file_number = 0
+    file_name = ""
+    if ( col == "4-25" ) {
+        min_num_vars = 25
+        col = 4
+        net_eitc = 1
+    } else {
+        min_num_vars = col
+        net_eitc = 0
+    }
     error = 0
     if ( col < 2 || col > 28 ) {
         printf( "ERROR: col=%d not in [2,28] range\n", col ) > "/dev/stderr"
         error = 1
         exit
     }
-    file_number = 0
-    file_name = ""
-    min_num_vars = col
 }
 error==1 { exit }
 
@@ -44,7 +51,11 @@ file_number==1 {
     }
     id1[i1] = $1
     tax1[i1] = $4
-    var1[i1] = $col
+    if ( net_eitc == 1 ) {
+        var1[i1] = $col - $25
+    } else {
+        var1[i1] = $col
+    }
 }
 
 file_number==2 {
@@ -57,7 +68,11 @@ file_number==2 {
     }
     id2[i2] = $1
     tax2[i2] = $4
-    var2[i2] = $col
+    if ( net_eitc == 1 ) {
+        var2[i2] = $col - $25
+    } else {
+        var2[i2] = $col
+    }
 }
 
 END {
@@ -122,9 +137,14 @@ END {
         } else {
             signed_max_abs_vardiff = -max_abs_vardiff
         }
-        printf( "%s= %2d %6d %6d %9.2f [%d]\n",
+        if ( net_eitc == 1 ) {
+            colstr = "4-"
+        } else {
+            colstr = sprintf("%2s", col)
+        }
+        printf( "%s= %s %6d %6d %9.2f [%d]\n",
                 "TAXDIFF:ovar,#diffs,#smdiffs,maxdiff[id]",
-                col,
+                colstr,
                 num_diffs,
                 num_small_diffs,
                 signed_max_abs_vardiff,

--- a/taxcalc/validation/taxdiffs.tcl
+++ b/taxcalc/validation/taxdiffs.tcl
@@ -7,11 +7,14 @@
 #    OR --drake option skips output variables not in Drake Software output
 
 proc usage {} {
-    set args "\[--ovar4 | --drake\] 1st-out-file 2nd-out-file"
+    set options "--ovar4 | --ovar4-eitc | --drake"
+    set args "\[$options\] file1 file2"
     puts stderr "USAGE: tclsh taxdiffs.tcl $args"
     set details "computes diffs only for output variable 4"
     puts stderr "       WHERE using --ovar4 option $details"
-    set details "skips output not produced by Drake Software"
+    set details "computes diffs only for ovar4 less ovar25"
+    puts stderr "       WHERE using --ovar4-eitc option $details"
+    set details "skips output not in Drake Software files"
     puts stderr "          OR using --drake option $details"
 }
 
@@ -31,6 +34,7 @@ if { $argc < 2 || $argc > 3 } {
     exit 1
 }
 set ovar4 0
+set ovar4_eitc 0
 set drake 0
 if { $argc == 2 } {
     set iarg 0
@@ -40,6 +44,8 @@ if { $argc == 2 } {
     set option [lindex $argv 0]
     if { [string compare $option "--ovar4"] == 0 } {
         set ovar4 1
+    } elseif { [string compare $option "--ovar4-eitc"] == 0 } {
+        set ovar4_eitc 1
     } elseif { [string compare $option "--drake"] == 0 } {
         set drake 1
     } else {
@@ -60,42 +66,47 @@ if { ![file exists $out2_filename] } {
     exit 1
 }
 set awkfilename [file join [file dirname [info script]] taxdiff.awk]
-if { $ovar4 == 0 } {
-    taxdiff $awkfilename  6 $out1_filename $out2_filename
-    if { $drake == 1 } {
-        # skip 7 and 9
-    } else {
-        taxdiff $awkfilename  7 $out1_filename $out2_filename
-        taxdiff $awkfilename  9 $out1_filename $out2_filename
-    }
-    taxdiff $awkfilename 10 $out1_filename $out2_filename
-    if { $drake == 1 } {
-        # skip 11
-    } else {
-        taxdiff $awkfilename 11 $out1_filename $out2_filename
-    }
-    taxdiff $awkfilename 12 $out1_filename $out2_filename
-    taxdiff $awkfilename 14 $out1_filename $out2_filename
-    taxdiff $awkfilename 15 $out1_filename $out2_filename
-    taxdiff $awkfilename 16 $out1_filename $out2_filename
-    taxdiff $awkfilename 17 $out1_filename $out2_filename
-    taxdiff $awkfilename 18 $out1_filename $out2_filename
-    taxdiff $awkfilename 19 $out1_filename $out2_filename
-    taxdiff $awkfilename 22 $out1_filename $out2_filename
-    taxdiff $awkfilename 23 $out1_filename $out2_filename
-    taxdiff $awkfilename 24 $out1_filename $out2_filename
-    taxdiff $awkfilename 25 $out1_filename $out2_filename
-    if { $drake == 1 } {
-        # skip 26
-    } else {
-        taxdiff $awkfilename 26 $out1_filename $out2_filename
-    }
-    taxdiff $awkfilename 27 $out1_filename $out2_filename
-    if { $drake == 1 } {
-        # skip 28
-    } else {
-        taxdiff $awkfilename 28 $out1_filename $out2_filename
-    }
+if { $ovar4 == 1 } {
+    taxdiff $awkfilename  4 $out1_filename $out2_filename
+    exit 0
+} elseif { $ovar4_eitc == 1} {
+    taxdiff $awkfilename 4-25 $out1_filename $out2_filename
+    exit 0
+}
+taxdiff $awkfilename  6 $out1_filename $out2_filename
+if { $drake == 1 } {
+    # skip 7 and 9
+} else {
+    taxdiff $awkfilename  7 $out1_filename $out2_filename
+    taxdiff $awkfilename  9 $out1_filename $out2_filename
+}
+taxdiff $awkfilename 10 $out1_filename $out2_filename
+if { $drake == 1 } {
+    # skip 11
+} else {
+    taxdiff $awkfilename 11 $out1_filename $out2_filename
+}
+taxdiff $awkfilename 12 $out1_filename $out2_filename
+taxdiff $awkfilename 14 $out1_filename $out2_filename
+taxdiff $awkfilename 15 $out1_filename $out2_filename
+taxdiff $awkfilename 16 $out1_filename $out2_filename
+taxdiff $awkfilename 17 $out1_filename $out2_filename
+taxdiff $awkfilename 18 $out1_filename $out2_filename
+taxdiff $awkfilename 19 $out1_filename $out2_filename
+taxdiff $awkfilename 22 $out1_filename $out2_filename
+taxdiff $awkfilename 23 $out1_filename $out2_filename
+taxdiff $awkfilename 24 $out1_filename $out2_filename
+taxdiff $awkfilename 25 $out1_filename $out2_filename
+if { $drake == 1 } {
+    # skip 26
+} else {
+    taxdiff $awkfilename 26 $out1_filename $out2_filename
+}
+taxdiff $awkfilename 27 $out1_filename $out2_filename
+if { $drake == 1 } {
+    # skip 28
+} else {
+    taxdiff $awkfilename 28 $out1_filename $out2_filename
 }
 taxdiff $awkfilename  4 $out1_filename $out2_filename
 exit 0


### PR DESCRIPTION
This pull request expands the scope of cross-model validation capabilities by allowing tabulation of differences in income tax liability minus the EITC amount.  This is useful because Tax-Calculator uses a formula approach to computing EITC while commercial tax-preparation software includes the enormous EITC look-up table in the IRS instructions.  This new ability allows a quick tabulation of income tax liability differences other than those caused by differences between formula EITC and table EITC amounts.

There are no changes in Tax-Calculator logic or results in this pull request.
