### PR TITLE
Add skeleton files in new taxcalc/reforms directory

### DIFF
--- a/taxcalc/reforms/README.md
+++ b/taxcalc/reforms/README.md
@@ -1,0 +1,11 @@
+This directory contains examples of tax reform provisions that can be
+combined and modified to construct tax reform proposals.
+
+Such reform proposals can then be uploaded to the [TaxBrain
+webapp](http://www.ospc.org/taxbrain/) (or used on your local
+computer) to estimate reform effects.
+
+[This document](REFORMS.md) provides access to the reform provisions
+in a way that corresponds to how the policy parameters are organized
+on the TaxBrain webapp.
+

--- a/taxcalc/reforms/REFORMS.md
+++ b/taxcalc/reforms/REFORMS.md
@@ -1,0 +1,52 @@
+HOW TO SPECIFY TAX REFORMS
+==========================
+
+Description of JSON reform files goes here.
+
+Payroll Taxes
+-------------
+
+
+Social Security Taxability
+--------------------------
+
+
+Adjustments
+-----------
+
+
+Exemptions
+----------
+
+
+Standard Deduction
+------------------
+
+
+Personal Refundable Credit
+--------------------------
+
+
+Itemized Deductions
+-------------------
+
+
+Regular Taxes
+-------------
+
+
+Alternative Minimum Tax
+-----------------------
+
+
+Nonrefundable Credits
+---------------------
+
+
+Other Taxes
+-----------
+
+
+Refundable Credits
+------------------
+


### PR DESCRIPTION
Very incomplete.  The long-run strategy is to add many example tax reform provisions (with each provision being in a `taxcalc/reforms/*.json` file) that can be combined to build up complex tax reform proposals.  The resulting tax reform files can then be uploaded to TaxBrain to determine their aggregate revenue and distributional effects.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey @codykallen @zrisher 