### PR TITLE
Change call order of FairShareTax function

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -189,13 +189,13 @@ class Calculator(object):
         C1040(self.policy, self.records)
         DecomposeEITC(self.policy, self.records)
         IITAX(self.policy, self.records)
-        ExpandIncome(self.policy, self.records)
-        FairShareTax(self.policy, self.records)
 
     def calc_all(self, zero_out_calc_vars=False):
         # conducts static analysis of Calculator object for current_year
         self.calc_one_year(zero_out_calc_vars)
         BenefitSurtax(self)
+        FairShareTax(self.policy, self.records)
+        ExpandIncome(self.policy, self.records)
 
     def increment_year(self):
         next_year = self.policy.current_year + 1

--- a/taxcalc/comparison/reform_results.txt
+++ b/taxcalc/comparison/reform_results.txt
@@ -212,3 +212,8 @@ Tax-Calculator,-167.7,-170.3,-175.0,-180.8
 ""
 Increase Personal Refundable credit amount to 1000 with phaseout starting at AGI 10,000 and phaseout rate at 0.01
 Tax-Calculator,-111.7,-112.1,-114.3,-117.7
+""
+FAIR SHARE TAX
+""
+Increase FST rate from zero to 0.30 beginning in 2017
+Tax-Calculator,30.0,30.7,31.0,31.9

--- a/taxcalc/comparison/reforms.json
+++ b/taxcalc/comparison/reforms.json
@@ -496,5 +496,16 @@
         "name": "Increase Personal Refundable credit amount to 1000 with phaseout starting at AGI 10,000 and phaseout rate at 0.01",
         "output_type": "_iitax",
         "compare_with": {}
+    },
+
+    "r54": {
+        "start_year": 2017,
+        "value": {"_FST_AGI_trt": [0.3],
+                  "_FST_AGI_thd_lo": [[1.0e6, 1.0e6, 0.5e6, 1.0e6, 1.0e6, 0.5e6]],
+                  "_FST_AGI_thd_hi": [[2.0e6, 2.0e6, 1.0e6, 2.0e6, 2.0e6, 1.0e6]]},
+        "section_name": "FAIR SHARE TAX",
+        "name": "Increase FST rate from zero to 0.30 beginning in 2017",
+        "output_type": "_iitax",
+        "compare_with": {}
     }
 }

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1959,9 +1959,10 @@
                   [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]],
         "validations": {"min": "_PT_brk6"}
     },
-    "_FST_AGI_trt":{
-        "long_name": "Rate applied to AGI to determine tentative FST",
-        "description": "The result of multiplying AGI by this is the tentative FST used to calculate final FST",
+
+    "_FST_AGI_trt": {
+        "long_name": "Rate applied to AGI to determine tentative Fair Share Tax",
+        "description": "The result of multiplying AGI by this is the tentative FST, which is used to calculate final FST.",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -1970,11 +1971,12 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0.0]
-     },
+        "value": [0.0],
+        "validations": {"min": 0.0}
+    },
 
-    "_FST_AGI_thd_lo":{
-        "long_name": "Minimum AGI needed to be subject to FST",
+    "_FST_AGI_thd_lo": {
+        "long_name": "Minimum AGI needed to be subject to Fair Share Tax",
         "description": "A taxpayer is only subject to the FST if they exceed this level of AGI",
         "irs_ref": "",
         "note": "",
@@ -1984,11 +1986,13 @@
         "row_label": ["2013"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[1000000, 1000000, 500000, 1000000, 1000000, 500000]]
+        "value": [[1.0e6, 1.0e6, 0.5e6, 1.0e6, 1.0e6, 0.5e6]],
+        "validations": {"min": 0.0, "max": "_FST_AGI_thd_hi"}
     },
-    "_FST_AGI_thd_hi":{
-        "long_name": "AGI level at which the FST is fully phased in",
-        "description": "The FST will be fully phased in at this level of AGI. If there is no phase in, this is equivalent to the lower AGI threshold",
+
+    "_FST_AGI_thd_hi": {
+        "long_name": "AGI level at which the Fair Share Tax is fully phased in",
+        "description": "The FST will be fully phased in at this level of AGI. If there is no phase-in, this upper threshold should be set equal to the lower AGI threshold",
         "irs_ref": "",
         "note": "",
         "start_year": 2013,
@@ -1997,7 +2001,7 @@
         "row_label": ["2013"],
         "cpi_inflated": true,
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[2000000, 2000000, 1000000, 2000000, 2000000, 1000000]]
-
+        "value": [[2.0e6, 2.0e6, 1.0e6, 2.0e6, 2.0e6, 1.0e6]],
+        "validations": {"min": "_FST_AGI_thd_lo"}
     }
 }

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1961,8 +1961,8 @@
     },
 
     "_FST_AGI_trt": {
-        "long_name": "Rate applied to AGI to determine tentative Fair Share Tax",
-        "description": "The result of multiplying AGI by this is the tentative FST, which is used to calculate final FST.",
+        "long_name": "Rate applied to AGI to determine full Fair Share Tax",
+        "description": "The result of multiplying AGI by this is full FST (before credit for income tax and employee share of payroll taxes).",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1194,12 +1194,10 @@ def FairShareTax(c00100, MARS, ptax_was, ptax_sey, ptax_amc,
     """
     if c00100 >= FST_AGI_thd_lo[MARS - 1]:
         employee_share = 0.5 * ptax_was + 0.5 * ptax_sey + ptax_amc
-        tentFST = max(c00100 * FST_AGI_trt - _iitax - employee_share, 0.)
+        fst = max(c00100 * FST_AGI_trt - _iitax - employee_share, 0.)
         gap = max(FST_AGI_thd_hi[MARS - 1] - FST_AGI_thd_lo[MARS - 1], 0.)
-        if gap == 0. or c00100 >= FST_AGI_thd_hi[MARS - 1]:
-            fst = tentFST
-        else:
-            fst = tentFST * (c00100 - FST_AGI_thd_lo[MARS - 1]) / gap
+        if gap > 0. and c00100 < FST_AGI_thd_hi[MARS - 1]:
+            fst *= (c00100 - FST_AGI_thd_lo[MARS - 1]) / gap
         _iitax += fst
         _combined += fst
     else:

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1192,16 +1192,16 @@ def FairShareTax(c00100, MARS, ptax_was, ptax_sey, ptax_amc,
 
     _combined : individual income tax plus payroll taxes augmented by fst
     """
-    if c00100 >= FST_AGI_thd_lo[MARS - 1]:
+    if FST_AGI_trt > 0. and c00100 >= FST_AGI_thd_lo[MARS - 1]:
         employee_share = 0.5 * ptax_was + 0.5 * ptax_sey + ptax_amc
         fst = max(c00100 * FST_AGI_trt - _iitax - employee_share, 0.)
-        gap = max(FST_AGI_thd_hi[MARS - 1] - FST_AGI_thd_lo[MARS - 1], 0.)
-        if gap > 0. and c00100 < FST_AGI_thd_hi[MARS - 1]:
-            fst *= (c00100 - FST_AGI_thd_lo[MARS - 1]) / gap
+        thd_gap = max(FST_AGI_thd_hi[MARS - 1] - FST_AGI_thd_lo[MARS - 1], 0.)
+        if thd_gap > 0. and c00100 < FST_AGI_thd_hi[MARS - 1]:
+            fst *= (c00100 - FST_AGI_thd_lo[MARS - 1]) / thd_gap
         _iitax += fst
         _combined += fst
     else:
-        fst = 0.0
+        fst = 0.
     return (fst, _iitax, _combined)
 
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1193,20 +1193,17 @@ def FairShareTax(c00100, MARS, ptax_was, ptax_sey, ptax_amc,
     _combined : individual income tax plus payroll taxes augmented by fst
     """
     if c00100 >= FST_AGI_thd_lo[MARS - 1]:
-        tentFST = c00100 * FST_AGI_trt
         employee_share = 0.5 * ptax_was + 0.5 * ptax_sey + ptax_amc
-        if (c00100 >= FST_AGI_thd_hi[MARS - 1] or
-                FST_AGI_thd_hi[MARS - 1] == FST_AGI_thd_lo[MARS - 1]):
-            fst = max(tentFST - _iitax - employee_share, 0.0)
+        tentFST = max(c00100 * FST_AGI_trt - _iitax - employee_share, 0.)
+        gap = max(FST_AGI_thd_hi[MARS - 1] - FST_AGI_thd_lo[MARS - 1], 0.)
+        if gap == 0. or c00100 >= FST_AGI_thd_hi[MARS - 1]:
+            fst = tentFST
         else:
-            fst = max((((c00100 - FST_AGI_thd_lo[MARS - 1]) /
-                        (FST_AGI_thd_hi[MARS - 1] -
-                         FST_AGI_thd_lo[MARS - 1])) *
-                       (tentFST - _iitax - employee_share)), 0.0)
+            fst = tentFST * (c00100 - FST_AGI_thd_lo[MARS - 1]) / gap
+        _iitax += fst
+        _combined += fst
     else:
         fst = 0.0
-    _iitax += fst
-    _combined += fst
     return (fst, _iitax, _combined)
 
 


### PR DESCRIPTION
This pull request started out with the goal of improving `current_law_policy.json` syntax (so as to eliminate several pylint warnings) and of streamlining FairShareTax calculations (so as to slightly speed them up).  In addition to these cosmetic changes, the `calculate.py` call order of the FairShareTax function has been changed so that it is the final income tax calculation.  Before this change, the FairShareTax was incorrectly called before the income tax calculation in the BenefitSurtax function.

@MattHJensen @feenberg @andersonfrailey @Amy-Xu @GoFroggyRun 