### PR TITLE
Add ability to narrow investment income exclusion base

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -133,9 +133,9 @@
 
     "_ALD_Investment_ec_rt": {
         "long_name": "Investment income exclusion rate",
-        "description": "Decimal fraction of investment income that can be excluded from AGI.",
+        "description": "Decimal fraction of investment income base that can be excluded from AGI.",
         "irs_ref": "Form 1040, line 8a",
-        "notes": "The final taxable investment income will be (1-_ALD_Investment_ec_rt)*investment_income. Even though the excluded portion of investment income is not included in AGI, it still is included in investment income used to calculate the Net Investment Income Tax and Earned Income Tax Credit.",
+        "notes": "The final taxable investment income will be (1-_ALD_Investment_ec_rt)*investment_income_base. Even though the excluded portion of investment income is not included in AGI, it still is included in investment income used to calculate the Net Investment Income Tax and Earned Income Tax Credit.",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
@@ -143,6 +143,20 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [0.0]
+    },
+
+    "_ALD_Investment_ec_base_all": {
+        "long_name": "Investment income exclusion comprehensive base",
+        "description": "Defines scope of base: true implies investment income base includes all investment income; false implies base includes only qualified dividends, long-term capital gains, and taxable interest income.",
+        "irs_ref": "",
+        "notes": "Value of false characterizes Ryan-Brady tax plan.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [true]
     },
 
     "_ALD_Dependents_hc": {

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -187,7 +187,8 @@ def Adj(e03150, e03210, c03260,
 
 
 @iterate_jit(nopython=True)
-def CapGains(p23250, p22250, _sep, ALD_Investment_ec_rt, ALD_StudentLoan_hc,
+def CapGains(p23250, p22250, _sep, ALD_StudentLoan_hc,
+             ALD_Investment_ec_rt, ALD_Investment_ec_base_all,
              e00200, e00300, e00600, e00650, e00700, e00800,
              CG_nodiff, CG_ec, CG_reinvest_ec_rt,
              e00900, e01100, e01200, e01400, e01700, e02000, e02100,
@@ -200,9 +201,13 @@ def CapGains(p23250, p22250, _sep, ALD_Investment_ec_rt, ALD_StudentLoan_hc,
     c23650 = p23250 + p22250
     # limitation on capital losses
     c01000 = max((-3000. / _sep), c23650)
+    # compute exclusion of investment income from AGI
+    if ALD_Investment_ec_base_all:
+        invinc = e00300 + e00600 + c01000 + e01100 + e01200
+    else:
+        invinc = e00300 + e00650 + p23250
+    invinc_agi_ec = ALD_Investment_ec_rt * max(0., invinc)
     # compute ymod1 variable that is included in AGI
-    invinc = e00300 + e00600 + c01000 + e01100 + e01200
-    invinc_agi_ec = ALD_Investment_ec_rt * invinc
     ymod1 = (e00200 + e00700 + e00800 + e00900 + e01400 + e01700 +
              invinc - invinc_agi_ec +
              e02000 + e02100 + e02300)

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -235,7 +235,7 @@ def test_2():
         2015: {
             '_ACTC_Income_thd': [actc_thd],
             '_SS_Earnings_c': [mte],
-            '_ALD_Investment_ec_base_all': [false]
+            '_ALD_Investment_ec_base_all': [False]
         }
     }
     funit = (

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -235,6 +235,7 @@ def test_2():
         2015: {
             '_ACTC_Income_thd': [actc_thd],
             '_SS_Earnings_c': [mte],
+            '_ALD_Investment_ec_base_all': [false]
         }
     }
     funit = (


### PR DESCRIPTION
The Ryan-Brady [Blueprint](http://abetterway.speaker.gov/_assets/pdf/ABetterWay-Tax-PolicyPaper.pdf) says in part:
```
This Blueprint provides for reduced tax on investment income. Families
and individuals will be able to deduct 50 percent of their net capital
gains, dividends, and interest income, leading to basic rates of 6
percent, 12.5 percent, and 16.5 percent on such investment income
depending on the individual’s tax bracket. This approach is similar to
how relief from double taxation of savings and investment was
structured for several years after the enactment of the first round of
Reagan tax cuts in 1981. However, this Blueprint also includes
interest income within the reduced tax on investment income, as part
of the move in the direction of a cash-flow tax.
```
Tax-Calculator already has the ability to compute an AGI exclusion of some percent of **all** investment income.  This pull request adds the ability to specify a narrower base for the calculation of the investment income exclusion, with this narrower base including the three types of investment income specified in the Blueprint quotation above.

@MattHJensen @feenberg @codykallen @Amy-Xu @GoFroggyRun @andersonfrailey 