### PR TITLE
More updates regarding validation/tests

### DIFF
--- a/DATAPREP.md
+++ b/DATAPREP.md
@@ -47,3 +47,10 @@ to specify the taxpayer-spouse split.  You will get an error message
 from Tax-Calculator, and it will stop running, if you do not split the
 filing-unit amount between taxpayer and spouse so that the above equations
 hold for each filing unit in the input file.
+
+In addition to this earning-splitting data-preparation issue,
+Tax-Calculator expects that the value of ordinary dividends (e00600)
+will be no less than the value of qualified dividends (e00650) for
+each filing unit.  Again, it is the responsibility of anyone preparing
+data for Tax-Calculator input to ensure that this relationship is
+true.

--- a/TESTING.md
+++ b/TESTING.md
@@ -73,17 +73,9 @@ Testing with validation/tests
 -----------------------------
 
 The current version of the validation/tests runs only under Mac and Linux;
-if you are working under Windows, skip this second phase of testing.
-
-The validation/tests generate samples of tax filing
-units whose attributes are specified in a random, non-representative
-manner.  Each sample is used to generate tax liabilities, intermediate
-income tax results, and marginal tax rates using Internet-TAXSIM and
-simtax.py, which is a command-line interface to the Tax-Calculator.
-And then the output from the two models are compared item-by-item and
-unit-by-unit to produce cross-model-validation summary results.  See
-the [description of the Internet-TAXSIM validation
-tests](taxcalc/validation/README.md) for more details.
+if you are working under Windows, skip this second phase of testing.  See
+the [description of the validation tests](taxcalc/validation/README.md)
+for more details.
 
 Run the second-phase of testing as follows at the Mac or Linux command
 prompt in the tax-calculator directory at the top of the repository

--- a/taxcalc/validation/taxsim/test
+++ b/taxcalc/validation/taxsim/test
@@ -45,7 +45,7 @@ else
     OVAR4="--ovar4"
 fi
 # Unzip Internet-TAXSIM output for specified INPUT and REFORM
-unzip -oq out-taxsim.zip $LYY.in.out-taxsim$SUFFIX
+unzip -oq output-taxsim.zip $LYY.in.out-taxsim$SUFFIX
 # Compare simtax and Internet-TAXSIM OUTPUT
 tclsh ../taxdiffs.tcl $OVAR4 $LYY.in.out-simtax$SUFFIX \
                              $LYY.in.out-taxsim$SUFFIX > $LYY$SUFFIX.taxdiffs

--- a/taxcalc/validation/taxsim/tests
+++ b/taxcalc/validation/taxsim/tests
@@ -24,22 +24,23 @@ fi
 echo "STARTING WITH TAXSIM VALIDATION TESTS : `date`"
 rm -f testerror
 if [[ "$ALLTESTS" == true ]] ; then
-    bash test c13 . &
-    bash test c14 . &
-    bash test c15 . &
-    wait
-    bash test c13 19_0.05 &
-    bash test c14 19_0.05 &
-    wait
-    bash test c13 18_0.07 &
-    bash test c14 18_0.07 &
-    wait
-    bash test c13 50_1 &
-    bash test c14 50_1 &
-    wait
-    bash test c13 75_500 &
-    bash test c14 75_500 &
-    wait
+    echo "ALL option is not currently implemented in validation/taxsim/tests"
+    # bash test c13 . &
+    # bash test c14 . &
+    # bash test c15 . &
+    # wait
+    # bash test c13 19_0.05 &
+    # bash test c14 19_0.05 &
+    # wait
+    # bash test c13 18_0.07 &
+    # bash test c14 18_0.07 &
+    # wait
+    # bash test c13 50_1 &
+    # bash test c14 50_1 &
+    # wait
+    # bash test c13 75_500 &
+    # bash test c14 75_500 &
+    # wait
 fi
 # bash test d13 . &
 # bash test d14 . &

--- a/taxcalc/validation/tests
+++ b/taxcalc/validation/tests
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Executes validation TESTS by calling TESTS scripts in various subdirectories.
+# .... check number of command-line arguments
+if [[ "$#" -gt 1 ]]; then
+    echo "ERROR: can specify at most one command-line argument"
+    echo "USAGE: ./tests [all]"
+    echo "       (using the 'all' option may execute four tests at a time)"
+    exit 1
+fi
+# .... specify whether or not to execute all tests
+ALL=""
+if [[ "$#" -eq 1 ]]; then
+    if [[ "$1" == "all" ]]; then
+        ALL="all"
+    else
+        echo "ERROR: optional command-line argument must be all"
+        echo "USAGE: ./tests [all]"
+        exit 1
+    fi
+fi
+cd taxsim ; bash tests $ALL ; cd ..
+exit 0


### PR DESCRIPTION
Update various documentation files and add `taxcalc/validation/tests` bash script.  No change in tax-calculating logic or results.