### PR TITLE
Addition totals calculated for dropq calculation

### DIFF
--- a/taxcalc/dropq/dropq.py
+++ b/taxcalc/dropq/dropq.py
@@ -518,11 +518,12 @@ def run_nth_year(year_n, start_year, is_strict, tax_dta="", user_mods="",
     # diffs of plan Y by decile
     # Means of plan Y by income bin
     # diffs of plan Y by income bin
-    mY_dec, mX_dec, df_dec, pdf_dec, cdf_dec, mY_bin, mX_bin, df_bin, \
-        pdf_bin, cdf_bin, diff_sum, payrolltax_diff_sum, combined_diff_sum, \
-        sum_baseline, pr_sum_baseline, combined_sum_baseline, sum_reform, \
-        pr_sum_reform, combined_sum_reform =\
-        groupby_means_and_comparisons(soit_baseline, soit_reform, mask)
+    (mY_dec, mX_dec, df_dec, pdf_dec, cdf_dec, mY_bin, mX_bin, df_bin,
+        pdf_bin, cdf_bin, diff_sum, payrolltax_diff_sum, combined_diff_sum,
+        sum_baseline, pr_sum_baseline, combined_sum_baseline, sum_reform,
+        pr_sum_reform,
+        combined_sum_reform) = groupby_means_and_comparisons(soit_baseline,
+                                                             soit_reform, mask)
 
     elapsed_time = time.time() - start_time
     print("elapsed time for this run: ", elapsed_time)

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+import numpy.testing as npt
 from pandas import DataFrame, Series
 
 from taxcalc.dropq.dropq_utils import *
@@ -102,6 +103,15 @@ def test_full_dropq_puf(puf_path):
     diff = abs(pure_reform_revenue - dropq_reform_revenue)
     # Assert that dropq revenue is similar to the "pure" calculation
     assert diff / dropq_reform_revenue < 0.02
+
+    # Assert that Reform - Baseline = Reported Delta
+    delta_yr0 = fiscal_tots[0]
+    baseline_yr0 = fiscal_tots[1]
+    reform_yr0 = fiscal_tots[2]
+    diff_yr0 = (reform_yr0.loc['combined_tax'] -
+                baseline_yr0.loc['combined_tax']).values
+    delta_yr0 = delta_yr0.loc['combined_tax'].values
+    npt.assert_array_almost_equal(diff_yr0, delta_yr0, decimal=3)
 
 
 @pytest.mark.parametrize("is_strict, rjson, growth_params, no_elast",


### PR DESCRIPTION
 - Instead of just a summary calculation of the delta between the policy
   and reform for total individual income tax, total payroll tax, and
   total combined tax for each budget year, we also compute these values
   for baseline and reform separately.