### PR TITLE
Rename CG_as_II as CG_nodiff (plus other cosmetic changes)

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -132,13 +132,13 @@ class Calculator(object):
     def records(self):
         return self._records
 
-    def TaxInc_to_AMTI(self):
+    def TaxInc_to_AMT(self):
         TaxInc(self.policy, self.records)
         SchXYZTax(self.policy, self.records)
         GainsTax(self.policy, self.records)
         AGIsurtax(self.policy, self.records)
         NetInvIncTax(self.policy, self.records)
-        AMTInc(self.policy, self.records)
+        AMT(self.policy, self.records)
 
     def calc_one_year(self, zero_out_calc_vars=False):
         # calls all the functions except those in calc_all() function
@@ -160,14 +160,14 @@ class Calculator(object):
         item_no_limit = copy.deepcopy(self.records.c21060)
         self.records.c04470 = np.zeros(self.records.dim)
         self.records.c21060 = np.zeros(self.records.dim)
-        self.TaxInc_to_AMTI()
+        self.TaxInc_to_AMT()
         std_taxes = copy.deepcopy(self.records.c05800)
         # Set standard deduction to zero, calculate taxes w/o
         # standard deduction, and store AMT + Regular Tax
         self.records._standard = np.zeros(self.records.dim)
         self.records.c21060 = item_no_limit
         self.records.c04470 = item
-        self.TaxInc_to_AMTI()
+        self.TaxInc_to_AMT()
         item_taxes = copy.deepcopy(self.records.c05800)
         # Replace standard deduction with zero where the taxpayer
         # would be better off itemizing
@@ -178,7 +178,7 @@ class Calculator(object):
         self.records.c21060[:] = np.where(item_taxes < std_taxes,
                                           item_no_limit, 0.)
         # Calculate taxes with optimal itemized deduction
-        self.TaxInc_to_AMTI()
+        self.TaxInc_to_AMT()
         F2441(self.policy, self.records)
         EITC(self.policy, self.records)
         ChildTaxCredit(self.policy, self.records)

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -135,7 +135,7 @@
         "long_name": "Investment income exclusion",
         "description": "This decimal fraction can be applied to limit the investment income included in AGI. ",
         "irs_ref": "Form 1040, line 8a",
-        "notes": "The final taxable investment income will be (1- exclusion) * Investment income. Even though this portion of income wouldn't be included in AGI, it still contributes to Net Investment Income Tax and Earned Income Tax Credit.",
+        "notes": "The final taxable investment income will be (1-_ALD_Investment_ec)*Investment income. Even though the excluded portion of investment income is not included in AGI, it still is included in investment income used to calculate Net Investment Income Tax and Earned Income Tax Credit.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
@@ -508,7 +508,7 @@
 
     "_AMED_thd": {
         "long_name": "Additional Medicare threshold",
-        "description": "If their Medicare wages, RRTA compensation and self-employment income is above this threshold, taxpayers are subject to additional Medicare tax. ",
+        "description": "If their Medicare wages, RRTA compensation and self-employment income is above this threshold, taxpayers are subject to additional Medicare tax.",
         "irs_ref": "Form 8959, line 5, in-line. ",
         "start_year": 2013,
         "col_var": "",
@@ -521,7 +521,7 @@
 
     "_AMED_trt": {
         "long_name": "Additional Medicare tax rate",
-        "description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding additional Medicare threshold. ",
+        "description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding additional Medicare threshold.",
         "irs_ref": "Form 8959, line 7, in-line. ",
         "start_year": 2013,
         "col_var": "",
@@ -876,17 +876,18 @@
         "validations": {"min": "_II_brk6"}
     },
 
-    "_CG_as_II": {
-        "long_name": "Long term capital gains and qualified dividends taxed same as other income",
-        "description": "This zero/one parameter specifies whether or not long term capital gains and qualified dividends are taxed like other income.",
-        "irs_ref": "Current-law value is zero and Schedule D tax rules are used.",
+    "_CG_nodiff": {
+        "long_name": "Long term capital gains and qualified dividends taxed no different than other income",
+        "description": "Specifies whether or not long term capital gains and qualified dividends are taxed like other income.",
+        "irs_ref": "Current-law value is zero implying different tax treatment in Schedule D and AMT; a value of one implies same tax treatment in both regular and alternative minimum tax rules, but the same treatment can differ for regular and AMT.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0]
+        "value": [0],
+        "validations": {"min": 0, "max": 1}
     },
 
     "_CG_rt1": {
@@ -1079,7 +1080,7 @@
 
     "_AMT_em": {
         "long_name": "AMT exemption amount",
-        "description": "The amount of AMTI exempted from AMT.",
+        "description": "The amount of AMT taxable income exempted from AMT.",
         "irs_ref": "Form 1040, line 45, instruction (Worksheet).",
         "notes": "",
         "start_year": 2013,
@@ -1099,7 +1100,7 @@
 
     "_AMT_prt": {
         "long_name": "AMT exemption phaseout rate",
-        "description": "AMT exemption will decrease at this rate for each dollar of AMTI exceeding AMT phaseout start. ",
+        "description": "AMT exemption will decrease at this rate for each dollar of AMT taxable income exceeding AMT phaseout start. ",
         "irs_ref": "Form 6251, line 29, instructions. ",
         "notes": "",
         "start_year": 2013,
@@ -1112,7 +1113,7 @@
     },
 
     "_AMT_trt1": {
-        "long_name": "AMT rate for AMTI under the surtax threshold",
+        "long_name": "AMT rate for AMT taxable income under the surtax threshold",
         "description": "The tax rate applied to the portion of AMT income below the surtax threshold. ",
         "irs_ref": "Form 6251, line 31, in-line. ",
         "notes": "",
@@ -1126,7 +1127,7 @@
     },
 
     "_AMT_trt2": {
-        "long_name": "Additional AMT rate for AMTI above the surtax threshold",
+        "long_name": "Additional AMT rate for AMT taxable income above the surtax threshold",
         "description": "The tax rate applied to the portion of AMT income above the surtax threshold.",
         "irs_ref": "Form 6251, line 31, in-line. ",
         "notes": "This is the additional tax rate (on top of .26) for AMT income",
@@ -1161,7 +1162,7 @@
 
     "_AMT_em_ps": {
         "long_name": "AMT exemption phaseout start",
-        "description": "AMT exemption starts to decrease when AMTI goes beyond this threshold.",
+        "description": "AMT exemption starts to decrease when AMT taxable income goes beyond this threshold.",
         "irs_ref": "Form 1040, line 45, instruction (Worksheet).",
         "notes": "",
         "start_year": 2013,
@@ -1180,8 +1181,8 @@
     },
 
     "_AMT_em_pe": {
-        "long_name": "AMT exemption phaseout ending AMTI (Married filling Separately)",
-        "description": "The AMT exemption is entirely disallowed beyond this AMTI level for individuals who are married but filing separately.",
+        "long_name": "AMT exemption phaseout ending AMT taxable income (Married filling Separately)",
+        "description": "The AMT exemption is entirely disallowed beyond this AMT taxable income level for individuals who are married but filing separately.",
         "irs_ref": "Form 6251, line 28, instruction.",
         "notes": "",
         "start_year": 2013,
@@ -1306,7 +1307,7 @@
 
     "_NIIT_thd": {
         "long_name": "Net Investment Income Tax income threshold (UIMC)",
-        "description": "If one taxpayer's MAGI (modified AGI) is more than this threshold, he or she is subject to the additional Medicare tax. ",
+        "description": "If MAGI (modified AGI) is more than this threshold, tax unit is subject to the Net Investment Income Tax.",
         "irs_ref": "Form 8960, line 14, instructions. ",
         "notes": "",
         "start_year": 2013,
@@ -1319,8 +1320,8 @@
     },
 
     "_NIIT_trt": {
-        "long_name": "Net Investment Income Tax rate (UIMC)",
-        "description": "Also called the Unearned Income Medicare Contribution. The lessor of net investment income and the amount by which MAGI exceeds a threshold is taxed at this rate.",
+        "long_name": "Net Investment Income Tax rate",
+        "description": "The amount by which MAGI exceeds _NIIT_thd is taxed at this rate.",
         "irs_ref": "Form 8960, line 21, in-line. ",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -514,13 +514,13 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
              II_brk1, II_brk2, II_brk3, II_brk4, II_brk5, II_brk6, II_brk7,
              PT_rt1, PT_rt2, PT_rt3, PT_rt4, PT_rt5, PT_rt6, PT_rt7, PT_rt8,
              PT_brk1, PT_brk2, PT_brk3, PT_brk4, PT_brk5, PT_brk6, PT_brk7,
-             CG_as_II,
+             CG_nodiff,
              CG_rt1, CG_rt2, CG_rt3, CG_rt4, CG_thd1, CG_thd2, CG_thd3,
              c24516, c24517, c24520, c05700, _taxbc):
     """
     GainsTax function implements (2015) Schedule D Tax Worksheet logic for
     the special taxation of long-term capital gains and qualified dividends
-    if CG_as_II is false (that is, zero)
+    if CG_nodiff is false (that is, zero)
     """
     # pylint: disable=too-many-statements,too-many-branches
     if c01000 > 0. or c23650 > 0. or p23250 > 0. or e01100 > 0. or e00650 > 0.:
@@ -528,7 +528,7 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
     else:
         hasqdivltcg = 0  # no qualified dividends or long-term capital gains
 
-    if CG_as_II != 0.:
+    if CG_nodiff != 0.:
         hasqdivltcg = 0  # no special taxation of qual divids and l-t cap gains
 
     if hasqdivltcg == 1:
@@ -632,18 +632,17 @@ def AGIsurtax(c00100, MARS, AGI_surtax_trt, AGI_surtax_thd, _taxbc, _surtax):
 
 
 @iterate_jit(nopython=True)
-def AMTInc(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
-           c04470, c17000, c20800, c21040, e24515, MARS, _sep,
-           c24520, c05700, e62900, e00700, c24516, age_head, _earned,
-           cmbtp_itemizer, cmbtp_standard,
-           KT_c_Age, AMT_tthd, AMT_thd_MarriedS,
-           AMT_em, AMT_prt, AMT_trt1, AMT_trt2,
-           AMT_Child_em, AMT_em_ps, AMT_em_pe,
-           AMT_CG_thd1, AMT_CG_thd2, AMT_CG_thd3, AMT_CG_rt1, AMT_CG_rt2,
-           AMT_CG_rt3, AMT_CG_rt4, c05800, c09600, c62100):
-
+def AMT(e07300, c24517, _standard, f6251, c00100, c18300, _taxbc,
+        c04470, c17000, c20800, c21040, e24515, MARS, _sep,
+        c24520, c05700, e62900, e00700, c24516, age_head, _earned,
+        cmbtp_itemizer, cmbtp_standard,
+        KT_c_Age, AMT_tthd, AMT_thd_MarriedS,
+        AMT_em, AMT_prt, AMT_trt1, AMT_trt2,
+        AMT_Child_em, AMT_em_ps, AMT_em_pe,
+        AMT_CG_thd1, AMT_CG_thd2, AMT_CG_thd3, AMT_CG_rt1, AMT_CG_rt2,
+        AMT_CG_rt3, AMT_CG_rt4, c05800, c09600, c62100):
     """
-    AMTInc function computes Alternative Minimum Tax taxable income
+    AMT function computes Alternative Minimum Tax taxable income
     """
     # pylint: disable=too-many-statements,too-many-branches
     c62720 = c24517

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -211,7 +211,7 @@ class Policy(ParametersBase):
         except ValueError as valerr:
             msg = 'Policy reform text below contains invalid JSON:\n'
             msg += str(valerr) + '\n'
-            msg += 'The above location of the first error is approximate.\n'
+            msg += 'Above location of the first error may be approximate.\n'
             msg += 'The invalid JSON reform text is between the lines:\n'
             bline = 'XX----.----1----.----2----.----3----.----4'
             bline += '----.----5----.----6----.----7'


### PR DESCRIPTION
No change in tax-calculating logic or in test results.