### PR TITLE
Fix pytest deprc warning and add json r/w to utils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
-[pytest]
+[tool:pytest]
 pep8ignore = E402
 testpaths = taxcalc

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -715,6 +715,15 @@ def test_ascii_output_function(csvfile, asciifile):
     os.remove(output_test.name)
 
 
+def test_json_read_write():
+    test_file = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    test_dict = {1: 1, 'b': 'b', 3: '3'}
+    write_json_to_file(test_dict, test_file.name)
+    assert read_json_from_file(test_file.name) == {'1': 1, 'b': 'b', '3': '3'}
+    test_file.close()
+    os.remove(test_file.name)
+
+
 def test_string_to_number():
     assert string_to_number(None) == 0
     assert string_to_number('') == 0

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -13,7 +13,6 @@ import copy
 from collections import defaultdict, OrderedDict
 import json
 import six
-import os
 import numpy as np
 import pandas as pd
 try:
@@ -22,7 +21,6 @@ try:
 except ImportError:
     BOKEH_AVAILABLE = False
 
-TAXCALC_PATH = os.path.dirname(os.path.realpath(__file__))
 
 STATS_COLUMNS = ['_expanded_income', 'c00100', '_standard',
                  'c04470', 'c04600', 'c04800', 'c05200', 'c62100', 'c09600',

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -11,7 +11,9 @@ Tax-Calculator utility functions.
 import math
 import copy
 from collections import defaultdict, OrderedDict
+import json
 import six
+import os
 import numpy as np
 import pandas as pd
 try:
@@ -20,6 +22,7 @@ try:
 except ImportError:
     BOKEH_AVAILABLE = False
 
+TAXCALC_PATH = os.path.dirname(os.path.realpath(__file__))
 
 STATS_COLUMNS = ['_expanded_income', 'c00100', '_standard',
                  'c04470', 'c04600', 'c04800', 'c05200', 'c62100', 'c09600',
@@ -1104,6 +1107,23 @@ def xtr_graph_plot(data,
     fig.legend.spacing = 5
     fig.legend.padding = 5
     return fig
+
+
+def read_json_from_file(path):
+    """
+    Return a dict of data loaded from the json file stored at path.
+    """
+    with open(path, 'r') as file:
+        data = json.load(file)
+    return data
+
+
+def write_json_to_file(data, path, indent=4, sort_keys=False):
+    """
+    Write data to a file at path in json format.
+    """
+    with open(path, 'w') as file:
+        json.dump(data, file, indent=indent, sort_keys=sort_keys)
 
 
 def string_to_number(string):


### PR DESCRIPTION
This small PR:

Changes the pytest section title in `setup.cfg` to fix this deprecation error: 
```
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
```

And adds to `taxcalc.utils`:
* a helper to read json from a file
* a helper to write json to a file
* a TAXCALC_PATH helper constant

All of which are used in an upcoming Luca work commit.

No changes to tax calculation logic.

Please let me know if any issues!


