### PR TITLE
Add puf mtr test results following merge of PR#987

### DIFF
--- a/taxcalc/tests/pufcsv_mtr_expect.txt
+++ b/taxcalc/tests/pufcsv_mtr_expect.txt
@@ -46,3 +46,6 @@ PTAX and ITAX mtr histogram bin counts for e18500:
 PTAX and ITAX mtr histogram bin counts for e19200:
 219814 : 219814      0      0      0      0      0      0      0      0      0
 219814 :  31873  27863  18869   5222 135987      0      0      0      0      0
+PTAX and ITAX mtr histogram bin counts for e26270:
+219814 : 219814      0      0      0      0      0      0      0      0      0
+219814 :      0      0      0      0  53605  69550  45986  28210  21788    675


### PR DESCRIPTION
Pull request #987 forgot to add the new results for `e26270` in the `puf_mtr_expect.txt` file.