### PR TITLE
Add new test to cover continue statement in TaxForm to_evars_direct method

### DIFF
--- a/taxcalc/filings/forms/tax_form.py
+++ b/taxcalc/filings/forms/tax_form.py
@@ -139,17 +139,20 @@ class TaxForm(object):
         """
         results = {}
 
-        if self._EVAR_MAP_BY_YEAR:
+        if self._EVAR_MAP_BY_YEAR and self.year in self._EVAR_MAP_BY_YEAR:
             year_evar_map = self._EVAR_MAP_BY_YEAR[self.year]
         else:
             year_evar_map = None
 
         for key, value in self._fields.items():
             if self._EVAR_MAP and key in self._EVAR_MAP:
+                # print('(a) key, value = {} : {}'.format(key, value))
                 evar = self._EVAR_MAP[key]
             elif year_evar_map and key in year_evar_map:
+                # print('(b) key, value = {} : {}'.format(key, value))
                 evar = year_evar_map[key]
             else:
+                # print('(c) key, value = {} : {}'.format(key, value))
                 continue
             if evar in results and results[evar] != value:
                 raise ValueError('Different calc for same evar.')

--- a/taxcalc/tests/filings/forms/test_tax_form.py
+++ b/taxcalc/tests/filings/forms/test_tax_form.py
@@ -52,6 +52,7 @@ def test_tax_form_tax_id():
     assert form.tax_unit_id == '47'
 
 
+@pytest.mark.one
 def test_tax_form_evar_mapping_direct():
     child_class = type("TestTaxForm", (TaxForm,), {
         '_EVAR_MAP': {
@@ -80,7 +81,7 @@ def test_tax_form_evar_mapping_direct():
     child_class = type("EmptyTaxForm", (TaxForm,), {
         '_EVAR_MAP': {}, '_EVAR_MAP_BY_YEAR': {}
     })
-    form = child_class(2013, fields={'field_1': 47, 'field_2': 59})
+    form = child_class(2013, fields={'field_1': '47', 'field_2': '59'})
     assert form.to_evars_direct() == {}
 
 

--- a/taxcalc/tests/filings/forms/test_tax_form.py
+++ b/taxcalc/tests/filings/forms/test_tax_form.py
@@ -77,6 +77,12 @@ def test_tax_form_evar_mapping_direct():
         'e00003': 3,
     }
 
+    child_class = type("EmptyTaxForm", (TaxForm,), {
+        '_EVAR_MAP': {}, '_EVAR_MAP_BY_YEAR': {}
+    })
+    form = child_class(2013, fields={'field_1': 47, 'field_2': 59})
+    assert form.to_evars_direct() == {}
+
 
 def test_tax_form_evar_mapping_direct_conflict():
     child_class = type("TestTaxForm", (TaxForm,), {

--- a/taxcalc/tests/filings/forms/test_tax_form.py
+++ b/taxcalc/tests/filings/forms/test_tax_form.py
@@ -52,7 +52,6 @@ def test_tax_form_tax_id():
     assert form.tax_unit_id == '47'
 
 
-@pytest.mark.one
 def test_tax_form_evar_mapping_direct():
     child_class = type("TestTaxForm", (TaxForm,), {
         '_EVAR_MAP': {


### PR DESCRIPTION
This pull request attempts to add unit-test coverage for the continue statement in the `TaxForm.to_evars_direct` method.