### PR TITLE
Add NIIT_PT_taxed policy parameter and NIIT logic

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1319,6 +1319,20 @@
         "value": [[200000, 250000, 125000, 200000, 250000, 125000]]
     },
 
+    "_NIIT_PT_taxed": {
+        "long_name": "Whether or not partnership and S-corp income is in NIIT base",
+        "description": "0 ==> e26270 excluded from NIIT base; 1 ==> e26270 is in NIIT base",
+        "irs_ref": "",
+        "notes": "Current law has _NIIT_PT_taxed equal to zero",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0]
+    },
+
     "_NIIT_trt": {
         "long_name": "Net Investment Income Tax rate",
         "description": "The amount by which MAGI exceeds _NIIT_thd is taxed at this rate.",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -729,13 +729,15 @@ def AMT(e07300, dwks13, _standard, f6251, c00100, c18300, _taxbc,
 
 @iterate_jit(nopython=True)
 def NetInvIncTax(e00300, e00600, e02000, e26270, c01000,
-                 c00100, NIIT_thd, MARS, NIIT_trt, NIIT):
+                 c00100, NIIT_thd, MARS, NIIT_PT_taxed, NIIT_trt, NIIT):
     """
     NetInvIncTax function computes Net Investment Income Tax amount
     (assume all annuity income is excluded from net investment income)
     """
     modAGI = c00100  # no deducted foreign earned income to add
     NII = max(0., e00300 + e00600 + (e02000 - e26270) + c01000)
+    if NIIT_PT_taxed != 0.:
+        NII += e26270
     NIIT = NIIT_trt * min(NII, max(0., modAGI - NIIT_thd[MARS - 1]))
     return NIIT
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -735,9 +735,10 @@ def NetInvIncTax(e00300, e00600, e02000, e26270, c01000,
     (assume all annuity income is excluded from net investment income)
     """
     modAGI = c00100  # no deducted foreign earned income to add
-    NII = max(0., e00300 + e00600 + (e02000 - e26270) + c01000)
-    if NIIT_PT_taxed != 0.:
-        NII += e26270
+    if NIIT_PT_taxed == 0.:
+        NII = max(0., e00300 + e00600 + c01000 + e02000 - e26270)
+    else:  # do not subtract e26270 from e02000
+        NII = max(0., e00300 + e00600 + c01000 + e02000)
     NIIT = NIIT_trt * min(NII, max(0., modAGI - NIIT_thd[MARS - 1]))
     return NIIT
 


### PR DESCRIPTION
This pull request adds the ability to simulate a Clinton income tax reform provision: the inclusion of partnership and S-corporation pass-through income in the base of the Net Investment Income Tax.  A [recent TPC report](http://www.taxpolicycenter.org/publications/updated-analysis-hillary-clintons-tax-proposals/full) on page 4 describes this reform provision as follows:
```
Clinton proposes “rationalizing” the 3.8 percent net investment Income tax (NIIT)
imposed by the Affordable Care Act on investment income for filers with incomes
above $200,000 ($250,000 for married filers).  Clinton would broaden the tax base
of the NIIT to include all pass-through business income not subject to the self-
employment payroll (SECA) tax.  Currently, some pass-through income is not subject
to either SECA or the NIIT.
```
This pull request does not alter tax-calculating logic under current-law policy, but does add the ability to simulate this reform provision.  Using this pull request produces a static income tax revenue increase for 2018 that is consistent with the corresponding TPC estimate, which is combined together with the estimated effects of several changes in capital-gains-realizations rules.  So, "consistent" means that the Tax-Calculator estimate for 2018 is less than the combined TPC estimate for 2018.  Details are below for those interested.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey @codykallen 

```
$ cp ../tax-calculator-data/puf.csv .

$ python inctax.py puf.csv 2018 --blowup --weights 
You loaded data for 2009.
Your data have been extrapolated to 2018.

$ cat ptniit.json 
{
    // include partnership and S-corp income (e26270) in NIITTbase in 2017+
    "_NIIT_PT_taxed":{"2017": [1]}
}

$ python inctax.py puf.csv 2018 --blowup --weights --reform ptniit.json
You loaded data for 2009.
Your data have been extrapolated to 2018.

$ ls puf-18*
puf-18.out-inctax		puf-18.out-inctax-ptniit

$ awk '{r+=$4*$29}END{print r}' puf-18.out-inctax
1.61649e+12

$ awk '{r+=$4*$29}END{print r}' puf-18.out-inctax-ptniit
1.6322e+12

2018 T-C estimate of reform's effect on inctax revenue is $15.71 billion.

The TPC 2018 estimate for this reform are combined together with the estimate
of the impact of several capital-gains-realization reforms; the combined estimate
is $21.6 billion for 2018. (TPC report dated 18-Oct-2016, page 8)
```
