### PR TITLE
Fix CTC_new logic and parameter documentation

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1746,7 +1746,7 @@
         "start_year": 2013,
         "col_var": ["single", "joint", "separate", "head of household", "widow", "separate"],
         "row_label": ["2013"],
-        "cpi_inflated": false,
+        "cpi_inflated": true,
         "col_label": "",
         "value": [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
     },
@@ -1767,7 +1767,7 @@
 
     "_CTC_new_refund_limit_rt": {
         "long_name": "New child tax credit refund limit rate",
-        "description": "The fraction of payroll taxes that serves as a limit to the amount of new child tax credit that can be refunded.",
+        "description": "The fraction of payroll taxes (employee plus employer shares, but excluding all Medicare payroll taxes) that serves as a limit to the amount of new child tax credit that can be refunded.",
         "irs_ref": "",
         "notes": "Set this parameter to zero for no refundability; set it to 9e99 for unlimited refundability.",
         "start_year": 2013,

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1711,8 +1711,8 @@
     },
 
     "_CTC_new_c": {
-        "long_name": "New refundable child tax credit amount per child",
-        "description": "In addition to all credits currently available for dependents, this parameter gives each qualifying child a new refundable credit.",
+        "long_name": "New refundable child tax credit maximum amount per child",
+        "description": "In addition to all credits currently available for dependents, this parameter gives each qualifying child a new refundable credit with this maximum amount.",
         "irs_ref": "",
         "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
         "start_year": 2013,
@@ -1726,7 +1726,7 @@
 
     "_CTC_new_rt": {
         "long_name": "New refundable child tax credit amount phasein rate",
-        "description": "The amount of the new child tax credit, per child, is increased at this rate per dollar of AGI until _CTC_new_c is reached.",
+        "description": "The total amount of the new child tax credit is increased at this rate per dollar of AGI until _CTC_new_c times the number of qualified children is reached.",
         "irs_ref": "",
         "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
         "start_year": 2013,
@@ -1740,9 +1740,9 @@
 
     "_CTC_new_ps": {
         "long_name": "New refundable child tax credit phaseout starting AGI",
-        "description": "The amount of new child tax credit is reduced for taxpayers with AGI higher than this level.",
+        "description": "The total amount of new child tax credit is reduced for taxpayers with AGI higher than this level.",
         "irs_ref": "",
-        "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
+        "notes": "",
         "start_year": 2013,
         "col_var": ["single", "joint", "separate", "head of household", "widow", "separate"],
         "row_label": ["2013"],
@@ -1752,10 +1752,10 @@
     },
 
     "_CTC_new_prt": {
-        "long_name": "New refundable child tax credit amount, per child phaseout rate",
-        "description": "The amount of the new child tax credit, per child, is reduced at this rate per dollar exceeding the phaseout starting AGI (_CTC_new_ps).",
+        "long_name": "New refundable child tax credit amount phaseout rate",
+        "description": "The total amount of the new child tax credit is reduced at this rate per dollar exceeding the phaseout starting AGI, _CTC_new_ps.",
         "irs_ref": "",
-        "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
+        "notes": "",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
@@ -1766,10 +1766,10 @@
     },
 
     "_CTC_new_refund_limit_rt": {
-        "long_name": "New child tax credit refund limit",
+        "long_name": "New child tax credit refund limit rate",
         "description": "The fraction of payroll taxes that serves as a limit to the amount of new child tax credit that can be refunded.",
         "irs_ref": "",
-        "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
+        "notes": "Set this parameter to zero for no refundability; set it to 9e99 for unlimited refundability.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
@@ -1777,7 +1777,7 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [0.0],
-        "validations": {"min": 0, "max": 1}
+        "validations": {"min": 0}
     },
 
     "_ID_BenefitSurtax_Switch": {

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -22,7 +22,7 @@ from .decorators import iterate_jit, jit
 def EI_PayrollTax(SS_Earnings_c, e00200, e00200p, e00200s,
                   FICA_ss_trt, FICA_mc_trt, ALD_SelfEmploymentTax_HC,
                   e00900p, e00900s, e02100p, e02100s,
-                  _payrolltax, ptax_was, setax, c03260,
+                  _payrolltax, ptax_was, setax, c03260, ptax_oasdi,
                   _sey, _earned, _earned_p, _earned_s):
     """
     Compute part of total OASDI+HI payroll taxes and earned income variables.
@@ -58,6 +58,13 @@ def EI_PayrollTax(SS_Earnings_c, e00200, e00200p, e00200s,
     # compute part of total regular payroll taxes for filing unit
     _payrolltax = ptax_was + setax
 
+    # compute OASDI part of payroll taxes
+    ptax_oasdi = ptax_ss_was_p + ptax_ss_was_s + setax_ss_p + setax_ss_s
+
+    # compute self-employment tax on taxable self-employment income
+    setax_ss_p = FICA_ss_trt * txearn_sey_p
+    setax_ss_s = FICA_ss_trt * txearn_sey_s
+
     # compute _earned* variables and AGI deduction for
     # "employer share" of self-employment tax, c03260
     # Note: c03260 is the amount on 2015 Form 1040, line 27
@@ -67,7 +74,7 @@ def EI_PayrollTax(SS_Earnings_c, e00200, e00200p, e00200s,
                          (1. - ALD_SelfEmploymentTax_HC) * 0.5 * setax_p))
     _earned_s = max(0., (e00200s + sey_s -
                          (1. - ALD_SelfEmploymentTax_HC) * 0.5 * setax_s))
-    return (_sey, _payrolltax, ptax_was, setax, c03260,
+    return (_sey, _payrolltax, ptax_was, setax, c03260, ptax_oasdi,
             _earned, _earned_p, _earned_s)
 
 
@@ -1134,7 +1141,7 @@ def C1040(c05800, c07180, c07200, c07220, c07230, c07240, c07260, c07300,
 def IITAX(c59660, c11070, c10960, personal_credit,
           c09200, _payrolltax,
           CTC_new_c, CTC_new_rt,
-          n24, c00100, MARS,
+          n24, c00100, MARS, ptax_oasdi,
           CTC_new_ps, CTC_new_prt, CTC_new_refund_limit_rt,
           ctc_new, _eitc, _refund, _iitax, _combined):
     """
@@ -1151,7 +1158,7 @@ def IITAX(c59660, c11070, c10960, personal_credit,
             ctc_new = min(ctc_new, ctc_new_reduced)
         if CTC_new_refund_limit_rt >= 0. and ctc_new > 0.:
             refund_new = max(0., ctc_new - c09200)
-            limit_new = CTC_new_refund_limit_rt * _payrolltax
+            limit_new = CTC_new_refund_limit_rt * ptax_oasdi
             limited_new = max(0., refund_new - limit_new)
             ctc_new = max(0., ctc_new - limited_new)
     else:

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -128,7 +128,7 @@ def Adj(e03150, e03210, c03260,
 
         e03240 : Domestic Production Activity Deduction
 
-        c03260 : Self-employed tax AGI deduction (after haircut)
+        c03260 : Self-employment tax AGI deduction (after haircut)
 
         e03270 : Self employed health insurance deduction
 
@@ -1143,18 +1143,17 @@ def IITAX(c59660, c11070, c10960, personal_credit,
     # compute new refundable child tax credit
     if n24 > 0:
         posagi = max(c00100, 0.)
-        ctc = min(CTC_new_rt * posagi, CTC_new_c)  # per kid credit
+        ctc_new = min(CTC_new_rt * posagi, CTC_new_c * n24)
         ymax = CTC_new_ps[MARS - 1]
         if posagi > ymax:
-            ctcx = max(0.,
-                       CTC_new_c - CTC_new_prt * (posagi - ymax))
-            ctc = min(ctc, ctcx)
-        ctc_new = ctc * n24
-        if CTC_new_refund_limit_rt > 0. and ctc_new > 0.:
+            ctc_new_reduced = max(0.,
+                                  ctc_new - CTC_new_prt * (posagi - ymax))
+            ctc_new = min(ctc_new, ctc_new_reduced)
+        if CTC_new_refund_limit_rt >= 0. and ctc_new > 0.:
             refund_new = max(0., ctc_new - c09200)
             limit_new = CTC_new_refund_limit_rt * _payrolltax
-            excess_new = max(0., refund_new - limit_new)
-            ctc_new = max(0., ctc_new - excess_new)
+            limited_new = max(0., refund_new - limit_new)
+            ctc_new = max(0., ctc_new - limited_new)
     else:
         ctc_new = 0.
     # compute final taxes

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -153,7 +153,7 @@ class Records(object):
         'c07180',
         'c07230', 'prectc', 'c07220', 'c59660',
         'c09200', 'c07100', '_eitc',
-        '_payrolltax', 'ptax_was', 'setax', 'c03260', 'ptax_amc',
+        '_payrolltax', 'ptax_was', 'setax', 'c03260', 'ptax_amc', 'ptax_oasdi',
         '_sep', '_num',
         'c05200',
         'c62100',


### PR DESCRIPTION
Revisions are based on thoughts provoked by the extremely useful comments on pull request #1029 by @MattHJensen.  Here are the results from this pull request:
```
---------------------------------------------------------
_CTC_new_refund_limit_rt     2018 Income Tax Revenue ($B)
---------------------------------------------------------
0.0 (no refundability)                   1518.70
1.0 (payroll tax refund limit)           1460.02
9e99 (unlimited refundability)           1459.27
---------------------------------------------------------
```
To help clarify the intent of this pull request, here is a description from the reform's sponsor:
```
The proposal would fully replace the current CTC and ACTC with a larger tax credit
that would offset payroll taxes.  This tax credit would phase in at the rate of payroll
taxes paid (12.4%) with a maximum credit of $3000 per child.  The credit would 
phase out at a rate of 10% for incomes above $175,000 for individual filers and 
$350,000 for joint filers. The credit would also be refundable up to the value of
payroll taxes paid.
```
@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey @codykallen 