### PR TITLE
Set e01500=e01700 in SimpleTaxIO._specify_input method

### DIFF
--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -678,6 +678,7 @@ class SimpleTaxIO(object):
         recs.e00600[idx] = ivar[9]  # qual.div. included in ordinary dividends
         recs.e00300[idx] = ivar[10]  # other property income (+/-)
         recs.e01700[idx] = ivar[11]  # federally taxable pensions
+        recs.e01500[idx] = ivar[11]  # total pensions (taxable plus nontaxable)
         recs.e02400[idx] = ivar[12]  # gross social security benefits
         recs.e00400[idx] = ivar[13]  # federal tax-exempt interest
         # no use of ivar[14] because no state income tax calculations


### PR DESCRIPTION
This pull request sets total (taxable plus nontaxable) pension benefits, `e01500`, equal to taxable pension benefits, `e01700`, when Internet-TAXSIM-like input data is read by the SimpleTaxIO class.  See the discussion associated with merged pull request #898 for the reasons for making this change, other from the fact the whole-includes-the-parts logic dictates this change.