### PR TITLE
Another set of cosmetic changes to AMT function code

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -146,7 +146,7 @@ class Records(object):
         '_sey', '_earned', '_earned_p', '_earned_s',
         'ymod', 'ymod1',
         'c04800', 'c19200', 'c20500',
-        '_taxbc', '_standard', 'dwks10', 'dwks13', 'dwks14',
+        '_taxbc', '_standard', 'dwks10', 'dwks13', 'dwks14', 'dwks19',
         'c05700',
         'c05800',
         'c07180',


### PR DESCRIPTION
Part of a series of pull requests that make AMT function variable names and logic order more like IRS Form 6251. There are no changes to tax-calculating logic or to any test results.