### PR TITLE
Eliminate unreachable 'raise ValueError' statement in tax_form.py file

### DIFF
--- a/taxcalc/filings/forms/tax_form.py
+++ b/taxcalc/filings/forms/tax_form.py
@@ -121,12 +121,10 @@ class TaxForm(object):
         indirect = self.to_evars_indirect() or {}
 
         # Check for conflicts
-        for key in direct:
-            if key in indirect and direct[key] != indirect[key]:
-                raise ValueError('Different calc for same evar.')
-        for key in indirect:
-            if key in direct and direct[key] != indirect[key]:
-                raise ValueError('Different calc for same evar.')
+        for key in direct.keys() + indirect.keys():
+            if key in direct and key in indirect:
+                if direct[key] != indirect[key]:
+                    raise ValueError('Different calc for same evar.')
 
         direct.update(indirect)
         return direct

--- a/taxcalc/filings/forms/tax_form.py
+++ b/taxcalc/filings/forms/tax_form.py
@@ -121,7 +121,7 @@ class TaxForm(object):
         indirect = self.to_evars_indirect() or {}
 
         # Check for conflicts
-        for key in direct.keys() + indirect.keys():
+        for key in list(direct.keys()) + list(indirect.keys()):
             if key in direct and key in indirect:
                 if direct[key] != indirect[key]:
                     raise ValueError('Different calc for same evar.')


### PR DESCRIPTION
This pull request attempts to increase unit-test code coverage by rewriting the conflict-checking code in the TaxForm `to_evars` method.

@zrisher 