### PR TITLE
Add parameter to allow LTCG+QDIV income to be taxed as other income

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -876,6 +876,19 @@
         "validations": {"min": "_II_brk6"}
     },
 
+    "_CG_as_II": {
+        "long_name": "Long term capital gains and qualified dividends taxed same as other income",
+        "description": "This zero/one parameter specifies whether or not long term capital gains and qualified dividends are taxed like other income.",
+        "irs_ref": "Current-law value is zero and Schedule D tax rules are used.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0]
+    },
+
     "_CG_rt1": {
         "long_name": "Long term capital gain and qualified dividends rate 1",
         "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 1 are taxed at this rate. ",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -155,8 +155,8 @@ def CapGains(p23250, p22250, _sep, ALD_Investment_ec, ALD_StudentLoan_HC,
     c01000 = max((-3000. / _sep), c23650)
     # compute ymod* variables
     ymod1 = (e00200 + e00700 + e00800 + e00900 + e01400 + e01700 +
-             (1 - ALD_Interest_ec) * (e00300 + e00600 +
-                                      c01000 + e01100 + e01200) +
+             (1 - ALD_Investment_ec) * (e00300 + e00600 +
+                                        c01000 + e01100 + e01200) +
              e02000 + e02100 + e02300)
     ymod2 = e00400 + (0.50 * e02400) - c02900
     ymod3 = (1 - ALD_StudentLoan_HC) * e03210 + e03230 + e03240

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -154,8 +154,9 @@ def CapGains(p23250, p22250, _sep, ALD_Interest_ec, ALD_StudentLoan_HC,
     # limitation on capital losses
     c01000 = max((-3000. / _sep), c23650)
     # compute ymod* variables
-    ymod1 = (e00200 + (1 - ALD_Interest_ec) * e00300 + e00600 + e00700 +
-             e00800 + e00900 + c01000 + e01100 + e01200 + e01400 + e01700 +
+    ymod1 = (e00200 + e00700 + e00800 + e00900 + e01400 + e01700 +
+             (1 - ALD_Interest_ec) * (e00300 + e00600 +
+                                      c01000 + e01100 + e01200) +
              e02000 + e02100 + e02300)
     ymod2 = e00400 + (0.50 * e02400) - c02900
     ymod3 = (1 - ALD_StudentLoan_HC) * e03210 + e03230 + e03240
@@ -483,17 +484,22 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
              e24515, e24518, MARS, c04800, c05200,
              II_rt1, II_rt2, II_rt3, II_rt4, II_rt5, II_rt6, II_rt7, II_rt8,
              II_brk1, II_brk2, II_brk3, II_brk4, II_brk5, II_brk6, II_brk7,
+             CG_as_II,
              CG_rt1, CG_rt2, CG_rt3, CG_rt4, CG_thd1, CG_thd2, CG_thd3,
              c24516, c24517, c24520, c05700, _taxbc):
     """
     GainsTax function implements (2015) Schedule D Tax Worksheet logic for
     the special taxation of long-term capital gains and qualified dividends
+    if CG_as_II is false (that is, zero)
     """
     # pylint: disable=too-many-statements,too-many-branches
     if c01000 > 0. or c23650 > 0. or p23250 > 0. or e01100 > 0. or e00650 > 0.:
         hasqdivltcg = 1  # has qualified dividends or long-term capital gains
     else:
         hasqdivltcg = 0  # no qualified dividends or long-term capital gains
+
+    if CG_as_II != 0.:
+        hasqdivltcg = 0  # no special taxation of qual divids and l-t cap gains
 
     if hasqdivltcg == 1:
 


### PR DESCRIPTION
This pull request attempts to provide an easy-to-use policy parameter that causes long-term capital gains and qualified dividends to be taxed at the same rates as wage and salary income.  The changes in this pull request have no effect on current-law tax results, but these changes need review to determine if they do tax calculations correctly when the new `_CG_as_II` parameter is set to one.

Such a reform raises 2016 income tax revenue by almost $41.9 billion.  I have no idea if that is a plausible revenue increase when eliminating the special tax treatment of LTCG+QDIV
income.
```
tax-calculator$ cp ../tax-calculator-data/puf.csv .
tax-calculator$ python inctax.py puf.csv 2016 --weights
tax-calculator$ cat cgsame.json
{ "_CG_as_II": {"2016": [1] } }
tax-calculator$ python inctax.py puf.csv 2016 --weights --reform cgsame.json 
tax-calculator$ ll puf*
-rw-r--r--  1 mrh  staff  39385372 Oct  7 12:34 puf-16.out-inctax
-rw-r--r--  1 mrh  staff  39391761 Oct  7 12:37 puf-16.out-inctax-cgsame
-rw-r--r--@ 1 mrh  staff  52839666 Oct  7 12:32 puf.csv
tax-calculator$ awk '{rev+=$4*$29}END{print rev}' puf-16.out-inctax
9.27552e+11
tax-calculator$ awk '{rev+=$4*$29}END{print rev}' puf-16.out-inctax-cgsame 
9.69409e+11
```

@MattHJensen @feenberg @codykallen @Amy-Xu @GoFroggyRun @andersonfrailey 