### PR TITLE
multiyear_diagnostic_table w behavior

### DIFF
--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -548,13 +548,14 @@ def test_multiyear_diagnostic_table_wo_behv(records_2009):
     # extract combined liabilities as a float and
     # adopt units of the raw calculator data in liabilities_x
     liabilities_y = adt.iloc[18].tolist()[0] * 1000000000
-    assert liabilities_x == liabilities_y
+    npt.assert_almost_equal(liabilities_x, liabilities_y, 2)
 
 
 def test_multiyear_diagnostic_table_w_behv(records_2009):
     pol = Policy()
     behv = Behavior()
     calc = Calculator(policy=pol, records=records_2009, behavior=behv)
+    assert calc.current_year == 2013
     reform = {
         2013: {
             '_II_rt7': [0.33],
@@ -573,7 +574,7 @@ def test_multiyear_diagnostic_table_w_behv(records_2009):
     # extract combined liabilities as a float and
     # adopt units of the raw calculator data in liabilities_x
     liabilities_y = adt.iloc[18].tolist()[0] * 1000000000
-    assert liabilities_x == liabilities_y
+    npt.assert_almost_equal(liabilities_x, liabilities_y, 2)
 
 
 @pytest.yield_fixture

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -532,6 +532,50 @@ def test_multiyear_diagnostic_table(records_2009):
     assert isinstance(adt, DataFrame)
 
 
+def test_multiyear_diagnostic_table_wo_behv(records_2009):
+    pol = Policy()
+    calc = Calculator(policy=pol, records=records_2009)
+    reform = {
+        2013: {
+            '_II_rt7': [0.33],
+            '_PT_rt7': [0.33],
+        }}
+    pol.implement_reform(reform)
+    calc.calc_all()
+    liabilities_x = (calc.records._combined *
+                     calc.records.s006).sum()
+    adt = multiyear_diagnostic_table(calc, 1)
+    # extract combined liabilities as a float and
+    # adopt units of the raw calculator data in liabilities_x
+    liabilities_y = adt.iloc[18].tolist()[0] * 1000000000
+    assert liabilities_x == liabilities_y
+
+
+def test_multiyear_diagnostic_table_w_behv(records_2009):
+    pol = Policy()
+    behv = Behavior()
+    calc = Calculator(policy=pol, records=records_2009, behavior=behv)
+    reform = {
+        2013: {
+            '_II_rt7': [0.33],
+            '_PT_rt7': [0.33],
+        }}
+    pol.implement_reform(reform)
+    reform_be = {2013: {'_BE_sub': [0.4],
+                        '_BE_cg': [-3.67]}}
+    behv.update_behavior(reform_be)
+    calc_clp = calc.current_law_version()
+    calc_behv = Behavior.response(calc_clp, calc)
+    calc_behv.calc_all()
+    liabilities_x = (calc_behv.records._combined *
+                     calc_behv.records.s006).sum()
+    adt = multiyear_diagnostic_table(calc_behv, 1)
+    # extract combined liabilities as a float and
+    # adopt units of the raw calculator data in liabilities_x
+    liabilities_y = adt.iloc[18].tolist()[0] * 1000000000
+    assert liabilities_x == liabilities_y
+
+
 @pytest.yield_fixture
 def csvfile():
     txt = ('A,B,C,D,EFGH\n'

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -559,13 +559,8 @@ def multiyear_diagnostic_table(calc, num_years=0):
     cal = copy.deepcopy(calc)
     dtlist = list()
     for iyr in range(1, num_years + 1):
-        if cal.behavior.has_response():
-            cal_clp = cal.current_law_version()
-            cal_br = cal.behavior.response(cal_clp, cal)
-            dtlist.append(create_diagnostic_table(cal_br))
-        else:
-            cal.calc_all()
-            dtlist.append(create_diagnostic_table(cal))
+        cal.calc_all()
+        dtlist.append(create_diagnostic_table(cal))
         if iyr < num_years:
             cal.increment_year()
     return pd.concat(dtlist, axis=1)


### PR DESCRIPTION
Resolves #985. 

The first commits add two tests for the `multiyear_diagnostic_table`. The first test verifies that the `multiyear_diagnostic_table` will generate the same combined liabilities as a calculator without any behavioral response. It passes with master. The second test fails with master, showing that the `multiyear_diagnostic_table` will not generate the same combined liabilities as a calculator that has already responded to behavior. 

The next commits make the second test pass by removing the built-in behavior response from the `multiyear_diagnostic_table`. 