### PR TITLE
Fix csvdump bug in inctax.py script

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -137,6 +137,8 @@ def main():
     if args.records:
         inctax.output_records(writing_output_file=True)
     elif args.csvdump:
+        inctax.calculate(writing_output_file=False, exact_output=args.exact,
+                         output_weights=args.weights)
         inctax.csv_dump(writing_output_file=True)
     else:
         inctax.calculate(writing_output_file=True, exact_output=args.exact,


### PR DESCRIPTION
Calculate CALCULATED_VARS before doing csvdump in the inctax.py command-line interface to Tax-Calculator.  This pull request does not change any tax-calculating logic, and thus, no tax results or test results are changed.