### PR TITLE
Implement Clinton CTC expansion

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1576,6 +1576,20 @@
         "value": [64]
     },
 
+        "_CTC_c_under5_bonus": {
+        "long_name": "Bonus child tax credit maximum for qualifying children under five",
+        "description": "The maximum amount of child tax credit allowed for each child is increased by this amount for qualifying children under 5 years old. ",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
     "_CTC_c": {
         "long_name": "Maximum child tax credit per child",
         "description": "The maximum amount of credit allowed for each child. ",
@@ -1680,6 +1694,21 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [3000]
+    },
+
+
+    "_ACTC_rt_bonus_under5family": {
+        "long_name": "Bonus additional child tax credit rate for families with qualifying children under 5",
+        "description": "For families with qualifying children under 5 years old, this bonus rate is added to the fraction of earnings used in calculating the ACTC (_ACTC_rt).",
+        "irs_ref": "Form 8812, line 6, inline.",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
     },
 
     "_ACTC_rt": {

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1096,9 +1096,9 @@ def AdditionalCTC(n24, prectc, _earned, c07220, ptax_was,
         if nu05 == 0:
             ACTC_rate = ACTC_rt
         else:
-            ACTC_rate += ACTC_rt_bonus_under5family
+            ACTC_rate = ACTC_rt + ACTC_rt_bonus_under5family
         c82890 = ACTC_rate * c82885
-    # Part II of 2005 Form 8812
+    # Part II of 2005 Foreignorm 8812
     if n24 >= ACTC_ChildNum and c82890 < c82935:
         c82900 = 0.5 * ptax_was
         c82905 = c03260 + e09800

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -122,7 +122,7 @@ class Records(object):
         'cmbtp_standard', 'cmbtp_itemizer',
         'age_head', 'age_spouse', 'blind_head', 'blind_spouse',
         'nu13', 'elderly_dependent',
-        's006'])
+        's006', 'nu05'])
 
     # specify set of input variables that MUST be read by Tax-Calculator:
     MUST_READ_VARS = set(['RECID', 'MARS'])

--- a/taxcalc/var_labels.txt
+++ b/taxcalc/var_labels.txt
@@ -72,6 +72,7 @@ MARS = Marital (filing) status: categorical variable
 MIDR = Married filing separately itemized deductions requirement indicator
 N24 = Number of children eligible for Child Tax Credit
 NU13 = Number of dependents under 13
+NU05 = Number of dependents under 5
 P08000 = Other tax credits
 P22250 = Schedule D: Short-term gains less losses
 P23250 = Schedule D: Long-term gains less losses


### PR DESCRIPTION
This allows for users to implement Clinton's CTC expansion in Tax-Calculator and resolves #1031. 

Here is how the Tax Policy Center [describes](http://www.taxpolicycenter.org/sites/default/files/alfresco/publication-pdfs/2000922-An-Updated-Analysis-of-Hillary-Clintons-Tax-Proposals.pdf) the Clinton proposal:

> NOTE: The Clinton campaign released a proposal for an expanded child tax credit (CTC) on
> October 11, 2016. Clinton proposes to increase the maximum credit to $2,000 and
> increase the phase-in rate from 15 percent to 45 percent for the refundable portion of the
> credit for families with children under age 5. For all families with eligible children, Clinton
> would eliminate the minimum earnings requirement (currently $3,000). 

Implementing all three reforms, TC generates a revenue cost of $15.6 B in 2020. TPC finds a revenue cost of $22 B in the same year, but this is stacked after several other reforms. 



# Test HC CTC Expansion Capabilities

### Import taxcalc package and other useful packages


```python
import sys
sys.path.append("../../")
from taxcalc import *
```

### Create Plan X and Plan Y  Policy objects containing current law policy and then implement reforms


```python
# The baseline includes AMT repeal. 
p_xx = Policy()

p_y1 = Policy()
reform1 = {2016: {
'_CTC_c_under5_bonus': [1000] }
}
p_y1.implement_reform(reform1)

p_y2 = Policy()
reform2 = {2016: {
'_CTC_c_under5_bonus': [1000],
'_ACTC_rt_bonus_under5family': [0.3],}
}
p_y2.implement_reform(reform2)

p_y3 = Policy()
reform3 = {2016: {
'_CTC_c_under5_bonus': [1000],
'_ACTC_rt_bonus_under5family': [0.3],
'_ACTC_Income_thd': [0]}
}
p_y3.implement_reform(reform3)
```

### Create calculator objects with default tax data and advance the calculator to 2020


```python
c_xx = Calculator(policy=p_xx, records=Records("../../puf.csv"))
c_xx.advance_to_year(2020)
c_y1 = Calculator(policy=p_y1, records=Records("../../puf.csv"))
c_y1.advance_to_year(2020)
c_y2 = Calculator(policy=p_y2, records=Records("../../puf.csv"))
c_y2.advance_to_year(2020)
c_y3 = Calculator(policy=p_y3, records=Records("../../puf.csv"))
c_y3.advance_to_year(2020)
```

    You loaded data for 2009.
    Your data include the following unused variables that will be ignored:
      filer
    Your data have been extrapolated to 2013.
    You loaded data for 2009.
    Your data include the following unused variables that will be ignored:
      filer
    Your data have been extrapolated to 2013.
    You loaded data for 2009.
    Your data include the following unused variables that will be ignored:
      filer
    Your data have been extrapolated to 2013.
    You loaded data for 2009.
    Your data include the following unused variables that will be ignored:
      filer
    Your data have been extrapolated to 2013.


### Calculate taxes under the baseline and under the reform. 


```python
c_xx.calc_all()
c_y1.calc_all()
c_y2.calc_all()
c_y3.calc_all()
```

### Calculate the change in combined payroll and individual income tax revenue between the baseline and reform


```python
((c_y1.records._combined - c_xx.records._combined)*c_xx.records.s006).sum() /1000000000
```




    -9.9367710395943565




```python
((c_y2.records._combined - c_xx.records._combined)*c_xx.records.s006).sum() /1000000000
```




    -13.687783966024691




```python
((c_y3.records._combined - c_xx.records._combined)*c_xx.records.s006).sum() /1000000000
```




    -15.584572910408944




```python

```

cc @codykallen @martinholmer @andersonfrailey @feenberg @GoFroggyRun