### PR TITLE
Fix long-standing typo in test_records.py file

### DIFF
--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -72,7 +72,7 @@ def test_correct_Records_instantiation_sample(puf_1991, weights_1991):
     ),
     (
         u'RECID,e00300\n'
-        u'1,   ,456789\n'
+        u'1,    456789\n'
     ),
     (
         u'RECID,MARS,e00600,e00650\n'


### PR DESCRIPTION
Fixes a typo in `test_records.py` that was introduced many months before the tests were recently parameterized.

Fixing this typo caused a small increase in unit-test code coverage.