### PR TITLE
Add _CG_dollar_ec and _CG_reinvest_ec policy parameters

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -943,6 +943,32 @@
         "validations": {"min": 0, "max": 1}
     },
 
+    "_CG_dollar_ec": {
+        "long_name": "Dollar amount of all capital gains and qualified dividends that are excluded from AGI.",
+        "description": "Current-law value is zero; positive value used only if _CG_nodiff is non-zero.",
+        "irs_ref": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_CG_reinvest_ec": {
+        "long_name": "Fraction of all capital gains and qualified dividends in excess of _CG_dollar_ec that are excluded from AGI.",
+        "description": "Current-law value is zero; positive value used only if _CG_nodiff is non-zero.  If positive, set to statutory exclusion rate times the fraction of capital gains and qualified dividends in excess of _CG_dollar_ec that are assumed to be reinvested within the year.",
+        "irs_ref": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
     "_CG_rt1": {
         "long_name": "Long term capital gain and qualified dividends rate 1",
         "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 1 are taxed at this rate. ",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -943,7 +943,7 @@
         "validations": {"min": 0, "max": 1}
     },
 
-    "_CG_dollar_ec": {
+    "_CG_ec": {
         "long_name": "Dollar amount of all capital gains and qualified dividends that are excluded from AGI.",
         "description": "Current-law value is zero; positive value used only if _CG_nodiff is non-zero.",
         "irs_ref": "",
@@ -956,9 +956,9 @@
         "value": [0.0]
     },
 
-    "_CG_reinvest_ec": {
-        "long_name": "Fraction of all capital gains and qualified dividends in excess of _CG_dollar_ec that are excluded from AGI.",
-        "description": "Current-law value is zero; positive value used only if _CG_nodiff is non-zero.  If positive, set to statutory exclusion rate times the fraction of capital gains and qualified dividends in excess of _CG_dollar_ec that are assumed to be reinvested within the year.",
+    "_CG_reinvest_ec_rt": {
+        "long_name": "Fraction of all capital gains and qualified dividends in excess of _CG_ec that are excluded from AGI.",
+        "description": "Current-law value is zero; positive value used only if _CG_nodiff is non-zero.  If positive, set to statutory exclusion rate times the fraction of capital gains and qualified dividends in excess of _CG_ec that are assumed to be reinvested within the year.",
         "irs_ref": "",
         "start_year": 2013,
         "col_var": "",
@@ -1385,8 +1385,8 @@
     },
 
     "_NIIT_thd": {
-        "long_name": "Net Investment Income Tax income threshold (UIMC)",
-        "description": "If MAGI (modified AGI) is more than this threshold, tax unit is subject to the Net Investment Income Tax.",
+        "long_name": "Net Investment Income Tax income threshold",
+        "description": "If MAGI (modified AGI) is more than this threshold, filing unit is subject to the Net Investment Income Tax.",
         "irs_ref": "Form 8960, line 14, instructions. ",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -173,7 +173,8 @@ def Adj(e03150, e03210, c03260,
 
 @iterate_jit(nopython=True)
 def CapGains(p23250, p22250, _sep, ALD_Investment_ec, ALD_StudentLoan_HC,
-             e00200, e00300, e00600, e00700, e00800,
+             e00200, e00300, e00600, e00650, e00700, e00800,
+             CG_nodiff, CG_dollar_ec, CG_reinvest_ec,
              e00900, e01100, e01200, e01400, e01700, e02000, e02100,
              e02300, e00400, e02400, c02900, e03210, e03230, e03240,
              c01000, c23650, ymod, ymod1):
@@ -184,11 +185,18 @@ def CapGains(p23250, p22250, _sep, ALD_Investment_ec, ALD_StudentLoan_HC,
     c23650 = p23250 + p22250
     # limitation on capital losses
     c01000 = max((-3000. / _sep), c23650)
-    # compute ymod* variables
+    # compute ymod1 variable that is included in AGI
     ymod1 = (e00200 + e00700 + e00800 + e00900 + e01400 + e01700 +
              (1 - ALD_Investment_ec) * (e00300 + e00600 +
                                         c01000 + e01100 + e01200) +
              e02000 + e02100 + e02300)
+    if CG_nodiff != 0.:
+        # apply QDIV+CG exclusion if QDIV+LTCG receive no special tax treatment
+        qdcg_pos = max(0., e00650 + c01000)
+        qdcg_exclusion = (max(CG_dollar_ec, qdcg_pos) +
+                          CG_reinvest_ec * max(0., qdcg_pos - CG_dollar_ec))
+        ymod1 = max(0., ymod1 - qdcg_exclusion)
+    # compute ymod variable that is used in OASDI benefit taxation logic
     ymod2 = e00400 + (0.50 * e02400) - c02900
     ymod3 = (1 - ALD_StudentLoan_HC) * e03210 + e03230 + e03240
     ymod = ymod1 + ymod2 + ymod3

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -174,7 +174,7 @@ def Adj(e03150, e03210, c03260,
 @iterate_jit(nopython=True)
 def CapGains(p23250, p22250, _sep, ALD_Investment_ec, ALD_StudentLoan_HC,
              e00200, e00300, e00600, e00650, e00700, e00800,
-             CG_nodiff, CG_dollar_ec, CG_reinvest_ec,
+             CG_nodiff, CG_ec, CG_reinvest_ec_rt,
              e00900, e01100, e01200, e01400, e01700, e02000, e02100,
              e02300, e00400, e02400, c02900, e03210, e03230, e03240,
              c01000, c23650, ymod, ymod1):
@@ -193,8 +193,8 @@ def CapGains(p23250, p22250, _sep, ALD_Investment_ec, ALD_StudentLoan_HC,
     if CG_nodiff != 0.:
         # apply QDIV+CG exclusion if QDIV+LTCG receive no special tax treatment
         qdcg_pos = max(0., e00650 + c01000)
-        qdcg_exclusion = (max(CG_dollar_ec, qdcg_pos) +
-                          CG_reinvest_ec * max(0., qdcg_pos - CG_dollar_ec))
+        qdcg_exclusion = (max(CG_ec, qdcg_pos) +
+                          CG_reinvest_ec_rt * max(0., qdcg_pos - CG_ec))
         ymod1 = max(0., ymod1 - qdcg_exclusion)
     # compute ymod variable that is used in OASDI benefit taxation logic
     ymod2 = e00400 + (0.50 * e02400) - c02900


### PR DESCRIPTION
This pull request adds two new policy parameters that, together with the _CG_nodiff parameter, make it possible to simulate the capital gains and qualified dividends reform provision in a new tax reform proposal.  These code changes cause no changes in current-law tax results or in the reform comparison results.

Here is a description of this reform provision:
```
Tax all (not just long-term) capital gains and qualified dividends at ordinary income
tax rates, but provide a 50% exclusion for capital gains that are reinvested within 
the same tax year that the gains are realized as well as a small investor exclusion of
the first $10,000 in capital gains.
```
This description was clarified by these answers to my questions:
```
Question 1: Reinvested capital gains and qualified dividends that are invested 
should be treated equally. The 50% exclusion should apply to realized gains and
qualified dividends that are reinvested in the same calendar year in which they
are realized/received.

Question 2: The small investor exclusion should also apply to both capital gains
and qualified dividends.

Question 3: The small investor exclusion should be adjusted for inflation, so it 
should be a nominal $10,000 threshold in the first year of enactment.

Question 4: The $10k exclusion should apply first and the 50% exclusion for 
reinvested gains and qualified dividends should apply second.  If I have $10,500
in capital gains and dividends, and I reinvest at least $500, then I would have to
include $250 in my taxable income.

Yes, the exclusions will reduce AGI.
```
Please review these code changes to see if you think they capture the logic of this reform.

See below for some preliminary results on the 2018 income tax revenue effects of this reform provision considered in isolation.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey @codykallen 

```
$ cp ../tax-calculator-data/puf.csv .

$ python inctax.py puf.csv 2018 --blowup --weights
You loaded data for 2009.
Your data have been extrapolated to 2018.

$ awk '{r+=$4*$29}END{print r}' puf-18.out-inctax
1.564e+12

$ cat qdcg.json 
{
    // This reform taxes LTCG+QDIV no differently than other income and
    // provides a dollar and fractional exclusion of CG+QDIV income from AGI
    "_CG_nodiff": {"2018": [1]},
    "_CG_dollar_ec": {"2018": [10000]},
    "_CG_reinvest_ec": {"2018": [0.30]}
        // above 0.30 effective rate is derived as follows:
        // - assume statutory exclusion rate is 0.50
        // - assume 60% is reinvested within the year
        // - so 0.50 * 0.60 equals 0.30  
        // Vary the effective rate as desired as there is little or no
        // evidence about what fraction is reinvested within the year
        // of realization.
}

$ python inctax.py puf.csv 2018 --blowup --weights --reform qdcg.json
You loaded data for 2009.
Your data have been extrapolated to 2018.

$ awk '{r+=$4*$29}END{print r}' puf-18.out-inctax-qdcg 
1.17878e+12

Notice that this reform provision (along with the 60% reinvestment
assumption) causes an decrease in 2018 aggregate income tax revenue
of about $385.2 billion.

If we change the assumed reinvestment rate from 60% to 40% --- so the
effective exclusion rate is 0.20 (instead of 0.30) --- then we have this:

$ awk '{r+=$4*$29}END{print r}' puf-18.out-inctax-qdcg 
1.18577e+12

Aggregate income tax revenue is up by a little, but the decline in
2018 revenue is still $378.2 billion.

If the effective reinvestment exclusion rate is reduced to zero, then
we have these results:

$ awk '{r+=$4*$29}END{print r}' puf-18.out-inctax-qdcg 
1.20664e+12

Aggregate income tax revenue is up by a little more, but the decline
in 2018 revenue is still $357.4 billion.
```
