### PR TITLE
[WIP] Add function to calculate cost of Trump dependent care deduction

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -146,6 +146,7 @@ class Calculator(object):
             self.records.zero_out_changing_calculated_vars()
         # pdb.set_trace()
         EI_PayrollTax(self.policy, self.records)
+        DependentCare(self.policy, self.records)
         Adj(self.policy, self.records)
         CapGains(self.policy, self.records)
         SSBenefits(self.policy, self.records)

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -145,6 +145,61 @@
         "value": [0.0]
     },
 
+        "_ALD_Dependents_HC":{
+        "long_name": "Deduction for childcare costs",
+        "description": "This decimal fraction, if greater than zero, reduces the portion of childcare costs that can be deducted from AGI",
+        "irs_ref": "",
+        "notes": "The final adjustment would be (1 - Haircut) * Average childcare costs",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "value": [1.0]
+    },
+
+    "_ALD_Dependents_Child_ec":{
+        "long_name": "National average childcare costs",
+        "description": "The weighted average of childcare costs in the US",
+        "irs_ref":"",
+        "notes": "This is a weighted average of childcare costs in each state",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "value": [7156]
+    },
+
+    "_ALD_Dependents_Elder_ec": {
+        "long_name": "Elderly care exclusion proposed in Trump's tax plan",
+        "description": "A tax payer can take this above the line deduction if they have an elderly dependent",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": [
+            "2013"
+        ],
+        "cpi_inflated": true,
+        "value": [5000]
+    },
+
+    "_ALD_Dependents_thd": {
+        "long_name": "Maximum level of income to qualify for the deduction",
+        "description": "A taxpayer can only claim this deduction if their total income is below this level",
+        "irs_ref": "Form 2441",
+        "note": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[250000, 500000, 250000, 500000, 500000, 250000]]
+    },
+
     "_SS_thd50": {
         "long_name": "Threshold for Social Security benefit taxability 1",
         "description": "The first threshold for Social Security benefit taxability: if taxpayers have provisional income greater than this threshold, up to 50% of their Social Security benefit will be subject to tax under current law.",

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -122,6 +122,7 @@ class Records(object):
         'MARS', 'MIDR', 'RECID',
         'cmbtp_standard', 'cmbtp_itemizer',
         'age_head', 'age_spouse', 'blind_head', 'blind_spouse',
+        'age_dep1', 'age_dep2', 'age_dep3', 'age_dep4', 'age_dep5',
         's006', 'filer'])
 
     # specify set of all Record variables that MUST be read by Tax-Calculator:
@@ -133,7 +134,8 @@ class Records(object):
         'f2441', 'f6251',
         'n24', 'XTOT',
         'MARS', 'MIDR', 'RECID',
-        'age_head', 'age_spouse', 'blind_head', 'blind_spouse'])
+        'age_head', 'age_spouse', 'blind_head', 'blind_spouse',
+        'age_dep1', 'age_dep2', 'age_dep3', 'age_dep4', 'age_dep5'])
 
     # specify set of all Record variables that cannot be read in:
     CALCULATED_VARS = set([
@@ -164,7 +166,7 @@ class Records(object):
         '_iitax', '_refund',
         '_expanded_income', 'c07300', 'c07400',
         'c07600', 'c07240', 'c07260', 'c08000',
-        '_surtax', '_combined', 'personal_credit', 'fstax'])
+        '_surtax', '_combined', 'personal_credit', 'fstax', 'care_deduction'])
 
     INTEGER_CALCULATED_VARS = set(['_num', '_sep', '_exact'])
 

--- a/taxcalc/var_labels.txt
+++ b/taxcalc/var_labels.txt
@@ -1,3 +1,8 @@
+AGE_DEP1 = Age of first dependent
+AGE_DEP2 = Age of second dependent
+AGE_DEP3 = Age of third dependent
+AGE_DEP4 = Age of fourth dependent
+AGE_DEP5 = Age of fifth dependent
 AGE_HEAD = Age in years of taxpayer (i.e., primary filer)
 AGE_SPOUSE = Age in years of spouse (i.e., secondary filer if present)
 BLIND_HEAD = zero/one indicator for taxpayer (i.e., primary filer)


### PR DESCRIPTION
This PR calculates the cost of the above-the-line deduction for child and elderly care [proposed by Trump:](https://www.donaldjtrump.com/policies/tax-plan/?/positions/tax-reform)

> Americans will be able to take an above-the-line deduction for children under age 13 that will be capped at state average for age of child, and for eldercare for a dependent. The exclusion will not be available to taxpayers with total income over $500,000 Married-Joint /$250,000 Single, and because of the cap on the size of the benefit, working and middle class families will see the largest percentage reduction in their taxable income.

It is dependent on variables that will be added to the forthcoming PUF file and I'll drop the WIP label when that new PUF is adopted. At this point I'm mostly looking for feedback on the logic and any other suggestions that could be offered while I work on getting the new PUF out.

I made a new function to calculate rather than adding it into the `Adj` function to keep things readable. I also put the average cost of childcare in the current law policy file, but if there is a better place for it I'm open to suggestions. 

The new PUF required for this function will be ready this week and will be the same as what is currently used just with the ages of the depends in the tax units included.