### PR TITLE
Add tests for incorrect calls of TaxForm set_fields method

### DIFF
--- a/taxcalc/filings/forms/tax_form.py
+++ b/taxcalc/filings/forms/tax_form.py
@@ -106,8 +106,8 @@ class TaxForm(object):
         valid_fields = self.__class__._VALID_FIELDS
         for key, value in data.items():
             if valid_fields and key not in valid_fields:
-                print('Unknown field {0} for form {2}'.
-                      format(key, self.form_name()))
+                msg = 'Unknown field {0} for form {1}'
+                raise ValueError(msg.format(key, self.form_name()))
             else:
                 self._fields[key] = value
 

--- a/taxcalc/tests/filings/forms/test_tax_form.py
+++ b/taxcalc/tests/filings/forms/test_tax_form.py
@@ -52,6 +52,17 @@ def test_tax_form_tax_id():
     assert form.tax_unit_id == '47'
 
 
+def test_incorrect_set_fields_calls():
+    child_class = type("TestTaxForm", (TaxForm,), {
+        '_VALID_FIELDS': ['field1', 'field2', 'field3'],
+    })
+    form = child_class(2013)
+    with pytest.raises(ValueError):
+        form.set_fields(list())
+    with pytest.raises(ValueError):
+        form.set_fields({'field9': '12345'})
+
+
 def test_tax_form_evar_mapping_direct():
     child_class = type("TestTaxForm", (TaxForm,), {
         '_EVAR_MAP': {


### PR DESCRIPTION
This pull request increases unit-test code coverage by adding new tests to the `test_tax_form.py` file.  This pull request reduces the number of code-coverage misses in the `taxcalc/filings/forms` directory from four to two.

@zrisher 