### PR TITLE
Avoid double-precision rounding error in dropq test

### DIFF
--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -106,7 +106,7 @@ def test_full_dropq_puf(puf_path):
     diff_yr0 = 1e-9 * (reform_yr0.loc['combined_tax'] -
                        baseline_yr0.loc['combined_tax']).values
     delta_yr0 = 1e-9 * delta_yr0.loc['combined_tax'].values
-    npt.assert_array_almost_equal(diff_yr0, delta_yr0, decimal=6)
+    npt.assert_array_almost_equal(diff_yr0, delta_yr0, decimal=9)
 
 
 @pytest.mark.parametrize("is_strict, rjson, growth_params, no_elast",

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -103,10 +103,10 @@ def test_full_dropq_puf(puf_path):
     delta_yr0 = fiscal_tots[0]
     baseline_yr0 = fiscal_tots[1]
     reform_yr0 = fiscal_tots[2]
-    diff_yr0 = 1e-9 * (reform_yr0.loc['combined_tax'] -
-                       baseline_yr0.loc['combined_tax']).values
-    delta_yr0 = 1e-9 * delta_yr0.loc['combined_tax'].values
-    npt.assert_array_almost_equal(diff_yr0, delta_yr0, decimal=9)
+    diff_yr0 = (reform_yr0.loc['combined_tax'] -
+                baseline_yr0.loc['combined_tax']).values
+    delta_yr0 = delta_yr0.loc['combined_tax'].values
+    npt.assert_allclose(diff_yr0, delta_yr0)
 
 
 @pytest.mark.parametrize("is_strict, rjson, growth_params, no_elast",


### PR DESCRIPTION
This pull request makes no substantive changes in `test_dropq.py`, but does scale back expectations about the equality of two large floating-point numbers in a test that was added in pull request #1060.  That new test expected two numbers that are conceptually equal to be the same down to the third decimal place.  The new test passed on one local computer, but failed on another local computer (as described in the #1060 conversation).  Travis-CI does not run this test because the test uses the confidential `puf.csv` file.  But the two numbers being compared are large: about 1.081e11.  So the original test would fail if the two numbers were (for example):
```
108,100,000,000.001 and
108,100,000,000.002
```
The expectation was for 15 digits of accuracy, which is at the outer limits of double-precision accuracy.  This pull request simply scales back expectations for how close two large floating-point numbers must be to be considered equal.

@talumbau 