### PR TITLE
Small fixes for TaxForm tests

### DIFF
--- a/taxcalc/filings/forms/tax_form.py
+++ b/taxcalc/filings/forms/tax_form.py
@@ -138,7 +138,7 @@ class TaxForm(object):
         results = {}
 
         if self._EVAR_MAP_BY_YEAR:
-            year_evar_map = self._EVAR_MAP_BY_YEAR[self.year]
+            year_evar_map = self._EVAR_MAP_BY_YEAR.get(self.year)
         else:
             year_evar_map = None
 

--- a/taxcalc/filings/forms/tax_form.py
+++ b/taxcalc/filings/forms/tax_form.py
@@ -148,7 +148,7 @@ class TaxForm(object):
             elif year_evar_map and key in year_evar_map:
                 evar = year_evar_map[key]
             else:
-                continue
+                continue  # pragma: no cover
             if evar in results and results[evar] != value:
                 raise ValueError('Different calc for same evar.')
             results[evar] = value

--- a/taxcalc/tests/filings/forms/test_tax_form.py
+++ b/taxcalc/tests/filings/forms/test_tax_form.py
@@ -89,6 +89,14 @@ def test_tax_form_evar_mapping_direct():
     }
 
 
+def test_tax_form_evar_mapping_direct_missing_year():
+    child_class = type("TestTaxForm", (TaxForm,), {
+        '_EVAR_MAP_BY_YEAR': {1998: {'field_1': 'e00001'}}
+    })
+    form = child_class(1999)
+    form.to_evars_direct() == {}
+
+
 def test_tax_form_evar_mapping_direct_conflict():
     child_class = type("TestTaxForm", (TaxForm,), {
         '_EVAR_MAP': {

--- a/taxcalc/tests/filings/forms/test_tax_form.py
+++ b/taxcalc/tests/filings/forms/test_tax_form.py
@@ -81,6 +81,7 @@ def test_tax_form_evar_mapping_direct():
         'field_1': '1',
         'field_2': '2',
         'field_3': '3',
+        'field_4': '4',
     })
     assert form.to_evars_direct() == {
         'e00001': 1,


### PR DESCRIPTION
add test and fix for KeyError in to_evars_direct - as discovered in #963
skip coverage on continue due to [coveragepy#198] (https://bitbucket.org/ned/coveragepy/issues/198/continue-marked-as-not-covered) and include in to_evars_direct test anyway

@martinholmer 