### PR TITLE
Fix pylint warnings caused by upgrade to pylint 1.5.4

### DIFF
--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -6,12 +6,11 @@ Implement Numba JIT decorators used to speed-up tax-calculating functions.
 # pylint --disable=locally-disabled decorators.py
 # (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
-
-import inspect
-from .policy import Policy
-from six import StringIO
 import ast
+import inspect
 import toolz
+from six import StringIO
+from .policy import Policy
 
 
 def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
@@ -31,26 +30,25 @@ def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
     return wrap
 
 
-# pylint: disable=invalid-name
 try:
-    import numba
-    jit = numba.jit
+    import numba  # pylint: disable=wrong-import-order,wrong-import-position
+    jit = numba.jit  # pylint: disable=invalid-name
     DO_JIT = True
 except (ImportError, AttributeError):
-    jit = id_wrapper
+    jit = id_wrapper  # pylint: disable=invalid-name
     DO_JIT = False
 # One way to use the Python debugger is to do these two things:
 #    (a) uncomment the two lines below item (b) in this comment, and
 #    (b) import pdb package and call pdb.set_trace() in calculator.py
-# jit = id_wrapper  # uncomment this and next line to use debugger
-# DO_JIT = False  # uncomment this and prior line to use debugger
+# jit = id_wrapper
+# DO_JIT = False
 
 
 class GetReturnNode(ast.NodeVisitor):
     """
     A NodeVisitor to get the return tuple names from a calc-style function.
     """
-    def visit_Return(self, node):  # pylint: disable=no-self-use
+    def visit_Return(self, node):  # pylint: disable=invalid-name,no-self-use
         """
         visit_Return is used by NodeVisitor.visit method.
         """
@@ -203,7 +201,6 @@ def apply_jit(dtype_sig_out, dtype_sig_in, parameters=None, **kwargs):
         make_wrapper function nested in apply_jit function.
         """
         theargs = inspect.getargspec(func).args
-        # pylint: disable=star-args
         jitted_apply = make_apply_function(func, dtype_sig_out,
                                            dtype_sig_in, parameters, **kwargs)
 
@@ -279,7 +276,6 @@ def iterate_jit(parameters=None, **kwargs):
             raise ValueError("Can't find return statement in function!")
 
         # Now create the apply-style possibly-jitted function
-        # pylint: disable=star-args
         applied_jitted_f = make_apply_function(func,
                                                list(reversed(all_out_args)),
                                                in_args,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -13,9 +13,9 @@ Tax-Calculator functions that calculate payroll and individual income taxes.
 
 
 import math
+import copy
 import numpy as np
 from .decorators import iterate_jit, jit
-import copy
 
 
 @iterate_jit(nopython=True)
@@ -775,7 +775,7 @@ def EITC(MARS, DSI, EIC, c00100, e00300, e00400, e00600, c01000,
     if EIC == 0:
         # enforce age eligibility rule for those with no EITC-eligible children
         # (assume that an unknown age_* value implies EITC age eligibility)
-        # pylint: disable=bad-continuation
+        # pylint: disable=bad-continuation,too-many-boolean-expressions
         if MARS == 2:
             if (age_head >= EITC_MinEligAge and
                 age_head <= EITC_MaxEligAge) or \

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -7,10 +7,10 @@ Tax-Calculator tax-filing-unit Records class.
 # (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 
-import pandas as pd
-import numpy as np
 import os
 import six
+import numpy as np
+import pandas as pd
 from pkg_resources import resource_stream, Requirement, DistributionNotFound
 
 

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -8,8 +8,8 @@ Tax-Calculator simple tax input-output class.
 
 import os
 import sys
-import six
 import re
+import six
 import pandas as pd
 from .policy import Policy
 from .records import Records

--- a/taxcalc/taxbrain/behavior.py
+++ b/taxcalc/taxbrain/behavior.py
@@ -20,7 +20,7 @@ import sys
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 PUFCSV_PATH = os.path.join(CUR_PATH, '..', '..', 'puf.csv')
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-# pylint: disable=import-error
+# pylint: disable=wrong-import-position,import-error
 from taxcalc import Policy, Records, Calculator, Behavior
 
 

--- a/taxcalc/taxbrain/consumption.py
+++ b/taxcalc/taxbrain/consumption.py
@@ -21,7 +21,7 @@ import numpy as np
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 PUFCSV_PATH = os.path.join(CUR_PATH, '..', '..', 'puf.csv')
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-# pylint: disable=import-error
+# pylint: disable=wrong-import-position,import-error
 from taxcalc import Policy, Records, Calculator, Consumption
 
 

--- a/taxcalc/taxbrain/make_reforms.py
+++ b/taxcalc/taxbrain/make_reforms.py
@@ -21,7 +21,8 @@ import argparse
 import numpy as np
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-from taxcalc import Policy  # pylint: disable=import-error
+# pylint: disable=wrong-import-position,import-error
+from taxcalc import Policy
 
 
 PARAMS_NOT_SCALED = set(['_ACTC_ChildNum',

--- a/taxcalc/taxbrain/reforms.py
+++ b/taxcalc/taxbrain/reforms.py
@@ -20,9 +20,11 @@ import sys
 import re
 import json
 from time import sleep
+import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 PUF_PATH = os.path.join(CUR_PATH, '..', '..', 'puf.csv')
 CWD_PATH = os.path.join(CUR_PATH, '..', '..', 'chromedriver')
+# pylint: disable=wrong-import-position
 import selenium
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -33,7 +35,6 @@ import pyperclip
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
 # pylint: disable=import-error
 from taxcalc import Policy, Records, Calculator, create_diagnostic_table
-import pandas as pd
 
 
 MIN_START_YEAR = 2013

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -8,11 +8,11 @@ Tests for Tax-Calculator functions.py logic.
 
 import os
 import re
-from taxcalc import IncomeTaxIO, Records  # pylint: disable=import-error
-from io import StringIO
-import pandas as pd
 import ast
+from io import StringIO
 import six
+import pandas as pd
+from taxcalc import IncomeTaxIO, Records  # pylint: disable=import-error
 
 
 class GetFuncDefs(ast.NodeVisitor):

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -7,11 +7,11 @@ Tests for Tax-Calculator IncomeTaxIO class.
 # (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 import os
-from taxcalc import IncomeTaxIO  # pylint: disable=import-error
-from io import StringIO
-import pandas as pd
-import pytest
 import tempfile
+from io import StringIO
+import pytest
+import pandas as pd
+from taxcalc import IncomeTaxIO  # pylint: disable=import-error
 
 
 RAWINPUTFILE_FUNITS = 4

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -18,12 +18,12 @@ Read tax-calculator/TESTING.md for details.
 # (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 import os
-from taxcalc import Policy, Records, Calculator  # pylint: disable=import-error
-from taxcalc import multiyear_diagnostic_table  # pylint: disable=import-error
-import pytest
 import difflib
+import pytest
 import numpy as np
 import pandas as pd
+from taxcalc import Policy, Records, Calculator  # pylint: disable=import-error
+from taxcalc import multiyear_diagnostic_table  # pylint: disable=import-error
 
 
 @pytest.fixture(scope='session')
@@ -84,7 +84,8 @@ def test_agg(tests_path, puf_path):
     # create aggregate diagnostic table using sub sample of records
     fullsample = pd.read_csv(puf_path)
     rn_seed = 80  # to ensure two-percent sub-sample is always the same
-    subsample = fullsample.sample(frac=0.02, random_state=rn_seed)
+    subsample = fullsample.sample(frac=0.02,  # pylint: disable=no-member
+                                  random_state=rn_seed)
     rec_subsample = Records(data=subsample)
     calc_subsample = Calculator(policy=Policy(), records=rec_subsample)
     adt_subsample = multiyear_diagnostic_table(calc_subsample, num_years=nyrs)
@@ -190,10 +191,7 @@ def test_mtr(tests_path, puf_path):
     variable_header = 'PTAX and ITAX mtr histogram bin counts for'
     # compute marginal tax rate (mtr) histograms for each mtr variable
     for var_str in Calculator.MTR_VALID_VARIABLES:
-        if var_str == 'e01400':
-            zero_out = True
-        else:
-            zero_out = False
+        zero_out = (var_str == 'e01400')
         (mtr_ptax, mtr_itax, _) = calc.mtr(variable_str=var_str,
                                            negative_finite_diff=MTR_NEG_DIFF,
                                            zero_out_calculated_vars=zero_out,

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -8,9 +8,9 @@ Tests for Tax-Calculator SimpleTaxIO class.
 # (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 import os
-from taxcalc import SimpleTaxIO  # pylint: disable=import-error
-import pytest
 import tempfile
+import pytest
+from taxcalc import SimpleTaxIO  # pylint: disable=import-error
 
 
 NUM_INPUT_LINES = 4

--- a/taxcalc/validation/csv_in.py
+++ b/taxcalc/validation/csv_in.py
@@ -20,7 +20,8 @@ import pandas as pd
 import numpy as np
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-from taxcalc import Records  # pylint: disable=import-error
+# pylint: disable=wrong-import-position,import-error
+from taxcalc import Records
 
 # specify maximum allowed values for command-line parameters
 MAX_YEAR = 2023  # maximum tax year allowed for tax calculations
@@ -134,6 +135,7 @@ def main(taxyear, rnseed, ssize):
         sys.stderr.write(msg + '\n')
         return 1
     xdf = pd.read_csv(pufcsv_filename)
+    # pylint: disable=no-member
 
     # remove xdf variables not needed in xYY.csv file
     if TRACE:


### PR DESCRIPTION
This pull request eliminates the warnings that appeared after upgrading `pylint` from version 1.4.2 to version 1.5.4.  There is no change in tax-calculating logic or in any tax results.