### PR TITLE
Use AMT_CG_rt1 parameter in AMT function

### DIFF
--- a/taxcalc/comparison/reform_results.txt
+++ b/taxcalc/comparison/reform_results.txt
@@ -115,10 +115,10 @@ Budget Options,11,9,8,7
 CAPITAL GAIN
 ""
 Increase long term cap gain and dividends tax rates by 2 percentage, no behavioral response
-Tax-Calculator,13.2,13.5,13.7,14.0
+Tax-Calculator,13.3,13.7,13.9,14.1
 ""
 Increase long term cap gain and dividends tax rates by 2 percentage, BE_cg elasticity assumed to be -3.67
-Tax-Calculator,3.3,3.4,3.5,3.7
+Tax-Calculator,3.4,3.4,3.6,3.7
 Budget Options,5,5,5,6
 ""
 REGULAR TAXES

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -690,8 +690,7 @@ def AMT(e07300, dwks13, _standard, f6251, c00100, c18300, _taxbc,
         line45 = max(0., AMT_CG_thd1[MARS - 1] - line44)
         line46 = min(line30, line37)
         line47 = min(line45, line46)  # line47 is amount taxed at AMT_CG_rt1
-        cgtax1 = line47 * AMT_CG_rt1  # FORM 6251 INSTRUCTION PARAMETERIZED
-        cgtax1 = 0.  # ORGINAL CODE WITHOUT ANY PARAMETERIZATION OF TAX RATE
+        cgtax1 = line47 * AMT_CG_rt1
         line48 = line46 - line47
         line51 = dwks19  # FORM 6251 INSTRUCTION
         line51 = dwks14  # ORIGINAL CODE


### PR DESCRIPTION
This pull request fixes an `AMT` function bug in which the `AMT_CG_rt1` policy parameter was not used: essentially, the value of this parameter had been hardwired to zero.  This bug fix does not cause any changes in current-law-policy output because `AMT_CG_rt1` is zero under current law.  But this bug fix does cause changes in any reform that specifies a positive value for `AMT_CG_rt1`.  Examples of such reforms are 30 and 31 in `taxcalc/comparison/reforms.json`, which is part of the standard Tax-Calculator test suite.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey @codykallen 