### PR TITLE
Change default mtr_graph_data income_measure to expanded_income

### DIFF
--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -562,6 +562,7 @@ def test_mtr_graph_data(records_2009):
         gdata = mtr_graph_data(calcx, calc)
     gdata = mtr_graph_data(calc, calc, mars=1,
                            mtr_wrt_full_compen=True,
+                           income_measure='wages',
                            dollar_weighting=True)
     assert type(gdata) == dict
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -690,7 +690,7 @@ def mtr_graph_data(calc1, calc2,
                    mtr_measure='combined',
                    mtr_variable='e00200p',
                    mtr_wrt_full_compen=False,
-                   income_measure='wages',
+                   income_measure='expanded_income',
                    dollar_weighting=False):
     """
     Prepare marginal tax rate data needed by xtr_graph_plot utility function.


### PR DESCRIPTION
This pull request simply changes the default value of the `income_measure` argument to the `mtr_graph_data` function from `wages` to `expanded_income`.