### PR TITLE
Eliminate pylint warnings from test_functions.py code

### DIFF
--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -102,14 +102,10 @@ def test_calc_and_used_vars(tests_path):
     found_error2 = False
     msg2 = 'calculated & returned variables are not function arguments\n'
     for fname in fnames:
-        if fname == 'BenefitSurtax':
-            continue  # because BenefitSurtax is not really a function
-        if fname == 'ComputeBenefit':
-            continue  # because ComputeBenefit is not really a function
-        if fname == 'BenefitLimitation':
-            continue  # because BenefitLimitation is not really a function
-        cvars_set = set(cvars[fname])
-        rvars_set = set(rvars[fname])
+        if fname == 'ComputeBenefit' or \
+           fname == 'BenefitSurtax' or \
+           fname == 'BenefitLimitation':
+            continue  # because fname is not really a function
         crvars_set = set(cvars[fname]) & set(rvars[fname])
         if not crvars_set <= set(fargs[fname]):
             found_error2 = True


### PR DESCRIPTION
Unit-test code-style changes only; no change in tax-calculating logic or results.