### PR TITLE
Add c03260 to _expanded_income and fix handling of c03260 haircut

### DIFF
--- a/taxcalc/comparison/reform_results.txt
+++ b/taxcalc/comparison/reform_results.txt
@@ -36,7 +36,7 @@ Tax-Calculator,1.7,1.8,2.0,2.1
 Tax Expenditure,2,2,2,2
 ""
 Eliminate adjustment for self-employment tax
-Tax-Calculator,4.2,4.3,4.6,4.8
+Tax-Calculator,3.8,4.0,4.3,4.5
 ""
 Eliminate adjustment for self-employed health insurance
 Tax-Calculator,6.0,6.3,6.6,6.9

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -20,7 +20,7 @@ from .decorators import iterate_jit, jit
 
 @iterate_jit(nopython=True)
 def EI_PayrollTax(SS_Earnings_c, e00200, e00200p, e00200s,
-                  FICA_ss_trt, FICA_mc_trt,
+                  FICA_ss_trt, FICA_mc_trt, ALD_SelfEmploymentTax_HC,
                   e00900p, e00900s, e02100p, e02100s,
                   _payrolltax, ptax_was, setax, c03260,
                   _sey, _earned, _earned_p, _earned_s):
@@ -51,19 +51,22 @@ def EI_PayrollTax(SS_Earnings_c, e00200, e00200p, e00200s,
     setax_ss_s = FICA_ss_trt * txearn_sey_s
     setax_mc_p = FICA_mc_trt * max(0., sey_p * sey_frac)
     setax_mc_s = FICA_mc_trt * max(0., sey_s * sey_frac)
-    setax = setax_ss_p + setax_ss_s + setax_mc_p + setax_mc_s
+    setax_p = setax_ss_p + setax_mc_p
+    setax_s = setax_ss_s + setax_mc_s
+    setax = setax_p + setax_s
 
     # compute part of total regular payroll taxes for filing unit
     _payrolltax = ptax_was + setax
 
-    # compute AGI deduction for "employer share" of self-employment tax
-    c03260 = 0.5 * setax  # half of setax represents the "employer share"
-
-    # compute _earned and its individual components
+    # compute _earned* variables and AGI deduction for
+    # "employer share" of self-employment tax, c03260
+    # Note: c03260 is the amount on 2015 Form 1040, line 27
+    c03260 = (1. - ALD_SelfEmploymentTax_HC) * 0.5 * setax
     _earned = max(0., e00200 + _sey - c03260)
-    _earned_p = max(0., e00200p + sey_p - 0.5 * (setax_ss_p + setax_mc_p))
-    _earned_s = max(0., e00200s + sey_s - 0.5 * (setax_ss_s + setax_mc_s))
-
+    _earned_p = max(0., (e00200p + sey_p -
+                         (1. - ALD_SelfEmploymentTax_HC) * 0.5 * setax_p))
+    _earned_s = max(0., (e00200s + sey_s -
+                         (1. - ALD_SelfEmploymentTax_HC) * 0.5 * setax_s))
     return (_sey, _payrolltax, ptax_was, setax, c03260,
             _earned, _earned_p, _earned_s)
 
@@ -93,9 +96,9 @@ def DependentCare(nu13, elderly_dependent, _earned,
     """
 
     if _earned <= ALD_Dependents_thd[MARS - 1]:
-        care_deduction = (((1 - ALD_Dependents_HC) * nu13 *
+        care_deduction = (((1. - ALD_Dependents_HC) * nu13 *
                            ALD_Dependents_Child_c) +
-                          ((1 - ALD_Dependents_HC) * elderly_dependent *
+                          ((1. - ALD_Dependents_HC) * elderly_dependent *
                            ALD_Dependents_Elder_c))
     else:
         care_deduction = 0.
@@ -105,8 +108,8 @@ def DependentCare(nu13, elderly_dependent, _earned,
 @iterate_jit(nopython=True)
 def Adj(e03150, e03210, c03260,
         e03270, e03300, e03400, e03500,
-        e03220, e03230, e03240, e03290, care_deduction, ALD_StudentLoan_HC,
-        ALD_SelfEmploymentTax_HC, ALD_SelfEmp_HealthIns_HC, ALD_KEOGH_SEP_HC,
+        e03220, e03230, e03240, e03290, care_deduction,
+        ALD_StudentLoan_HC, ALD_SelfEmp_HealthIns_HC, ALD_KEOGH_SEP_HC,
         ALD_EarlyWithdraw_HC, ALD_Alimony_HC,
         c02900):
     """
@@ -125,7 +128,7 @@ def Adj(e03150, e03210, c03260,
 
         e03240 : Domestic Production Activity Deduction
 
-        c03260 : Self employed payroll tax deduction
+        c03260 : Self employed payroll tax deduction (after haircut)
 
         e03270 : Self employed health insurance deduction
 
@@ -141,8 +144,6 @@ def Adj(e03150, e03210, c03260,
 
     Tax law parameters:
         ALD_StudentLoan_HC : Deduction for student loan interest haircut
-
-        ALD_SelfEmploymentTax_HC : Deduction for self-employment tax haircut
 
         ALD_SelfEmp_HealthIns_HC :
         Deduction for self employed health insurance haircut
@@ -161,12 +162,12 @@ def Adj(e03150, e03210, c03260,
     # Form 2555 foreign earned income deduction is always zero
     # Form 1040 adjustments
     c02900 = (e03150 +
-              (1 - ALD_StudentLoan_HC) * e03210 +
-              (1 - ALD_SelfEmploymentTax_HC) * c03260 +
-              (1 - ALD_SelfEmp_HealthIns_HC) * e03270 +
-              (1 - ALD_KEOGH_SEP_HC) * e03300 +
-              (1 - ALD_EarlyWithdraw_HC) * e03400 +
-              (1 - ALD_Alimony_HC) * e03500 +
+              (1. - ALD_StudentLoan_HC) * e03210 +
+              c03260 +
+              (1. - ALD_SelfEmp_HealthIns_HC) * e03270 +
+              (1. - ALD_KEOGH_SEP_HC) * e03300 +
+              (1. - ALD_EarlyWithdraw_HC) * e03400 +
+              (1. - ALD_Alimony_HC) * e03500 +
               e03220 + e03230 + e03240 + e03290 + care_deduction)
     return c02900
 
@@ -186,11 +187,11 @@ def CapGains(p23250, p22250, _sep, ALD_Investment_ec, ALD_StudentLoan_HC,
     c01000 = max((-3000. / _sep), c23650)
     # compute ymod* variables
     ymod1 = (e00200 + e00700 + e00800 + e00900 + e01400 + e01700 +
-             (1 - ALD_Investment_ec) * (e00300 + e00600 +
-                                        c01000 + e01100 + e01200) +
+             (1. - ALD_Investment_ec) * (e00300 + e00600 +
+                                         c01000 + e01100 + e01200) +
              e02000 + e02100 + e02300)
     ymod2 = e00400 + (0.50 * e02400) - c02900
-    ymod3 = (1 - ALD_StudentLoan_HC) * e03210 + e03230 + e03240
+    ymod3 = (1. - ALD_StudentLoan_HC) * e03210 + e03230 + e03240
     ymod = ymod1 + ymod2 + ymod3
     return (c01000, c23650, ymod, ymod1)
 
@@ -392,7 +393,7 @@ def AdditionalMedicareTax(e00200, MARS,
     _payrolltax : payroll tax augmented by Additional Medicare Tax
     """
     # Note: ratio of self-employment income subject to AMED tax
-    #       equals (1 - 0.5*(FICA_mc_trt+FICA_ss_trt)
+    #       equals (1. - 0.5*(FICA_mc_trt+FICA_ss_trt)
     ptax_amc = AMED_trt * (max(0., e00200 - AMED_thd[MARS - 1]) +
                            max(0., max(0., _sey) *
                                (1. - 0.5 * (FICA_mc_trt + FICA_ss_trt)) -
@@ -1064,7 +1065,6 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
 @iterate_jit(nopython=True)
 def AdditionalCTC(n24, prectc, _earned, c07220, ptax_was,
                   ACTC_Income_thd, ACTC_rt, ACTC_ChildNum,
-                  ALD_SelfEmploymentTax_HC,
                   c03260, e09800, c59660, e11200, c11070):
     """
     AdditionalCTC function calculates Additional (refundable) Child Tax Credit
@@ -1095,7 +1095,7 @@ def AdditionalCTC(n24, prectc, _earned, c07220, ptax_was,
     # Part II of 2005 Form 8812
     if n24 >= ACTC_ChildNum and c82890 < c82935:
         c82900 = 0.5 * ptax_was
-        c82905 = (1. - ALD_SelfEmploymentTax_HC) * c03260 + e09800
+        c82905 = c03260 + e09800
         c82910 = c82900 + c82905
         c82915 = c59660 + e11200
         c82920 = max(0., c82910 - c82915)
@@ -1321,7 +1321,8 @@ def FairShareTax(c00100, MARS, ptax_was, setax, ptax_amc,
 
 
 @iterate_jit(nopython=True)
-def ExpandIncome(ptax_was, e02400, c02500, c00100, e00400, _expanded_income):
+def ExpandIncome(ptax_was, c03260, e02400, c02500, c00100, e00400,
+                 _expanded_income):
     """
     ExpandIncome function: calculates and returns _expanded_income.
 
@@ -1331,6 +1332,7 @@ def ExpandIncome(ptax_was, e02400, c02500, c00100, e00400, _expanded_income):
     employer_share = 0.5 * ptax_was  # share of payroll tax on wages & salary
     non_taxable_ss_benefits = e02400 - c02500
     _expanded_income = (c00100 +  # adjusted gross income
+                        c03260 +  # "employer share" of setax
                         e00400 +  # non-taxable interest income
                         non_taxable_ss_benefits +
                         employer_share)

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -128,7 +128,7 @@ def Adj(e03150, e03210, c03260,
 
         e03240 : Domestic Production Activity Deduction
 
-        c03260 : Self employed payroll tax deduction (after haircut)
+        c03260 : Self-employed tax AGI deduction (after haircut)
 
         e03270 : Self employed health insurance deduction
 
@@ -393,7 +393,7 @@ def AdditionalMedicareTax(e00200, MARS,
     _payrolltax : payroll tax augmented by Additional Medicare Tax
     """
     # Note: ratio of self-employment income subject to AMED tax
-    #       equals (1. - 0.5*(FICA_mc_trt+FICA_ss_trt)
+    #       equals (1 - 0.5*(FICA_mc_trt+FICA_ss_trt)
     ptax_amc = AMED_trt * (max(0., e00200 - AMED_thd[MARS - 1]) +
                            max(0., max(0., _sey) *
                                (1. - 0.5 * (FICA_mc_trt + FICA_ss_trt)) -


### PR DESCRIPTION
This pull request adds the self-employment tax deduction from AGI, which is represented by the `c03260` variable, into the `_expanded_income` variable.  So, now `c03260` is treated in the `ExpandIncome` function exactly the same as the portion of social security benefits not in AGI is treated. 

In the course of reviewing `c03260` logic, a bug became apparent: the `_ALD_SelfEmploymentTax_HC` parameter was not being used in the calculation of the `_earned_p` and `_earned_s` variables even though it was being used in the calculation of the `_earned` variable.  Because the `_earned_p` and `earned_s` variables are used only in Form 2441, the effect of this bug fix was limited in scope and small in magnitude.

This pull request causes a small change in reform comparison results for one reform that completely eliminates the AGI deduction for half of the self-employment tax; all other 50+ reform comparisons are the same as before.  There are no changes in unit test results or in validation test results.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey @codykallen 