### PR TITLE
Extend no-different tax treatment of LTCG+QDIV income to AMT

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -132,13 +132,13 @@ class Calculator(object):
     def records(self):
         return self._records
 
-    def TaxInc_to_AMTI(self):
+    def TaxInc_to_AMT(self):
         TaxInc(self.policy, self.records)
         SchXYZTax(self.policy, self.records)
         GainsTax(self.policy, self.records)
         AGIsurtax(self.policy, self.records)
         NetInvIncTax(self.policy, self.records)
-        AMTInc(self.policy, self.records)
+        AMT(self.policy, self.records)
 
     def calc_one_year(self, zero_out_calc_vars=False):
         # calls all the functions except those in calc_all() function
@@ -160,14 +160,14 @@ class Calculator(object):
         item_no_limit = copy.deepcopy(self.records.c21060)
         self.records.c04470 = np.zeros(self.records.dim)
         self.records.c21060 = np.zeros(self.records.dim)
-        self.TaxInc_to_AMTI()
+        self.TaxInc_to_AMT()
         std_taxes = copy.deepcopy(self.records.c05800)
         # Set standard deduction to zero, calculate taxes w/o
         # standard deduction, and store AMT + Regular Tax
         self.records._standard = np.zeros(self.records.dim)
         self.records.c21060 = item_no_limit
         self.records.c04470 = item
-        self.TaxInc_to_AMTI()
+        self.TaxInc_to_AMT()
         item_taxes = copy.deepcopy(self.records.c05800)
         # Replace standard deduction with zero where the taxpayer
         # would be better off itemizing
@@ -178,7 +178,7 @@ class Calculator(object):
         self.records.c21060[:] = np.where(item_taxes < std_taxes,
                                           item_no_limit, 0.)
         # Calculate taxes with optimal itemized deduction
-        self.TaxInc_to_AMTI()
+        self.TaxInc_to_AMT()
         F2441(self.policy, self.records)
         EITC(self.policy, self.records)
         ChildTaxCredit(self.policy, self.records)

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -135,7 +135,7 @@
         "long_name": "Investment income exclusion",
         "description": "This decimal fraction can be applied to limit the investment income included in AGI. ",
         "irs_ref": "Form 1040, line 8a",
-        "notes": "The final taxable investment income will be (1- exclusion) * Investment income. Even though this portion of income wouldn't be included in AGI, it still contributes to Net Investment Income Tax and Earned Income Tax Credit.",
+        "notes": "The final taxable investment income will be (1-_ALD_Investment_ec)*Investment income. Even though the excluded portion of investment income is not included in AGI, it still is included in investment income used to calculate Net Investment Income Tax and Earned Income Tax Credit.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
@@ -1080,7 +1080,7 @@
 
     "_AMT_em": {
         "long_name": "AMT exemption amount",
-        "description": "The amount of AMTI exempted from AMT.",
+        "description": "The amount of AMT taxable income exempted from AMT.",
         "irs_ref": "Form 1040, line 45, instruction (Worksheet).",
         "notes": "",
         "start_year": 2013,
@@ -1100,7 +1100,7 @@
 
     "_AMT_prt": {
         "long_name": "AMT exemption phaseout rate",
-        "description": "AMT exemption will decrease at this rate for each dollar of AMTI exceeding AMT phaseout start. ",
+        "description": "AMT exemption will decrease at this rate for each dollar of AMT taxable income exceeding AMT phaseout start. ",
         "irs_ref": "Form 6251, line 29, instructions. ",
         "notes": "",
         "start_year": 2013,
@@ -1113,7 +1113,7 @@
     },
 
     "_AMT_trt1": {
-        "long_name": "AMT rate for AMTI under the surtax threshold",
+        "long_name": "AMT rate for AMT taxable income under the surtax threshold",
         "description": "The tax rate applied to the portion of AMT income below the surtax threshold. ",
         "irs_ref": "Form 6251, line 31, in-line. ",
         "notes": "",
@@ -1127,7 +1127,7 @@
     },
 
     "_AMT_trt2": {
-        "long_name": "Additional AMT rate for AMTI above the surtax threshold",
+        "long_name": "Additional AMT rate for AMT taxable income above the surtax threshold",
         "description": "The tax rate applied to the portion of AMT income above the surtax threshold.",
         "irs_ref": "Form 6251, line 31, in-line. ",
         "notes": "This is the additional tax rate (on top of .26) for AMT income",
@@ -1162,7 +1162,7 @@
 
     "_AMT_em_ps": {
         "long_name": "AMT exemption phaseout start",
-        "description": "AMT exemption starts to decrease when AMTI goes beyond this threshold.",
+        "description": "AMT exemption starts to decrease when AMT taxable income goes beyond this threshold.",
         "irs_ref": "Form 1040, line 45, instruction (Worksheet).",
         "notes": "",
         "start_year": 2013,
@@ -1181,8 +1181,8 @@
     },
 
     "_AMT_em_pe": {
-        "long_name": "AMT exemption phaseout ending AMTI (Married filling Separately)",
-        "description": "The AMT exemption is entirely disallowed beyond this AMTI level for individuals who are married but filing separately.",
+        "long_name": "AMT exemption phaseout ending AMT taxable income (Married filling Separately)",
+        "description": "The AMT exemption is entirely disallowed beyond this AMT taxable income level for individuals who are married but filing separately.",
         "irs_ref": "Form 6251, line 28, instruction.",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -508,7 +508,7 @@
 
     "_AMED_thd": {
         "long_name": "Additional Medicare threshold",
-        "description": "If their Medicare wages, RRTA compensation and self-employment income is above this threshold, taxpayers are subject to additional Medicare tax. ",
+        "description": "If their Medicare wages, RRTA compensation and self-employment income is above this threshold, taxpayers are subject to additional Medicare tax.",
         "irs_ref": "Form 8959, line 5, in-line. ",
         "start_year": 2013,
         "col_var": "",
@@ -521,7 +521,7 @@
 
     "_AMED_trt": {
         "long_name": "Additional Medicare tax rate",
-        "description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding additional Medicare threshold. ",
+        "description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding additional Medicare threshold.",
         "irs_ref": "Form 8959, line 7, in-line. ",
         "start_year": 2013,
         "col_var": "",
@@ -1307,7 +1307,7 @@
 
     "_NIIT_thd": {
         "long_name": "Net Investment Income Tax income threshold (UIMC)",
-        "description": "If one taxpayer's MAGI (modified AGI) is more than this threshold, he or she is subject to the additional Medicare tax. ",
+        "description": "If MAGI (modified AGI) is more than this threshold, tax unit is subject to the Net Investment Income Tax.",
         "irs_ref": "Form 8960, line 14, instructions. ",
         "notes": "",
         "start_year": 2013,
@@ -1320,8 +1320,8 @@
     },
 
     "_NIIT_trt": {
-        "long_name": "Net Investment Income Tax rate (UIMC)",
-        "description": "Also called the Unearned Income Medicare Contribution. The lessor of net investment income and the amount by which MAGI exceeds a threshold is taxed at this rate.",
+        "long_name": "Net Investment Income Tax rate",
+        "description": "The amount by which MAGI exceeds _NIIT_thd is taxed at this rate.",
         "irs_ref": "Form 8960, line 21, in-line. ",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -876,17 +876,18 @@
         "validations": {"min": "_II_brk6"}
     },
 
-    "_CG_as_II": {
-        "long_name": "Long term capital gains and qualified dividends taxed same as other income",
-        "description": "This zero/one parameter specifies whether or not long term capital gains and qualified dividends are taxed like other income.",
-        "irs_ref": "Current-law value is zero and Schedule D tax rules are used.",
+    "_CG_nodiff": {
+        "long_name": "Long term capital gains and qualified dividends taxed no different than other income",
+        "description": "Specifies whether or not long term capital gains and qualified dividends are taxed like other income.",
+        "irs_ref": "Current-law value is zero implying different tax treatment in Schedule D and AMT; a value of one implies no different tax treatment in both regular and alternative minimum tax rules.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0]
+        "value": [0],
+        "validations": {"min": 0, "max": 1}
     },
 
     "_CG_rt1": {

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -682,14 +682,10 @@ def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
 
     # different AMT taxation of LTCG+QDIV income
     if CG_nodiff == 0.:
-        if c24516 == 0.:
-            c62740 = c24517 + e24515
-        else:
-            c62740 = min(max(0., c24516), c24517 + e24515)
+        c62740 = min(c24516, e24515 + c24517)
         ngamtinc = max(0., amtinc - c62740)  # amtinc net of LTCG+QDIV income
-        c62745 = (AMT_trt1 * ngamtinc +
-                  AMT_trt2 * max(0., (ngamtinc - (AMT_tthd / _sep))))
-
+        ngtax = (AMT_trt1 * ngamtinc +
+                 AMT_trt2 * max(0., (ngamtinc - (AMT_tthd / _sep))))
         base_rt1 = 0.
         line45 = max(0., AMT_CG_thd1[MARS - 1] - c24520)
         line46 = min(amtinc, c24517)
@@ -716,7 +712,7 @@ def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
                  AMT_CG_rt3 * base_rt3 +
                  AMT_CG_rt4 * base_rt4)
         cgtax += c62770
-        diffamt = c62745 + cgtax  # AMT tax liab with differential taxation
+        diffamt = ngtax + cgtax  # AMT tax liab with differential taxation
     else:  # if CG_nodiff is not zero
         diffamt = sameamt  # AMT tax liab with same tax treatment of all income
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -650,26 +650,21 @@ def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
     # pylint: disable=too-many-statements,too-many-branches
 
     # taxation of all AMT taxable income, AMT liability is sameamt
-    c62720 = c24517
-    c60260 = e00700
-    c62730 = e24515
     if _standard == 0.0:
         if f6251 == 1:
             cmbtp = cmbtp_itemizer
         else:
             cmbtp = 0.
-        c62100 = (c00100 - c04470 +
+        c62100 = (c00100 - e00700 - c04470 +
                   max(0., min(c17000, 0.025 * c00100)) +
-                  c18300 -
-                  c60260 + c20800 - c21040)
-        c62100 += cmbtp
+                  c18300 + c20800 - c21040)
     if _standard > 0.0:
         if f6251 == 1:
             cmbtp = cmbtp_standard
         else:
             cmbtp = 0.
-        c62100 = c00100 - c60260
-        c62100 += cmbtp
+        c62100 = c00100 - e00700
+    c62100 += cmbtp
     if MARS == 3 or MARS == 6:
         amtsepadd = max(0.,
                         min(AMT_thd_MarriedS, 0.25 * (c62100 - AMT_em_pe)))
@@ -688,18 +683,18 @@ def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
     # different AMT taxation of LTCG+QDIV income
     if CG_nodiff == 0.:
         if c24516 == 0.:
-            c62740 = c62720 + c62730
+            c62740 = c24517 + e24515
         else:
-            c62740 = min(max(0., c24516), c62720 + c62730)
+            c62740 = min(max(0., c24516), c24517 + e24515)
         ngamtinc = max(0., amtinc - c62740)  # amtinc net of LTCG+QDIV income
         c62745 = (AMT_trt1 * ngamtinc +
                   AMT_trt2 * max(0., (ngamtinc - (AMT_tthd / _sep))))
 
         amt5pc = 0.
         line45 = max(0., AMT_CG_thd1[MARS - 1] - c24520)
-        line46 = min(amtinc, c62720)
+        line46 = min(amtinc, c24517)
         line47 = min(line45, line46)
-        line48 = min(amtinc, c62720) - line47
+        line48 = min(amtinc, c24517) - line47
         amt15pc = min(line48, max(0., AMT_CG_thd2[MARS - 1] - c24520 - line45))
         amtxtr = min(line48, max(0., AMT_CG_thd3[MARS - 1] - c24520 - line45))
         if ngamtinc == (amt15pc + line47):

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -528,9 +528,6 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
     else:
         hasqdivltcg = 0  # no qualified dividends or long-term capital gains
 
-    if CG_nodiff != 0.:
-        hasqdivltcg = 0  # no special taxation of qual divids and l-t cap gains
-
     if hasqdivltcg == 1:
 
         dwks1 = c04800
@@ -554,52 +551,52 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
         dwks12 = min(dwks9, dwks11)
         dwks13 = dwks10 - dwks12
         dwks14 = max(0., dwks1 - dwks13)
-        dwks16 = min(CG_thd1[MARS - 1], dwks1)
-        dwks17 = min(dwks14, dwks16)
-        dwks18 = max(0., dwks1 - dwks10)
-        dwks19 = max(dwks17, dwks18)
-        dwks20 = dwks16 - dwks17
-        lowest_rate_tax = CG_rt1 * dwks20
-        # break in worksheet lines
-        dwks21 = min(dwks1, dwks13)
-        dwks22 = dwks20
-        dwks23 = max(0., dwks21 - dwks22)
-        dwks25 = min(CG_thd2[MARS - 1], dwks1)
-        dwks26 = dwks19 + dwks20
-        dwks27 = max(0., dwks25 - dwks26)
-        dwks28 = min(dwks23, dwks27)
-        dwks29 = CG_rt2 * dwks28
-        dwks30 = dwks22 + dwks28
-        dwks31 = dwks21 - dwks30
-        dwks32 = CG_rt3 * dwks31
-        hi_base = max(0., dwks31 - CG_thd3[MARS - 1])
-        hi_incremental_rate = CG_rt4 - CG_rt3
-        highest_rate_incremental_tax = hi_incremental_rate * hi_base
-        # break in worksheet lines
-        dwks33 = min(dwks9, e24518)
-        dwks34 = dwks10 + dwks19
-        dwks36 = max(0., dwks34 - dwks1)
-        dwks37 = max(0., dwks33 - dwks36)
-        dwks38 = 0.25 * dwks37
-        # break in worksheet lines
-        dwks39 = dwks19 + dwks20 + dwks28 + dwks31 + dwks37
-        dwks40 = dwks1 - dwks39
-        dwks41 = 0.28 * dwks40
-        dwks42 = SchXYZ(dwks19, MARS, e00900, e26270,
-                        PT_rt1, PT_rt2, PT_rt3, PT_rt4, PT_rt5,
-                        PT_rt6, PT_rt7, PT_rt8,
-                        PT_brk1, PT_brk2, PT_brk3, PT_brk4, PT_brk5,
-                        PT_brk6, PT_brk7,
-                        II_rt1, II_rt2, II_rt3, II_rt4, II_rt5,
-                        II_rt6, II_rt7, II_rt8,
-                        II_brk1, II_brk2, II_brk3, II_brk4, II_brk5,
-                        II_brk6, II_brk7)
-        dwks43 = (dwks29 + dwks32 + dwks38 + dwks41 + dwks42 +
-                  lowest_rate_tax + highest_rate_incremental_tax)
-        dwks44 = c05200
-        dwks45 = min(dwks43, dwks44)
-
-        c24580 = dwks45
+        if CG_nodiff == 0.:
+            dwks16 = min(CG_thd1[MARS - 1], dwks1)
+            dwks17 = min(dwks14, dwks16)
+            dwks18 = max(0., dwks1 - dwks10)
+            dwks19 = max(dwks17, dwks18)
+            dwks20 = dwks16 - dwks17
+            lowest_rate_tax = CG_rt1 * dwks20
+            # break in worksheet lines
+            dwks21 = min(dwks1, dwks13)
+            dwks22 = dwks20
+            dwks23 = max(0., dwks21 - dwks22)
+            dwks25 = min(CG_thd2[MARS - 1], dwks1)
+            dwks26 = dwks19 + dwks20
+            dwks27 = max(0., dwks25 - dwks26)
+            dwks28 = min(dwks23, dwks27)
+            dwks29 = CG_rt2 * dwks28
+            dwks30 = dwks22 + dwks28
+            dwks31 = dwks21 - dwks30
+            dwks32 = CG_rt3 * dwks31
+            hi_base = max(0., dwks31 - CG_thd3[MARS - 1])
+            hi_incremental_rate = CG_rt4 - CG_rt3
+            highest_rate_incremental_tax = hi_incremental_rate * hi_base
+            # break in worksheet lines
+            dwks33 = min(dwks9, e24518)
+            dwks34 = dwks10 + dwks19
+            dwks36 = max(0., dwks34 - dwks1)
+            dwks37 = max(0., dwks33 - dwks36)
+            dwks38 = 0.25 * dwks37
+            # break in worksheet lines
+            dwks39 = dwks19 + dwks20 + dwks28 + dwks31 + dwks37
+            dwks40 = dwks1 - dwks39
+            dwks41 = 0.28 * dwks40
+            dwks42 = SchXYZ(dwks19, MARS, e00900, e26270,
+                            PT_rt1, PT_rt2, PT_rt3, PT_rt4, PT_rt5,
+                            PT_rt6, PT_rt7, PT_rt8,
+                            PT_brk1, PT_brk2, PT_brk3, PT_brk4, PT_brk5,
+                            PT_brk6, PT_brk7,
+                            II_rt1, II_rt2, II_rt3, II_rt4, II_rt5,
+                            II_rt6, II_rt7, II_rt8,
+                            II_brk1, II_brk2, II_brk3, II_brk4, II_brk5,
+                            II_brk6, II_brk7)
+            dwks43 = (dwks29 + dwks32 + dwks38 + dwks41 + dwks42 +
+                      lowest_rate_tax + highest_rate_incremental_tax)
+            dwks44 = c05200
+            dwks45 = min(dwks43, dwks44)
+            c24580 = dwks45
         c24516 = dwks10
         c24517 = dwks13
         c24520 = dwks14

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -596,20 +596,24 @@ def AGIsurtax(c00100, MARS, AGI_surtax_trt, AGI_surtax_thd, _taxbc, _surtax):
 
 
 @iterate_jit(nopython=True)
-def AMTInc(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
-           c04470, c17000, c20800, c21040, e24515, MARS, _sep,
-           c24520, c05700, e62900, e00700, c24516, age_head, _earned,
-           cmbtp_itemizer, cmbtp_standard,
-           KT_c_Age, AMT_tthd, AMT_thd_MarriedS,
-           AMT_em, AMT_prt, AMT_trt1, AMT_trt2,
-           AMT_Child_em, AMT_em_ps, AMT_em_pe,
-           AMT_CG_thd1, AMT_CG_thd2, AMT_CG_thd3, AMT_CG_rt1, AMT_CG_rt2,
-           AMT_CG_rt3, AMT_CG_rt4, c05800, c09600, c62100):
-
+def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
+        c04470, c17000, c20800, c21040, e24515, MARS, _sep,
+        c24520, c05700, e62900, e00700, c24516, age_head, _earned,
+        cmbtp_itemizer, cmbtp_standard,
+        KT_c_Age, AMT_tthd, AMT_thd_MarriedS,
+        AMT_em, AMT_prt, AMT_trt1, AMT_trt2,
+        AMT_Child_em, AMT_em_ps, AMT_em_pe, CG_nodiff,
+        AMT_CG_thd1, AMT_CG_thd2, AMT_CG_thd3, AMT_CG_rt1, AMT_CG_rt2,
+        AMT_CG_rt3, AMT_CG_rt4, c05800, c09600, c62100):
     """
-    AMTInc function computes Alternative Minimum Tax taxable income
+    AMT function computes Alternative Minimum Tax taxable income and liability:
+    c62100 is AMT taxable income
+    c09600 is AMT tax liability
+    c05800 is total (reg + AMT) income tax liability before credits
     """
     # pylint: disable=too-many-statements,too-many-branches
+
+    # taxation of all AMT taxable income, AMT liability is sameamt
     c62720 = c24517
     c60260 = e00700
     c62730 = e24515
@@ -641,53 +645,56 @@ def AMTInc(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
     if age_head != 0 and age_head < KT_c_Age:
         c62600 = min(c62600, _earned + AMT_Child_em)
     c62700 = max(0., c62100 - c62600)
-    alminc = c62700  # because no foreign earned income exclusion
-    amtfei = 0.
-    c62780 = (AMT_trt1 * alminc +
-              AMT_trt2 * max(0., (alminc - (AMT_tthd / _sep) - amtfei)))
+    amtinc = c62700  # because no foreign earned income exclusion
+    sameamt = (AMT_trt1 * amtinc +
+               AMT_trt2 * max(0., (amtinc - (AMT_tthd / _sep))))
+
+    # different AMT taxation of LTCG+QDIV income
+    if CG_nodiff == 0.:
+        if c24516 == 0.:
+            c62740 = c62720 + c62730
+        else:
+            c62740 = min(max(0., c24516), c62720 + c62730)
+        ngamtinc = max(0., amtinc - c62740)  # amtinc net of LTCG+QDIV income
+        c62745 = (AMT_trt1 * ngamtinc +
+                  AMT_trt2 * max(0., (ngamtinc - (AMT_tthd / _sep))))
+
+        amt5pc = 0.
+        line45 = max(0., AMT_CG_thd1[MARS - 1] - c24520)
+        line46 = min(amtinc, c62720)
+        line47 = min(line45, line46)
+        line48 = min(amtinc, c62720) - line47
+        amt15pc = min(line48, max(0., AMT_CG_thd2[MARS - 1] - c24520 - line45))
+        amtxtr = min(line48, max(0., AMT_CG_thd3[MARS - 1] - c24520 - line45))
+        if ngamtinc == (amt15pc + line47):
+            amt20pc = 0.
+            amtxtrpc = 0.
+        else:
+            amt20pc = line46 - amt15pc - line47
+            amtxtrpc = max(0., amt15pc - amtxtr)
+        if c62740 == 0.:
+            amt25pc = 0.
+        else:
+            amt25pc = max(0., amtinc - ngamtinc - line46)
+        c62747 = AMT_CG_rt1 * amt5pc
+        c62755 = AMT_CG_rt2 * amt15pc
+        c62760 = AMT_CG_rt3 * amt20pc
+        amtxtr = AMT_CG_rt4 * amtxtrpc
+        c62770 = 0.25 * amt25pc  # tax rate on "Unrecaptured Schedule E Gain"
+        # cgtxamt is the amount of line62 without line42 being added
+        cgtxamt = c62747 + c62755 + c62760 + amtxtr + c62770
+        diffamt = c62745 + cgtxamt  # AMT tax liab with differential taxation
+    else:  # if CG_nodiff is not zero
+        diffamt = sameamt  # AMT tax liab with same tax treatment of all income
+
+    # final AMT calculations
+    c62800 = min(sameamt, diffamt)
     if f6251 == 1:
         c62900 = e62900
     else:
         c62900 = e07300
-    if c24516 == 0.:
-        c62740 = c62720 + c62730
-    else:
-        c62740 = min(max(0., c24516), c62720 + c62730)
-    ngamty = max(0., alminc - c62740)
-    c62745 = (AMT_trt1 * ngamty +
-              AMT_trt2 * max(0., (ngamty - (AMT_tthd / _sep))))
-    # Capital Gain for AMT
-    tamt2 = 0.
-    amt5pc = 0.
-    line45 = max(0., AMT_CG_thd1[MARS - 1] - c24520)
-    line46 = min(alminc, c62720)
-    line47 = min(line45, line46)
-    line48 = min(alminc, c62720) - line47
-    amt15pc = min(line48, max(0., AMT_CG_thd2[MARS - 1] - c24520 - line45))
-    amt_xtr = min(line48, max(0., AMT_CG_thd3[MARS - 1] - c24520 - line45))
-
-    if ngamty != (amt15pc + line47):
-        amt20pc = line46 - amt15pc - line47
-        amtxtrpc = max(0., amt15pc - amt_xtr)
-    else:
-        amt20pc = 0.
-        amtxtrpc = 0.
-
-    if c62740 != 0.:
-        amt25pc = max(0., alminc - ngamty - line46)
-    else:
-        amt25pc = 0.
-    c62747 = AMT_CG_rt1 * amt5pc
-    c62755 = AMT_CG_rt2 * amt15pc
-    c62760 = AMT_CG_rt3 * amt20pc
-    amt_xtr = AMT_CG_rt4 * amtxtrpc
-    c62770 = 0.25 * amt25pc  # tax rate on "Unrecaptured Schedule E Gain"
-    # tamt2 is the amount of line62 without 42 being added
-    tamt2 = c62747 + c62755 + c62760 + c62770 + amt_xtr
-    c62800 = min(c62780, c62745 + tamt2 - amtfei)
     c63000 = c62800 - c62900
-    c63100 = _taxbc - e07300 - c05700
-    c63100 = max(0., c63100)
+    c63100 = max(0., _taxbc - e07300 - c05700)
     c63200 = max(0., c63000 - c63100)
     c09600 = c63200
     c05800 = _taxbc + c63200

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -690,31 +690,33 @@ def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
         c62745 = (AMT_trt1 * ngamtinc +
                   AMT_trt2 * max(0., (ngamtinc - (AMT_tthd / _sep))))
 
-        amt5pc = 0.
+        base_rt1 = 0.
         line45 = max(0., AMT_CG_thd1[MARS - 1] - c24520)
         line46 = min(amtinc, c24517)
         line47 = min(line45, line46)
         line48 = min(amtinc, c24517) - line47
-        amt15pc = min(line48, max(0., AMT_CG_thd2[MARS - 1] - c24520 - line45))
-        amtxtr = min(line48, max(0., AMT_CG_thd3[MARS - 1] - c24520 - line45))
-        if ngamtinc == (amt15pc + line47):
-            amt20pc = 0.
-            amtxtrpc = 0.
+        base_rt2 = min(line48,
+                       max(0., AMT_CG_thd2[MARS - 1] - c24520 - line45))
+        amtxtr = min(line48,
+                     max(0., AMT_CG_thd3[MARS - 1] - c24520 - line45))
+        if ngamtinc == (base_rt2 + line47):
+            base_rt3 = 0.
+            base_rt4 = 0.
         else:
-            amt20pc = line46 - amt15pc - line47
-            amtxtrpc = max(0., amt15pc - amtxtr)
+            base_rt3 = line46 - base_rt2 - line47
+            base_rt4 = max(0., base_rt2 - amtxtr)
         if c62740 == 0.:
             amt25pc = 0.
         else:
             amt25pc = max(0., amtinc - ngamtinc - line46)
-        c62747 = AMT_CG_rt1 * amt5pc
-        c62755 = AMT_CG_rt2 * amt15pc
-        c62760 = AMT_CG_rt3 * amt20pc
-        amtxtr = AMT_CG_rt4 * amtxtrpc
         c62770 = 0.25 * amt25pc  # tax rate on "Unrecaptured Schedule E Gain"
         # cgtxamt is the amount of line62 without line42 being added
-        cgtxamt = c62747 + c62755 + c62760 + amtxtr + c62770
-        diffamt = c62745 + cgtxamt  # AMT tax liab with differential taxation
+        cgtax = (AMT_CG_rt1 * base_rt1 +
+                 AMT_CG_rt2 * base_rt2 +
+                 AMT_CG_rt3 * base_rt3 +
+                 AMT_CG_rt4 * base_rt4)
+        cgtax += c62770
+        diffamt = c62745 + cgtax  # AMT tax liab with differential taxation
     else:  # if CG_nodiff is not zero
         diffamt = sameamt  # AMT tax liab with same tax treatment of all income
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -484,13 +484,13 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
              e24515, e24518, MARS, c04800, c05200,
              II_rt1, II_rt2, II_rt3, II_rt4, II_rt5, II_rt6, II_rt7, II_rt8,
              II_brk1, II_brk2, II_brk3, II_brk4, II_brk5, II_brk6, II_brk7,
-             CG_as_II,
+             CG_nodiff,
              CG_rt1, CG_rt2, CG_rt3, CG_rt4, CG_thd1, CG_thd2, CG_thd3,
              c24516, c24517, c24520, c05700, _taxbc):
     """
     GainsTax function implements (2015) Schedule D Tax Worksheet logic for
     the special taxation of long-term capital gains and qualified dividends
-    if CG_as_II is false (that is, zero)
+    if CG_nodiff is false (that is, zero)
     """
     # pylint: disable=too-many-statements,too-many-branches
     if c01000 > 0. or c23650 > 0. or p23250 > 0. or e01100 > 0. or e00650 > 0.:
@@ -498,7 +498,7 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
     else:
         hasqdivltcg = 0  # no qualified dividends or long-term capital gains
 
-    if CG_as_II != 0.:
+    if CG_nodiff != 0.:
         hasqdivltcg = 0  # no special taxation of qual divids and l-t cap gains
 
     if hasqdivltcg == 1:

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -686,20 +686,21 @@ def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
         ngamtinc = max(0., amtinc - c62740)  # amtinc net of LTCG+QDIV income
         ngtax = (AMT_trt1 * ngamtinc +
                  AMT_trt2 * max(0., (ngamtinc - (AMT_tthd / _sep))))
-        base_rt1 = 0.
         line45 = max(0., AMT_CG_thd1[MARS - 1] - c24520)
         line46 = min(amtinc, c24517)
-        line47 = min(line45, line46)
-        line48 = min(amtinc, c24517) - line47
-        base_rt2 = min(line48,
-                       max(0., AMT_CG_thd2[MARS - 1] - c24520 - line45))
+        base_rt1 = min(line45, line46)  # line47 amount
+        line48 = line46 - base_rt1
+        line53 = max(0., AMT_CG_thd2[MARS - 1] - c24520 - line45)
+        # line53 use of c24520 ia questionable   ^^^^^^
+        #   because line45 already subtracts out c24520
+        base_rt2 = min(line48, line53)  # line54 amount
         base_xtr = min(line48,
                        max(0., AMT_CG_thd3[MARS - 1] - c24520 - line45))
-        if ngamtinc == (base_rt2 + line47):
+        if ngamtinc == (base_rt2 + base_rt1):
             base_rt3 = 0.
             base_rt4 = 0.
         else:
-            base_rt3 = line46 - base_rt2 - line47
+            base_rt3 = line46 - base_rt2 - base_rt1
             base_rt4 = max(0., base_rt2 - base_xtr)
         if c62740 == 0.:
             amt25pc = 0.

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -697,20 +697,20 @@ def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
         line48 = min(amtinc, c24517) - line47
         base_rt2 = min(line48,
                        max(0., AMT_CG_thd2[MARS - 1] - c24520 - line45))
-        amtxtr = min(line48,
-                     max(0., AMT_CG_thd3[MARS - 1] - c24520 - line45))
+        base_xtr = min(line48,
+                       max(0., AMT_CG_thd3[MARS - 1] - c24520 - line45))
         if ngamtinc == (base_rt2 + line47):
             base_rt3 = 0.
             base_rt4 = 0.
         else:
             base_rt3 = line46 - base_rt2 - line47
-            base_rt4 = max(0., base_rt2 - amtxtr)
+            base_rt4 = max(0., base_rt2 - base_xtr)
         if c62740 == 0.:
             amt25pc = 0.
         else:
             amt25pc = max(0., amtinc - ngamtinc - line46)
         c62770 = 0.25 * amt25pc  # tax rate on "Unrecaptured Schedule E Gain"
-        # cgtxamt is the amount of line62 without line42 being added
+        # cgtax is the amount of line62 without line42 being added
         cgtax = (AMT_CG_rt1 * base_rt1 +
                  AMT_CG_rt2 * base_rt2 +
                  AMT_CG_rt3 * base_rt3 +

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -528,6 +528,9 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
     else:
         hasqdivltcg = 0  # no qualified dividends or long-term capital gains
 
+    if CG_nodiff != 0.:
+        hasqdivltcg = 0  # no qualified dividends or long-term capital gains
+
     if hasqdivltcg == 1:
 
         dwks1 = c04800
@@ -551,52 +554,52 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
         dwks12 = min(dwks9, dwks11)
         dwks13 = dwks10 - dwks12
         dwks14 = max(0., dwks1 - dwks13)
-        if CG_nodiff == 0.:
-            dwks16 = min(CG_thd1[MARS - 1], dwks1)
-            dwks17 = min(dwks14, dwks16)
-            dwks18 = max(0., dwks1 - dwks10)
-            dwks19 = max(dwks17, dwks18)
-            dwks20 = dwks16 - dwks17
-            lowest_rate_tax = CG_rt1 * dwks20
-            # break in worksheet lines
-            dwks21 = min(dwks1, dwks13)
-            dwks22 = dwks20
-            dwks23 = max(0., dwks21 - dwks22)
-            dwks25 = min(CG_thd2[MARS - 1], dwks1)
-            dwks26 = dwks19 + dwks20
-            dwks27 = max(0., dwks25 - dwks26)
-            dwks28 = min(dwks23, dwks27)
-            dwks29 = CG_rt2 * dwks28
-            dwks30 = dwks22 + dwks28
-            dwks31 = dwks21 - dwks30
-            dwks32 = CG_rt3 * dwks31
-            hi_base = max(0., dwks31 - CG_thd3[MARS - 1])
-            hi_incremental_rate = CG_rt4 - CG_rt3
-            highest_rate_incremental_tax = hi_incremental_rate * hi_base
-            # break in worksheet lines
-            dwks33 = min(dwks9, e24518)
-            dwks34 = dwks10 + dwks19
-            dwks36 = max(0., dwks34 - dwks1)
-            dwks37 = max(0., dwks33 - dwks36)
-            dwks38 = 0.25 * dwks37
-            # break in worksheet lines
-            dwks39 = dwks19 + dwks20 + dwks28 + dwks31 + dwks37
-            dwks40 = dwks1 - dwks39
-            dwks41 = 0.28 * dwks40
-            dwks42 = SchXYZ(dwks19, MARS, e00900, e26270,
-                            PT_rt1, PT_rt2, PT_rt3, PT_rt4, PT_rt5,
-                            PT_rt6, PT_rt7, PT_rt8,
-                            PT_brk1, PT_brk2, PT_brk3, PT_brk4, PT_brk5,
-                            PT_brk6, PT_brk7,
-                            II_rt1, II_rt2, II_rt3, II_rt4, II_rt5,
-                            II_rt6, II_rt7, II_rt8,
-                            II_brk1, II_brk2, II_brk3, II_brk4, II_brk5,
-                            II_brk6, II_brk7)
-            dwks43 = (dwks29 + dwks32 + dwks38 + dwks41 + dwks42 +
-                      lowest_rate_tax + highest_rate_incremental_tax)
-            dwks44 = c05200
-            dwks45 = min(dwks43, dwks44)
-            c24580 = dwks45
+        dwks16 = min(CG_thd1[MARS - 1], dwks1)
+        dwks17 = min(dwks14, dwks16)
+        dwks18 = max(0., dwks1 - dwks10)
+        dwks19 = max(dwks17, dwks18)
+        dwks20 = dwks16 - dwks17
+        lowest_rate_tax = CG_rt1 * dwks20
+        # break in worksheet lines
+        dwks21 = min(dwks1, dwks13)
+        dwks22 = dwks20
+        dwks23 = max(0., dwks21 - dwks22)
+        dwks25 = min(CG_thd2[MARS - 1], dwks1)
+        dwks26 = dwks19 + dwks20
+        dwks27 = max(0., dwks25 - dwks26)
+        dwks28 = min(dwks23, dwks27)
+        dwks29 = CG_rt2 * dwks28
+        dwks30 = dwks22 + dwks28
+        dwks31 = dwks21 - dwks30
+        dwks32 = CG_rt3 * dwks31
+        hi_base = max(0., dwks31 - CG_thd3[MARS - 1])
+        hi_incremental_rate = CG_rt4 - CG_rt3
+        highest_rate_incremental_tax = hi_incremental_rate * hi_base
+        # break in worksheet lines
+        dwks33 = min(dwks9, e24518)
+        dwks34 = dwks10 + dwks19
+        dwks36 = max(0., dwks34 - dwks1)
+        dwks37 = max(0., dwks33 - dwks36)
+        dwks38 = 0.25 * dwks37
+        # break in worksheet lines
+        dwks39 = dwks19 + dwks20 + dwks28 + dwks31 + dwks37
+        dwks40 = dwks1 - dwks39
+        dwks41 = 0.28 * dwks40
+        dwks42 = SchXYZ(dwks19, MARS, e00900, e26270,
+                        PT_rt1, PT_rt2, PT_rt3, PT_rt4, PT_rt5,
+                        PT_rt6, PT_rt7, PT_rt8,
+                        PT_brk1, PT_brk2, PT_brk3, PT_brk4, PT_brk5,
+                        PT_brk6, PT_brk7,
+                        II_rt1, II_rt2, II_rt3, II_rt4, II_rt5,
+                        II_rt6, II_rt7, II_rt8,
+                        II_brk1, II_brk2, II_brk3, II_brk4, II_brk5,
+                        II_brk6, II_brk7)
+        dwks43 = (dwks29 + dwks32 + dwks38 + dwks41 + dwks42 +
+                  lowest_rate_tax + highest_rate_incremental_tax)
+        dwks44 = c05200
+        dwks45 = min(dwks43, dwks44)
+
+        c24580 = dwks45
         c24516 = dwks10
         c24517 = dwks13
         c24520 = dwks14

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -211,7 +211,7 @@ class Policy(ParametersBase):
         except ValueError as valerr:
             msg = 'Policy reform text below contains invalid JSON:\n'
             msg += str(valerr) + '\n'
-            msg += 'The above location of the first error is approximate.\n'
+            msg += 'Above location of the first error may be approximate.\n'
             msg += 'The invalid JSON reform text is between the lines:\n'
             bline = 'XX----.----1----.----2----.----3----.----4'
             bline += '----.----5----.----6----.----7'


### PR DESCRIPTION
In merged pull request #973, Tax-Calculator logic was extended to allow LTCG+QDIV income to be taxed using the same regular tax brackets and rates as ordinary income (like wages and salaries).  In this pull request, the effect of the new #973 policy parameter (the name of which has been changed from `CG_as_II` to `_CG_nodiff`) has been extended to AMT logic.  Under current law, LTCG+QDIV income is taxed with different brackets and rates in both the regular tax and AMT calculations, and therefore, the current-law-policy value of the `_CG_nodiff` is zero (that is, false).  Changing the value of `_CG_nodiff` to one (that is, true) will cause both regular income tax and AMT logic to include LTCG+QDIV income along with other income in AGI and tax that combined income using the ordinary tax brackets and rates for regular taxes and AMT.  Note that these changes do not affect the role of LTCG+QDIV income in the calculation of NIIT or EITC.

We have conducted a simple test to show that the logic in this pull request seems to work as designed. 

Consider two individuals both sixty years old with no dependents, with $500,000 income and with $200,000 of AMT-preference itemized deductions.  The first of the two has only qualified dividend income, while the second has only wage and salary income.  Using `simtax.py` input format, the two individuals are as follows:
```
$ cat cases.in
1 2015 0 1 0 6000 0 0 500000 0 0 0 0 0 0 200000 0 0 0 0 0 0
2 2015 0 1 0 6000 500000 0 0 0 0 0 0 0 0 200000 0 0 0 0 0 0
```
We specify a simple reform that eliminates the differential tax treatment of LTCG+QDIV income in a JSON reform file with the following contents:
```
$ cat same.json
{"_CG_nodiff":{"2015":[1]}}
```
Under current-law policy (which has a favorable differential tax treatment of LTCG+QDIV income), the individuals have the following tax liabilities:
```
$ python simtax.py cases.in 
$ awk '{print FILENAME,$1,$4,$26,$27,$28}' cases.in.out-simtax
cases.in.out-simtax 1.  85122.50 500000.00  1260.00 72462.50
cases.in.out-simtax 2. 136292.00 500000.00 51292.42 84999.58
```
The first individual pays much less income tax than the second even though they both have AGI equal to $500,000.

Next we simulate income tax liability for these two individuals under the `same.json` reform that eliminates the differential income tax treatment of LTCG+QDIV income.
```
$ python simtax.py cases.in --reform same.json
$ awk '{print FILENAME,$1,$4,$26,$27,$28}' cases.in.out-simtax-same
cases.in.out-simtax-same 1. 147692.00 0.00 500000.00 51292.42 84999.58
cases.in.out-simtax-same 2. 136292.00 0.00 500000.00 51292.42 84999.58
```
Notice that now the first individual pays more tax than before (as expected given this reform) and that the AMT tax liability (that sum of output variables 27 and 28) are exactly the same: $136,292.  But then the question is why does the first individual owe a total income tax (output variable 4) that is $11,400 more than the second individual.  The answer is that the first individual owes an NIIT (net investment income tax) liability of that amount: `11400 = 0.038 * (500000 - 200000)`.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey @codykallen 
