### PR TITLE
Add filings and filings.forms subpackages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ config = {
     'version': version,
     'cmdclass': cmdclass,
     'license': 'MIT',
-    'packages': ['taxcalc'],
+    'packages': ['taxcalc', 'taxcalc.filings', 'taxcalc.filings.forms'],
     'include_package_data': True,
     'name': 'taxcalc',
     'install_requires': ['numpy', 'pandas'],


### PR DESCRIPTION
 - Added subpackages for setuptools for proper install of taxcalc

Without this change, if you install the package, it fails to import because it can't find the `filings` package. This commit is needed to create a new release so we can merge and deploy:

https://github.com/OpenSourcePolicyCenter/webapp-public/pull/342

cc @MattHJensen 