### PR TITLE
Nonrefundable credit for dependents

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -670,7 +670,7 @@
         "validations": {"min": 0}
     },
 
-    "_DependentCredit_c":{
+    "_DependentCredit_c": {
 	"long_name": "Nonrefundable credit for dependents",
 	"description": "This nonrefundable credit is applied to dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
         "irs_ref": "",
@@ -681,7 +681,7 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0],
+        "value": [0]
     },
 
     "_II_rt1": {

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -670,6 +670,20 @@
         "validations": {"min": 0}
     },
 
+    "_DependentCredit_c":{
+	"long_name": "Nonrefundable credit for dependents",
+	"description": "This nonrefundable credit is applied to dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
+        "irs_ref": "",
+        "notes": "The Ryan-Brady tax plan sets this at $500",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0],
+    },
+
     "_II_rt1": {
         "long_name": "Personal income tax rate 1",
         "description": "The lowest tax rate, applied to the portion of taxable income below tax bracket 1. ",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -676,12 +676,12 @@
         "irs_ref": "",
         "notes": "The Ryan-Brady tax plan sets this at $500",
         "start_year": 2013,
-        "col_var": "MARS",
+        "col_var": "",
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0.0],
+        "value": [0],
     },
 
     "_II_rt1": {

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -242,8 +242,8 @@ def SSBenefits(MARS, ymod, e02400, SS_thd50, SS_thd85,
 def AGI(ymod1, c02500, c02900, XTOT, MARS, _sep, DSI, _exact,
         II_em, II_em_ps, II_prt,
         II_credit, II_credit_ps, II_credit_prt,
-        c00100, pre_c04600, c04600, personal_credit, n24,
-        DependentCredit_c, CTC_prt, CTC_ps, _exact, dep_credit):
+        c00100, pre_c04600, c04600, personal_credit,
+        DependentCredit_c, CTC_prt, CTC_ps, n24, dep_credit):
     """
     AGI function: compute Adjusted Gross Income, c00100,
                   compute personal exemption amount, c04600, and

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -242,8 +242,8 @@ def SSBenefits(MARS, ymod, e02400, SS_thd50, SS_thd85,
 def AGI(ymod1, c02500, c02900, XTOT, MARS, _sep, DSI, _exact,
         II_em, II_em_ps, II_prt,
         II_credit, II_credit_ps, II_credit_prt,
-        c00100, pre_c04600, c04600, personal_credit,
-        DependentCredit_c, CTC_prt, CTC_ps, n24, dep_credit):
+        c00100, pre_c04600, c04600, personal_credit, n24,
+        DependentCredit_c, CTC_c, CTC_prt, CTC_ps, dep_credit):
     """
     AGI function: compute Adjusted Gross Income, c00100,
                   compute personal exemption amount, c04600, and

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1121,7 +1121,7 @@ def NonrefundableCredits(c05800, e07240, e07260, e07300, e07400,
     avail = avail - c07600
     c07200 = min(c07200, avail)  # Schedule R credit
     avail = avail - c07200
-    dep_credit = min(avail, dep_credit) # Dependent credit
+    dep_credit = min(avail, dep_credit)  # Dependent credit
     avail = avail - dep_credit
     c08000 = min(p08000, avail)  # Other credits
     avail = avail - c08000

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -905,7 +905,7 @@ def EITC(MARS, DSI, EIC, c00100, e00300, e00400, e00600, c01000,
 @iterate_jit(nopython=True)
 def ChildTaxCredit(n24, MARS, c00100, _exact,
                    CTC_c, CTC_ps, CTC_prt, prectc, nu05,
-                   CTC_c_under5_bonus, XTOT,
+                   CTC_c_under5_bonus, XTOT, _num,
                    DependentCredit_c, dep_credit):
     """
     ChildTaxCredit function computes prectc amount
@@ -918,18 +918,14 @@ def ChildTaxCredit(n24, MARS, c00100, _exact,
             excess = 1000. * math.ceil(excess / 1000.)
         prectc = max(0., prectc - CTC_prt * excess)
     # calculate dependent credit
-    if MARS == 2:
-        dep_count = XTOT - 2
-    else:
-        dep_count = XTOT - 1
-    dep_credit = DependentCredit_c * max(0, dep_count)
+    dep_credit = DependentCredit_c * max(0, XTOT - _num)
     # phase-out dependent credit
     if CTC_prt > 0. and c00100 > CTC_ps[MARS - 1]:
         thresh = CTC_ps[MARS - 1] + n24 * CTC_c / CTC_prt
         excess = c00100 - thresh
         if _exact == 1:
             excess = 1000. * math.ceil(excess / 1000.)
-        dep_phaseout = dep_phaseout = CTC_prt * (c00100 - excess)
+        dep_phaseout = CTC_prt * (c00100 - excess)
         dep_credit = max(0., dep_credit - dep_phaseout)
     return (prectc, dep_credit)
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -922,7 +922,7 @@ def ChildTaxCredit(n24, MARS, c00100, _exact,
         dep_count = XTOT - 2
     else:
         dep_count = XTOT - 1
-    dep_credit = DependentCredit_c * dep_count
+    dep_credit = DependentCredit_c * max(0, dep_count)
     # phase-out dependent credit
     if CTC_prt > 0. and c00100 > CTC_ps[MARS - 1]:
         thresh = CTC_ps[MARS - 1] + n24 * CTC_c / CTC_prt

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -905,7 +905,7 @@ def EITC(MARS, DSI, EIC, c00100, e00300, e00400, e00600, c01000,
 @iterate_jit(nopython=True)
 def ChildTaxCredit(n24, MARS, c00100, _exact,
                    CTC_c, CTC_ps, CTC_prt, prectc, nu05,
-                   CTC_c_under5_bonus,
+                   CTC_c_under5_bonus, XTOT,
                    DependentCredit_c, dep_credit):
     """
     ChildTaxCredit function computes prectc amount

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -165,7 +165,8 @@ class Records(object):
         '_iitax', '_refund', 'ctc_new',
         '_expanded_income', 'c07300', 'c07400',
         'c07600', 'c07240', 'c07260', 'c08000',
-        '_surtax', '_combined', 'personal_credit', 'fstax', 'care_deduction'])
+        '_surtax', '_combined', 'personal_credit', 'fstax', 'care_deduction',
+        'dep_credit'])
 
     INTEGER_CALCULATED_VARS = set(['_num', '_sep', '_exact'])
 


### PR DESCRIPTION
Per the Ryan-Brady plan, this is structured to phase-out as though added to the Child Tax Credit. For example, for a head of household with one child, the $1000 CTC would phase out between $75k and $95k, and the additional $500 dependent credit would phase out at the same rate between $95k and $105k. For a head of household with two children, the $2000 CTC would phase out between $75k and $115k, and the $1000 of dependent credit would phase out between $115k and $135k. 

I used the existing parameters for the Child Tax Credit because that is the structure of this credit. Alternatively, we could add a phase-out rate and threshold specific to this credit, but implementation of the Ryan-Brady plan would require setting these parameters to the same as those for the CTC.

This pull request resolves the second part of issue #1068 

@MattHJensen @martinholmer @andersonfrailey @GoFroggyRun @feenberg @Amy-Xu 