### PR TITLE
NIIT_PT_taxed -> boolean

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1399,16 +1399,16 @@
 
     "_NIIT_PT_taxed": {
         "long_name": "Whether or not partnership and S-corp income is in NIIT base",
-        "description": "0 ==> e26270 excluded from NIIT base; 1 ==> e26270 is in NIIT base",
+        "description": "false ==> e26270 excluded from NIIT base; true ==> e26270 is in NIIT base",
         "irs_ref": "",
-        "notes": "Current law has _NIIT_PT_taxed equal to zero",
+        "notes": "",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0]
+        "value": [false]
     },
 
     "_NIIT_rt": {

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -790,7 +790,7 @@ def NetInvIncTax(e00300, e00600, e02000, e26270, c01000,
     (assume all annuity income is excluded from net investment income)
     """
     modAGI = c00100  # no deducted foreign earned income to add
-    if NIIT_PT_taxed == 0.:
+    if not NIIT_PT_taxed:
         NII = max(0., e00300 + e00600 + c01000 + e02000 - e26270)
     else:  # do not subtract e26270 from e02000
         NII = max(0., e00300 + e00600 + c01000 + e02000)


### PR DESCRIPTION
In #1055, we started to use booleans instead of 1/0 indicators for parameter switches. I missed `NIIT_PT_taxed` before. 