### PR TITLE
Expand scope of JSON reform file

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -46,9 +46,10 @@ def main():
                         action="store_true")
     parser.add_argument('--reform',
                         help=('REFORM is name of optional file that contains '
-                              'tax reform provisions; the provisions are '
-                              'specified using JSON that may include '
-                              '//-comments. No REFORM filename implies use '
+                              'tax reform "policy" parameters and "behavior" '
+                              'parameters and "growth" parameters; the '
+                              'REFORM file is specified using JSON that may '
+                              'include //-comments. No --reform implies use '
                               'of current-law policy.'),
                         default=None)
     parser.add_argument('--exact',

--- a/inctax.py
+++ b/inctax.py
@@ -78,6 +78,17 @@ def main():
                               '--blowup option is used'),
                         default=False,
                         action="store_true")
+    parser.add_argument('--fullcomp',
+                        help=('optional flag that causes OUTPUT to have '
+                              'marginal tax rates (MTRs) calculated with '
+                              'respect to full compensation (but any '
+                              'behavioral-response calculations always use '
+                              'MTRs that are calculated with respect to full '
+                              'compensation).  No --fullcomp option implies '
+                              'MTRs reported in OUTPUT are not calculated '
+                              'with respect to full compensation'),
+                        default=False,
+                        action="store_true")
     output = parser.add_mutually_exclusive_group(required=False)
     output.add_argument('--records',
                         help=('optional flag that causes the output file to '
@@ -138,12 +149,16 @@ def main():
     if args.records:
         inctax.output_records(writing_output_file=True)
     elif args.csvdump:
-        inctax.calculate(writing_output_file=False, exact_output=args.exact,
-                         output_weights=args.weights)
+        inctax.calculate(writing_output_file=False,
+                         exact_output=args.exact,
+                         output_weights=args.weights,
+                         output_mtr_wrt_fullcomp=args.fullcomp)
         inctax.csv_dump(writing_output_file=True)
     else:
-        inctax.calculate(writing_output_file=True, exact_output=args.exact,
-                         output_weights=args.weights)
+        inctax.calculate(writing_output_file=True,
+                         exact_output=args.exact,
+                         output_weights=args.weights,
+                         output_mtr_wrt_fullcomp=args.fullcomp)
     # return no-error exit code
     return 0
 # end of main function code

--- a/inctax.py
+++ b/inctax.py
@@ -128,7 +128,7 @@ def main():
     # instantiate IncometaxIO object and do federal income tax calculations
     inctax = IncomeTaxIO(input_data=args.INPUT,
                          tax_year=args.TAXYEAR,
-                         policy_reform=args.reform,
+                         reform=args.reform,
                          exact_calculations=args.exact,
                          blowup_input_data=args.blowup,
                          output_weights=args.weights,

--- a/simtax.py
+++ b/simtax.py
@@ -39,9 +39,10 @@ def main():
                         action="store_true")
     parser.add_argument('--reform',
                         help=('REFORM is name of optional file that contains '
-                              'tax reform provisions; the provisions are '
-                              'specified using JSON that may include '
-                              '//-comments. No REFORM filename implies use '
+                              'tax reform "policy" parameters (any "behavior" '
+                              'or "growth" parameters are ignored); the '
+                              'REFORM file is specified using JSON that may '
+                              'include //-comments. No --reform implies use '
                               'of current-law policy.'),
                         default=None)
     parser.add_argument('--exact',

--- a/simtax.py
+++ b/simtax.py
@@ -40,10 +40,10 @@ def main():
     parser.add_argument('--reform',
                         help=('REFORM is name of optional file that contains '
                               'tax reform "policy" parameters (any "behavior" '
-                              'or "growth" parameters are ignored); the '
-                              'REFORM file is specified using JSON that may '
-                              'include //-comments. No --reform implies use '
-                              'of current-law policy.'),
+                              'or "growth" or "consumption" parameters are '
+                              'ignored); the REFORM file is specified using '
+                              'JSON that may include //-comments. No --reform '
+                              'implies use of current-law policy.'),
                         default=None)
     parser.add_argument('--exact',
                         help=('optional flag to suppress smoothing in income '

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -248,8 +248,8 @@ class Behavior(ParametersBase):
         Computes marginal tax rates for Calculator objects calc_x and calc_y
         for specified mtr_of income type and specified tax_type.
         """
-        _, iitax_x, combined_x = calc_x.mtr(mtr_of)
-        _, iitax_y, combined_y = calc_y.mtr(mtr_of)
+        _, iitax_x, combined_x = calc_x.mtr(mtr_of, wrt_full_compensation=True)
+        _, iitax_y, combined_y = calc_y.mtr(mtr_of, wrt_full_compensation=True)
         if tax_type == 'combined':
             return (combined_x, combined_y)
         elif tax_type == 'iitax':

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -127,6 +127,7 @@ class Behavior(ParametersBase):
         """
         # pylint: disable=too-many-locals,protected-access
         assert calc_x.records.dim == calc_y.records.dim
+        assert calc_x.records.current_year == calc_y.records.current_year
         # calculate sum of substitution and income effects
         if calc_y.behavior.BE_sub == 0.0 and calc_y.behavior.BE_inc == 0.0:
             sub = np.zeros(calc_x.records.dim)

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -255,5 +255,3 @@ class Behavior(ParametersBase):
             return (iitax_x, iitax_y)
         else:
             raise ValueError('tax_type must be "combined" or "iitax"')
-
-# end Behavior class

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -137,7 +137,9 @@ class Calculator(object):
                               var)
             while self.records.current_year < self.policy.current_year:
                 next_year = self.records.current_year + 1
-                self.growth.apply_change(self.records, next_year)
+                if next_year >= self.growth.start_year:
+                    self.growth.set_year(next_year)
+                    self.growth.apply_change(self.records)
                 self.records.increment_year()
             if verbose:
                 print('Your data have been extrapolated to ' +
@@ -215,7 +217,7 @@ class Calculator(object):
     def increment_year(self):
         next_year = self.policy.current_year + 1
         self.growth.set_year(next_year)
-        self.growth.apply_change(self.records, next_year)
+        self.growth.apply_change(self.records)
         self.records.increment_year()
         self.policy.set_year(next_year)
         self.behavior.set_year(next_year)
@@ -417,7 +419,7 @@ class Calculator(object):
         The returned dictionaries are suitable as the argument to
            the Policy implement_reform(reform_policy) method, or
            the Behavior update_behavior(reform_behavior) method, or
-           the Growth update_economic_growth(reform_growth) method.
+           the Growth update_growth(reform_growth) method.
         """
         # strip out //-comments without changing line numbers
         json_without_comments = re.sub('//.*', ' ', text_string)
@@ -462,7 +464,7 @@ class Calculator(object):
           keys are calendary years, and hence, is suitable as the argument to
           the Policy implement_reform(reform_policy) method, or
           the Behavior update_behavior(reform_behavior) method, or
-          the Growth update_economic_growth(reform_growth) method.
+          the Growth update_growth(reform_growth) method.
         Specified input dictionary has string parameter primary keys and
            string years as secondary keys.
         Returned dictionary has integer years as primary keys and

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -102,18 +102,27 @@ class Calculator(object):
             self.behavior = Behavior(start_year=policy.start_year)
         elif isinstance(behavior, Behavior):
             self.behavior = behavior
+            while self.behavior.current_year < self.policy.current_year:
+                next_year = self.behavior.current_year + 1
+                self.behavior.set_year(next_year)
         else:
             raise ValueError('behavior must be None or Behavior object')
         if growth is None:
             self.growth = Growth(start_year=policy.start_year)
         elif isinstance(growth, Growth):
             self.growth = growth
+            while self.growth.current_year < self.policy.current_year:
+                next_year = self.growth.current_year + 1
+                self.growth.set_year(next_year)
         else:
             raise ValueError('growth must be None or Growth object')
         if consumption is None:
             self.consumption = Consumption(start_year=policy.start_year)
         elif isinstance(consumption, Consumption):
             self.consumption = consumption
+            while self.consumption.current_year < self.policy.current_year:
+                next_year = self.consumption.current_year + 1
+                self.consumption.set_year(next_year)
         else:
             raise ValueError('consumption must be None or Consumption object')
         if sync_years and self.records.current_year == Records.PUF_YEAR:
@@ -127,16 +136,8 @@ class Calculator(object):
                         print('  ' +
                               var)
             while self.records.current_year < self.policy.current_year:
-                if self.behavior.current_year < self.policy.current_year:
-                    next_year = self.behavior.current_year + 1
-                    self.behavior.set_year(next_year)
-                if self.growth.current_year < self.policy.current_year:
-                    next_year = self.growth.current_year + 1
-                    self.growth.set_year(next_year)
-                    self.growth.apply_change(self.records, next_year)
-                if self.consumption.current_year < self.policy.current_year:
-                    next_year = self.consumption.current_year + 1
-                    self.consumption.set_year(next_year)
+                next_year = self.records.current_year + 1
+                self.growth.apply_change(self.records, next_year)
                 self.records.increment_year()
             if verbose:
                 print('Your data have been extrapolated to ' +
@@ -213,8 +214,8 @@ class Calculator(object):
 
     def increment_year(self):
         next_year = self.policy.current_year + 1
-        self.growth.apply_change(self.records, next_year)
         self.growth.set_year(next_year)
+        self.growth.apply_change(self.records, next_year)
         self.records.increment_year()
         self.policy.set_year(next_year)
         self.behavior.set_year(next_year)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -88,11 +88,11 @@ class Calculator(object):
                  sync_years=True, behavior=None, growth=None,
                  consumption=None):
         if isinstance(policy, Policy):
-            self._policy = policy
+            self.policy = policy
         else:
             raise ValueError('must specify policy as a Policy object')
         if isinstance(records, Records):
-            self._records = records
+            self.records = records
         else:
             raise ValueError('must specify records as a Records object')
         if behavior is None:
@@ -113,30 +113,22 @@ class Calculator(object):
             self.consumption = consumption
         else:
             raise ValueError('consumption must be None or Consumption object')
-        if sync_years and self._records.current_year == Records.PUF_YEAR:
+        if sync_years and self.records.current_year == Records.PUF_YEAR:
             if verbose:
                 print('You loaded data for ' +
-                      str(self._records.current_year) + '.')
-                if len(self._records.IGNORED_VARS) > 0:
+                      str(self.records.current_year) + '.')
+                if len(self.records.IGNORED_VARS) > 0:
                     print('Your data include the following unused ' +
                           'variables that will be ignored:')
-                    for var in self._records.IGNORED_VARS:
+                    for var in self.records.IGNORED_VARS:
                         print('  ' +
                               var)
-            while self._records.current_year < self._policy.current_year:
-                self._records.increment_year()
+            while self.records.current_year < self.policy.current_year:
+                self.records.increment_year()
             if verbose:
                 print('Your data have been extrapolated to ' +
-                      str(self._records.current_year) + '.')
-        assert self._policy.current_year == self._records.current_year
-
-    @property
-    def policy(self):
-        return self._policy
-
-    @property
-    def records(self):
-        return self._records
+                      str(self.records.current_year) + '.')
+        assert self.policy.current_year == self.records.current_year
 
     def TaxInc_to_AMT(self):
         TaxInc(self.policy, self.records)
@@ -343,7 +335,7 @@ class Calculator(object):
         incometax_chng = copy.deepcopy(self.records._iitax)
         combined_taxes_chng = incometax_chng + payrolltax_chng
         # calculate base level of taxes after restoring records object
-        setattr(self, '_records', recs0)
+        setattr(self, 'records', recs0)
         self.calc_all(zero_out_calc_vars=zero_out_calculated_vars)
         payrolltax_base = copy.deepcopy(self.records._payrolltax)
         incometax_base = copy.deepcopy(self.records._iitax)
@@ -371,8 +363,8 @@ class Calculator(object):
         """
         Return Calculator object same as self except with current-law policy.
         """
-        clp = self._policy.current_law_version()
-        recs = copy.deepcopy(self._records)
+        clp = self.policy.current_law_version()
+        recs = copy.deepcopy(self.records)
         behv = copy.deepcopy(self.behavior)
         grow = copy.deepcopy(self.growth)
         cons = copy.deepcopy(self.consumption)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -488,20 +488,11 @@ class Calculator(object):
             reform_pkey_param[pkey] = rdict
         # convert reform_pkey_param dictionary to reform_pkey_year dictionary
         years = set()
-        reform_pk_yr = dict()
+        reform_pkey_year = dict()
         for param, sdict in reform_pkey_param.items():
-            if not isinstance(param, six.string_types):
-                msg = 'pkey {} in reform is not a string'
-                raise ValueError(msg.format(param))
-            elif not isinstance(sdict, dict):
-                msg = 'pkey {} value {} is not a dictionary'
-                raise ValueError(msg.format(param, sdict))
             for year, val in sdict.items():
-                if not isinstance(year, int):
-                    msg = 'year skey {} in reform is not an integer'
-                    raise ValueError(msg.format(year))
                 if year not in years:
                     years.add(year)
-                    reform_pk_yr[year] = {}
-                reform_pk_yr[year][param] = val
-        return reform_pk_yr
+                    reform_pkey_year[year] = {}
+                reform_pkey_year[year][param] = val
+        return reform_pkey_year

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -127,6 +127,16 @@ class Calculator(object):
                         print('  ' +
                               var)
             while self.records.current_year < self.policy.current_year:
+                if self.behavior.current_year < self.policy.current_year:
+                    next_year = self.behavior.current_year + 1
+                    self.behavior.set_year(next_year)
+                if self.growth.current_year < self.policy.current_year:
+                    next_year = self.growth.current_year + 1
+                    self.growth.set_year(next_year)
+                    self.growth.apply_change(self.records, next_year)
+                if self.consumption.current_year < self.policy.current_year:
+                    next_year = self.consumption.current_year + 1
+                    self.consumption.set_year(next_year)
                 self.records.increment_year()
             if verbose:
                 print('Your data have been extrapolated to ' +

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -100,5 +100,3 @@ class Consumption(ParametersBase):
             records_var = getattr(records, var)
             mpc_var = getattr(self, 'MPC_{}'.format(var))
             records_var[:] += mpc_var * income_change
-
-# end Consumption class

--- a/taxcalc/dropq/dropq.py
+++ b/taxcalc/dropq/dropq.py
@@ -352,7 +352,7 @@ def run_nth_year_mtr_calc(year_n, start_year, is_strict, tax_dta, user_mods="",
 
     growth_assumptions = only_growth_assumptions(user_mods, start_year)
     if growth_assumptions:
-        calc1.growth.update_economic_growth(growth_assumptions)
+        calc1.growth.update_growth(growth_assumptions)
 
     while calc1.current_year < start_year:
         calc1.increment_year()
@@ -367,7 +367,7 @@ def run_nth_year_mtr_calc(year_n, start_year, is_strict, tax_dta, user_mods="",
     # Create a Calculator for the user specified plan
     calc3 = Calculator(policy=params3, records=records3, behavior=behavior3)
     if growth_assumptions:
-        calc3.growth.update_economic_growth(growth_assumptions)
+        calc3.growth.update_growth(growth_assumptions)
 
     while calc3.current_year < start_year:
         calc3.increment_year()
@@ -443,7 +443,7 @@ def calculate_baseline_and_reform(year_n, start_year, is_strict,
 
     growth_assumptions = only_growth_assumptions(user_mods, start_year)
     if growth_assumptions:
-        calc1.growth.update_economic_growth(growth_assumptions)
+        calc1.growth.update_growth(growth_assumptions)
 
     while calc1.current_year < start_year:
         calc1.increment_year()
@@ -454,7 +454,7 @@ def calculate_baseline_and_reform(year_n, start_year, is_strict,
     # Create a Calculator with one extra dollar of income
     calc2 = Calculator(policy=params2, records=records2)
     if growth_assumptions:
-        calc2.growth.update_economic_growth(growth_assumptions)
+        calc2.growth.update_growth(growth_assumptions)
 
     while calc2.current_year < start_year:
         calc2.increment_year()
@@ -478,7 +478,7 @@ def calculate_baseline_and_reform(year_n, start_year, is_strict,
     # Create a Calculator for the user specified plan
     calc3 = Calculator(policy=params3, records=records3, behavior=behavior3)
     if growth_assumptions:
-        calc3.growth.update_economic_growth(growth_assumptions)
+        calc3.growth.update_growth(growth_assumptions)
 
     if behavior_assumptions:
         calc3.behavior.update_behavior(behavior_assumptions)

--- a/taxcalc/growth.py
+++ b/taxcalc/growth.py
@@ -164,5 +164,3 @@ class Growth(ParametersBase):
             records.BF.ASOCSEC[year] += distance
             records.BF.AUCOMP[year] += distance
             records.BF.AIPD[year] += distance
-
-# end Growth class

--- a/taxcalc/growth.py
+++ b/taxcalc/growth.py
@@ -102,10 +102,11 @@ class Growth(ParametersBase):
         """
         # pylint: disable=no-member
         iyr = year - self.start_year
-        if self._factor_adjustment[iyr] != 0.0:
-            self._adjustment_change(records, year)
-        elif self._factor_target[iyr] != Growth.REAL_GDP_GROWTH_RATES[iyr]:
-            self._target_change(records, year)
+        if iyr >= 0:
+            if self._factor_adjustment[iyr] != 0.0:
+                self._adjustment_change(records, year)
+            elif self._factor_target[iyr] != Growth.REAL_GDP_GROWTH_RATES[iyr]:
+                self._target_change(records, year)
 
     # ----- begin private methods of Growth class -----
 

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -185,7 +185,7 @@ class IncomeTaxIO(object):
             beh = Behavior()
             beh.update_behavior(r_beh)
             gro = Growth()
-            gro.update_economic_growth(r_gro)
+            gro.update_growth(r_gro)
             self._calc = Calculator(policy=pol, records=recs,
                                     verbose=True,
                                     behavior=beh, growth=gro,

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -141,7 +141,7 @@ class IncomeTaxIO(object):
         # implement policy reform if one is specified
         if policy_reform:
             if self._using_reform_file:
-                reform = Policy.read_json_reform_file(policy_reform)
+                reform = Calculator.read_json_reform_file(policy_reform)
             else:
                 reform = policy_reform
             policy.implement_reform(reform)

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -75,7 +75,7 @@ class IncomeTaxIO(object):
     class instance: IncomeTaxIO
     """
 
-    def __init__(self, input_data, tax_year, policy_reform,
+    def __init__(self, input_data, tax_year, reform,
                  exact_calculations,
                  blowup_input_data, output_weights,
                  output_records, csv_dump):
@@ -101,17 +101,17 @@ class IncomeTaxIO(object):
             msg = 'INPUT is neither string nor Pandas DataFrame'
             raise ValueError(msg)
         # construct output_filename and delete old output file if it exists
-        if policy_reform is None:
+        if reform is None:
             ref = ''
             self._using_reform_file = True
         else:
-            if isinstance(policy_reform, six.string_types):
-                if policy_reform.endswith('.json'):
-                    ref = '-{}'.format(policy_reform[:-5])
+            if isinstance(reform, six.string_types):
+                if reform.endswith('.json'):
+                    ref = '-{}'.format(reform[:-5])
                 else:
-                    ref = '-{}'.format(policy_reform)
+                    ref = '-{}'.format(reform)
                 self._using_reform_file = True
-            elif isinstance(policy_reform, dict):
+            elif isinstance(reform, dict):
                 ref = ''
                 self._using_reform_file = False
             else:
@@ -139,13 +139,16 @@ class IncomeTaxIO(object):
         if tax_year > policy.end_year:
             msg = 'tax_year {} greater than policy.end_year {}'
             raise ValueError(msg.format(tax_year, policy.end_year))
-        # implement policy reform if one is specified
-        if policy_reform:
+        # implement reform if one is specified
+        if reform:
             if self._using_reform_file:
-                r_pol, _, _ = Calculator.read_json_reform_file(policy_reform)
+                r_pol, r_beh, r_gro = Calculator.read_json_reform_file(reform)
             else:
-                r_pol = policy_reform
+                r_pol = reform
+                r_beh = None
+                r_gro = None
             policy.implement_reform(r_pol)
+
         # set tax policy parameters to specified tax_year
         policy.set_year(tax_year)
         # read input file contents into Records object

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -256,7 +256,8 @@ class IncomeTaxIO(object):
 
     def calculate(self, writing_output_file=False,
                   exact_output=False,
-                  output_weights=False):
+                  output_weights=False,
+                  output_mtr_wrt_fullcomp=False):
         """
         Calculate taxes for all INPUT lines and write or return OUTPUT lines.
 
@@ -271,6 +272,10 @@ class IncomeTaxIO(object):
         output_weights: boolean
             whether or not to use s006 as an additional output variable.
 
+        output_mtr_wrt_fullcomp: boolean
+           whether or not to calculate marginal tax rates in OUTPUT file with
+           respect to full compensation.
+
         Returns
         -------
         output_lines: string
@@ -278,7 +283,8 @@ class IncomeTaxIO(object):
             otherwise output_lines contain all OUTPUT lines
         """
         output = {}  # dictionary indexed by Records index for filing unit
-        (mtr_ptax, mtr_itax, _) = self._calc.mtr(wrt_full_compensation=False)
+        (mtr_ptax, mtr_itax,
+         _) = self._calc.mtr(wrt_full_compensation=output_mtr_wrt_fullcomp)
         if self._reform and self._using_reform_file:
             self._calc = Behavior.response(self._calc_clp, self._calc)
         for idx in range(0, self._calc.records.dim):

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -20,6 +20,7 @@ from .policy import Policy
 from .records import Records
 from .behavior import Behavior
 from .growth import Growth
+from .consumption import Consumption
 from .calculate import Calculator
 from .simpletaxio import SimpleTaxIO
 
@@ -147,7 +148,8 @@ class IncomeTaxIO(object):
         # implement reform if one is specified
         if self._reform:
             if self._using_reform_file:
-                r_pol, r_beh, r_gro = Calculator.read_json_reform_file(reform)
+                (r_pol, r_beh,
+                 r_gro, r_con) = Calculator.read_json_reform_file(reform)
             else:
                 r_pol = reform
             pol.implement_reform(r_pol)
@@ -186,9 +188,13 @@ class IncomeTaxIO(object):
             beh.update_behavior(r_beh)
             gro = Growth()
             gro.update_growth(r_gro)
+            con = Consumption()
+            con.update_consumption(r_con)
             self._calc = Calculator(policy=pol, records=recs,
                                     verbose=True,
-                                    behavior=beh, growth=gro,
+                                    behavior=beh,
+                                    growth=gro,
+                                    consumption=con,
                                     sync_years=blowup_input_data)
         else:
             self._calc = Calculator(policy=pol, records=recs,

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -187,12 +187,12 @@ class IncomeTaxIO(object):
             gro = Growth()
             gro.update_economic_growth(r_gro)
             self._calc = Calculator(policy=pol, records=recs,
-                                    verbose=False,
+                                    verbose=True,
                                     behavior=beh, growth=gro,
                                     sync_years=blowup_input_data)
         else:
             self._calc = Calculator(policy=pol, records=recs,
-                                    verbose=False,
+                                    verbose=True,
                                     sync_years=blowup_input_data)
 
     def tax_year(self):

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -85,6 +85,7 @@ class IncomeTaxIO(object):
         # pylint: disable=too-many-arguments
         # pylint: disable=too-many-statements
         # pylint: disable=too-many-branches
+        # pylint: disable=too-many-locals
         if isinstance(input_data, six.string_types):
             self._using_input_file = True
             # check that input_data string ends with ".csv"
@@ -141,10 +142,10 @@ class IncomeTaxIO(object):
         # implement policy reform if one is specified
         if policy_reform:
             if self._using_reform_file:
-                reform = Calculator.read_json_reform_file(policy_reform)
+                r_pol, _, _ = Calculator.read_json_reform_file(policy_reform)
             else:
-                reform = policy_reform
-            policy.implement_reform(reform)
+                r_pol = policy_reform
+            policy.implement_reform(r_pol)
         # set tax policy parameters to specified tax_year
         policy.set_year(tax_year)
         # read input file contents into Records object

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -13,6 +13,7 @@ takes DataFrame input and returns Internet-TAXSIM-formatted output as string.
 
 import os
 import sys
+import copy
 import six
 import pandas as pd
 from .policy import Policy
@@ -177,15 +178,21 @@ class IncomeTaxIO(object):
         if self._reform and self._using_reform_file:
             clp = Policy()
             clp.set_year(tax_year)
-            self._calc_clp = Calculator(policy=clp, records=recs,
+            recs_clp = copy.deepcopy(recs)
+            self._calc_clp = Calculator(policy=clp, records=recs_clp,
+                                        verbose=False,
                                         sync_years=blowup_input_data)
+            beh = Behavior()
+            beh.update_behavior(r_beh)
+            gro = Growth()
+            gro.update_economic_growth(r_gro)
             self._calc = Calculator(policy=pol, records=recs,
-                                    behavior=Behavior(), growth=Growth(),
+                                    verbose=False,
+                                    behavior=beh, growth=gro,
                                     sync_years=blowup_input_data)
-            self._calc.behavior.update_behavior(r_beh)
-            self._calc.growth.update_economic_growth(r_gro)
         else:
             self._calc = Calculator(policy=pol, records=recs,
+                                    verbose=False,
                                     sync_years=blowup_input_data)
 
     def tax_year(self):

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -133,11 +133,9 @@ class ParametersBase(object):
 
         Notes
         -----
-        To increment the current year, use the following statement::
-
+        To increment the current year, use the following statement:
             behavior.set_year(behavior.current_year + 1)
-
-        where behavior is a policy Behavior object.
+        where, in this example, behavior is a Behavior object.
         """
         if year < self.start_year or year > self.end_year:
             msg = 'year {} passed to set_year() must be in [{},{}] range.'

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -7,8 +7,6 @@ Tax-Calculator federal tax policy Policy class.
 # (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 
-import six
-import numpy as np
 from .parameters import ParametersBase
 
 
@@ -174,10 +172,8 @@ class Policy(ParametersBase):
         Parameters
         ----------
         reform: dictionary of one or more YEAR:MODS pairs
-            see Notes to _update method for details on MODS structure, and
-            see read_json_reform_file method above for how to specify a
-            reform in a JSON file and translate it into a reform dictionary
-            suitable for input into this implement_reform method.
+            see Notes to Parameters _update method for info on MODS structure
+
         Raises
         ------
         ValueError:
@@ -267,39 +263,6 @@ class Policy(ParametersBase):
             self._update({year: reform[year]})
         self.set_year(precall_current_year)
 
-    @staticmethod
-    def convert_reform_dictionary(param_key_dict):
-        """
-        Converts specified param_key_dict into a dictionary whose primary
-        keys are calendary years, and hence, is suitable as the argument
-        to the implement_reform(reform_dict) method (see above).
-
-        Specified input dictionary has string policy-parameter primary keys
-           and string years as secondary keys.  See read_json_reform_file
-           method above.
-
-        Returned dictionary has integer years as primary keys and
-           string policy-parameters as secondary keys.
-        """
-        # convert year skey strings to integers and lists into np.arrays
-        reform_pkey_param = {}
-        for pkey, sdict in param_key_dict.items():
-            if not isinstance(pkey, six.string_types):
-                msg = 'pkey {} in reform is not a string'
-                raise ValueError(msg.format(pkey))
-            rdict = {}
-            for skey, val in sdict.items():
-                if not isinstance(skey, six.string_types):
-                    msg = 'skey {} in reform is not a string'
-                    raise ValueError(msg.format(skey))
-                else:
-                    year = int(skey)
-                rdict[year] = (np.array(val)
-                               if isinstance(val, list) else val)
-            reform_pkey_param[pkey] = rdict
-        # convert reform_pkey_param dictionary to reform_pkey_year dictionary
-        return Policy._reform_pkey_year(reform_pkey_param)
-
     def current_law_version(self):
         """
         Return Policy object same as self except with current-law policy.
@@ -316,37 +279,3 @@ class Policy(ParametersBase):
                      wage_growth_rates=wrate_dict)
         clv.set_year(self.current_year)
         return clv
-
-    # ----- begin private methods of Policy class -----
-
-    @staticmethod
-    def _reform_pkey_year(reform_pkey_param):
-        """
-        The input reform_pkey_param dictionary has string policy-parameter
-           primary keys and integer years as secondary keys.
-        Returned dictionary has integer years as primary keys and
-           string policy-parameters as secondary keys.
-        The returned dictionary is suitable as the argument to the
-           implement_reform(reform_dict) method (see above).
-        """
-        years = set()
-        reform_pk_yr = {}
-        for param, sdict in reform_pkey_param.items():
-            if not isinstance(param, six.string_types):
-                msg = 'pkey {} in reform is not a string'
-                raise ValueError(msg.format(param))
-            elif not isinstance(sdict, dict):
-                msg = 'pkey {} value {} is not a dictionary'
-                raise ValueError(msg.format(param, sdict))
-            for year, val in sdict.items():
-                if not isinstance(year, int):
-                    msg = 'year skey {} in reform is not an integer'
-                    raise ValueError(msg.format(year))
-                if year not in years:
-                    years.add(year)
-                    reform_pk_yr[year] = {}
-                reform_pk_yr[year][param] = val
-        return reform_pk_yr
-
-
-# end Policy class

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -7,9 +7,6 @@ Tax-Calculator federal tax policy Policy class.
 # (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
 
 
-import os
-import json
-import re
 import six
 import numpy as np
 from .parameters import ParametersBase
@@ -169,60 +166,6 @@ class Policy(ParametersBase):
         Returns list of wage growth rates starting with JSON_START_YEAR.
         """
         return self._wage_growth_rates
-
-    @staticmethod
-    def read_json_reform_file(reform_filename):
-        """
-        Read reform file, strip //-comments, and return dict based on JSON.
-        The reform file is JSON with string policy-parameter primary keys and
-           string years as secondary keys.  See tests/test_policy.py for an
-           extended example of a commented JSON reform file that can be read
-           by this method.
-        Returned dictionary has integer years as primary keys and
-           string policy-parameters as secondary keys.
-        The returned dictionary is suitable as the argument to the
-           implement_reform(reform_dict) method (see below).
-        """
-        if os.path.isfile(reform_filename):
-            txt = open(reform_filename, 'r').read()
-            return Policy.read_json_reform_text(txt)
-        else:
-            msg = 'Policy reform file {} could not be found'
-            raise ValueError(msg.format(reform_filename))
-
-    @staticmethod
-    def read_json_reform_text(text_string):
-        """
-        Strip //-comments from text_string and return dict based on JSON.
-        The reform text is JSON with string policy-parameter primary keys and
-           string years as secondary keys.  See tests/test_policy.py for an
-           extended example of a commented JSON reform text that can be read
-           by this method.
-        Returned dictionary has integer years as primary keys and
-           string policy-parameters as secondary keys.
-        The returned dictionary is suitable as the argument to the
-           implement_reform(reform_dict) method (see below).
-        """
-        # strip out //-comments without changing line numbers
-        json_without_comments = re.sub('//.*', ' ', text_string)
-        # convert JSON text into a dictionary with year skeys as strings
-        try:
-            reform_dict_raw = json.loads(json_without_comments)
-        except ValueError as valerr:
-            msg = 'Policy reform text below contains invalid JSON:\n'
-            msg += str(valerr) + '\n'
-            msg += 'Above location of the first error may be approximate.\n'
-            msg += 'The invalid JSON reform text is between the lines:\n'
-            bline = 'XX----.----1----.----2----.----3----.----4'
-            bline += '----.----5----.----6----.----7'
-            msg += bline + '\n'
-            linenum = 0
-            for line in json_without_comments.split('\n'):
-                linenum += 1
-                msg += '{:02d}{}'.format(linenum, line) + '\n'
-            msg += bline + '\n'
-            raise ValueError(msg)
-        return Policy.convert_reform_dictionary(reform_dict_raw)
 
     def implement_reform(self, reform):
         """

--- a/taxcalc/reforms/REFORMS.md
+++ b/taxcalc/reforms/REFORMS.md
@@ -32,6 +32,9 @@ reform provisions.  The structure of this file is as follows:
   },
   "growth": {
      <parameter_name>: {<calyear>: <parameter-value>}
+  },
+  "consumption": {
+     <parameter_name>: {<calyear>: <parameter-value>}
   }
 ```
 
@@ -49,7 +52,7 @@ separate, head of household, widow, separate.
 // Example of a reform file suitable for local use or uploading to TaxBrain.
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
-// Within each "policy", "behavior", and "growth" object, the
+// Within each "policy", "behavior", "growth", and "consumption" object, the
 // primary keys are parameters and secondary keys are years.
 // Both the primary and secondary key values must be enclosed in quotes (").
 // Boolean variables are specified as true or false (no quotes; all lowercase).
@@ -85,6 +88,8 @@ separate, head of household, widow, separate.
   "behavior": {
   },
   "growth": {
+  },
+  "consumption": {
   }
 }
 ```

--- a/taxcalc/reforms/REFORMS.md
+++ b/taxcalc/reforms/REFORMS.md
@@ -15,15 +15,24 @@ reform provisions.  The structure of this file is as follows:
 
 ```
 {
-   <parameter_name>: {<calyear>: <parameter-value>,
-                      ... 
-                      <calyear>: <parameter-value>},
-   <parameter_name>: {<calyear>: <parameter-value>},
-   ...
-   <parameter_name>: {<calyear>: <parameter-value>,
-                      ... 
-                      <calyear>: <parameter-value>}
-}
+  "policy": {
+     <parameter_name>: {<calyear>: <parameter-value>,
+                        ...
+                        <calyear>: <parameter-value>},
+     <parameter_name>: {<calyear>: <parameter-value>},
+     ...
+     <parameter_name>: {<calyear>: <parameter-value>,
+                        ...
+                        <calyear>: <parameter-value>}
+  },
+  "behavior": {
+     <parameter_name>: {<calyear>: <parameter-value>},
+     ...
+     <parameter_name>: {<calyear>: <parameter-value>}
+  },
+  "growth": {
+     <parameter_name>: {<calyear>: <parameter-value>}
+  }
 ```
 
 Notice each reform provision (except the last one) must end in a
@@ -39,15 +48,14 @@ separate, head of household, widow, separate.
 ```
 // Example of a reform file suitable for local use or uploading to TaxBrain.
 // This JSON file can contain any number of trailing //-style comments, which
-// will be removed before the remaining JSON is parsed.
-// The JSON primary keys are policy parameter names and the secondary keys
-// are calendar years.  Both these primary and secondary key values must be
-// enclosed in quotes (").
-// Policy parameter values are enclosed in single brackets when the parameter
-// is a scalar and enclosed in double brackets when the parameter is a vector.
-// Boolean values are specified as true or false (no quotes; all lowercase).
+// will be removed before the contents are converted from JSON to a dictionary.
+// Within each "policy", "behavior", and "growth" object, the
+// primary keys are parameters and secondary keys are years.
+// Both the primary and secondary key values must be enclosed in quotes (").
+// Boolean variables are specified as true or false (no quotes; all lowercase).
 {
-    "_AMT_brk1": // top of first AMT taxable income brackets
+  "policy": {
+    "_AMT_brk1": // top of first AMT tax bracket
     {"2015": [200000],
      "2017": [300000]
     },
@@ -73,6 +81,11 @@ separate, head of household, widow, separate.
     {"2017": false, // values in future years are same as this year value
      "2020": true   // values in future years indexed with this year as base
     }
+  },
+  "behavior": {
+  },
+  "growth": {
+  }
 }
 ```
 

--- a/taxcalc/reforms/ptaxes0.txt
+++ b/taxcalc/reforms/ptaxes0.txt
@@ -13,5 +13,7 @@
   "behavior": {
   },
   "growth": {
+  },
+  "consumption": {
   }
 }

--- a/taxcalc/reforms/ptaxes0.txt
+++ b/taxcalc/reforms/ptaxes0.txt
@@ -1,5 +1,6 @@
 // Raise OASDI ("social security") and HI ("Medicare") payroll tax rates
 {
+  "policy": {
     "_FICA_ss_trt": {    // currently at 0.124 (employee+employer share)
         "2018": [0.130], // raise by 0.6 percentage point
         "2020": [0.140]  // raise by another 1.0 percentage point
@@ -8,4 +9,9 @@
         "2019": [0.030], // raise by 0.1 percentage point
         "2021": [0.032]  // raise by another 0.2 percentage point
     }        
+  },
+  "behavior": {
+  },
+  "growth": {
+  }
 }

--- a/taxcalc/reforms/ptaxes1.txt
+++ b/taxcalc/reforms/ptaxes1.txt
@@ -1,8 +1,14 @@
 // Raise OASDI maximum taxable earnings, the "social security tax cap"
 {
+  "policy": {
     "_SS_Earnings_c": {   // at $118,500 in 2016; wage indexed after that
         "2018": [200000], // raise to $200,000 and wage index after that
         "2020": [250000]  // raise to $250,000 and wage index after that
     }
+  },
+  "behavior": {
+  },
+  "growth": {
+  }
 }
 

--- a/taxcalc/reforms/ptaxes1.txt
+++ b/taxcalc/reforms/ptaxes1.txt
@@ -9,6 +9,8 @@
   "behavior": {
   },
   "growth": {
+  },
+  "consumption": {
   }
 }
 

--- a/taxcalc/reforms/ptaxes2.txt
+++ b/taxcalc/reforms/ptaxes2.txt
@@ -8,5 +8,7 @@
   "behavior": {
   },
   "growth": {
+  },
+  "consumption": {
   }
 }

--- a/taxcalc/reforms/ptaxes2.txt
+++ b/taxcalc/reforms/ptaxes2.txt
@@ -1,6 +1,12 @@
 // Eliminate OASDI maximum taxable earnings, the so-called "pop-the-cap" reform
 {
+  "policy": {
     "_SS_Earnings_c": { // at $118,500 in 2016; wage indexed after that
         "2022": [9e99]  // raise to essentially infinity
     }
+  },
+  "behavior": {
+  },
+  "growth": {
+  }
 }

--- a/taxcalc/reforms/ptaxes3.txt
+++ b/taxcalc/reforms/ptaxes3.txt
@@ -16,5 +16,7 @@
   "behavior": {
   },
   "growth": {
+  },
+  "consumption": {
   }
 }

--- a/taxcalc/reforms/ptaxes3.txt
+++ b/taxcalc/reforms/ptaxes3.txt
@@ -1,5 +1,6 @@
 // Raise Additional Medicare Tax (Form 8959) tax rate and earnings exclusion
 {
+  "policy": {
     "_AMEDT_rt": { // currently at 0.009 on non-excluded earnings
         "2019": [0.010] // raise by 0.1 percentage point
     },
@@ -11,4 +12,9 @@
     "_AMEDT_ec_cpi": { // start price-indexing the exclusion
         "2019": true // values in future years price indexed
     }
+  },
+  "behavior": {
+  },
+  "growth": {
+  }
 }

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -104,7 +104,7 @@ class SimpleTaxIO(object):
         # implement reform if reform is specified
         if reform:
             if self._using_reform_file:
-                reform_dict = Policy.read_json_reform_file(reform)
+                reform_dict = Calculator.read_json_reform_file(reform)
             else:
                 reform_dict = reform
             self._policy.implement_reform(reform_dict)

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -105,11 +105,7 @@ class SimpleTaxIO(object):
         # implement reform if reform is specified (no behavior or growth)
         if reform:
             if self._using_reform_file:
-                r_pol, r_beh, r_gro = Calculator.read_json_reform_file(reform)
-                if r_beh != {} or r_gro != {}:
-                    msg = ('JSON reform file for simtax.py must '
-                           'have empty "behavior" and "growth" objects')
-                    raise ValueError(msg)
+                r_pol, _, _ = Calculator.read_json_reform_file(reform)
             else:
                 r_pol = reform
             self._policy.implement_reform(r_pol)

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -101,7 +101,7 @@ class SimpleTaxIO(object):
         # read input file contents into self._input dictionary
         self._read_input(input_filename)
         self._policy = Policy()
-        # implement reform if reform is specified
+        # implement reform if reform is specified (no behavior or growth)
         if reform:
             if self._using_reform_file:
                 r_pol, _, _ = Calculator.read_json_reform_file(reform)

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -102,10 +102,10 @@ class SimpleTaxIO(object):
         # read input file contents into self._input dictionary
         self._read_input(input_filename)
         self._policy = Policy()
-        # implement reform if reform is specified (no behavior or growth)
+        # implement reform if reform is specified (no behavior, growth or cons)
         if reform:
             if self._using_reform_file:
-                r_pol, _, _ = Calculator.read_json_reform_file(reform)
+                r_pol, _, _, _ = Calculator.read_json_reform_file(reform)
             else:
                 r_pol = reform
             self._policy.implement_reform(r_pol)

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -104,10 +104,10 @@ class SimpleTaxIO(object):
         # implement reform if reform is specified
         if reform:
             if self._using_reform_file:
-                reform_dict = Calculator.read_json_reform_file(reform)
+                r_pol, _, _ = Calculator.read_json_reform_file(reform)
             else:
-                reform_dict = reform
-            self._policy.implement_reform(reform_dict)
+                r_pol = reform
+            self._policy.implement_reform(r_pol)
         # validate input variable values
         self._validate_input()
         self._calc = self._calc_object(exact_calculations,

--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -27,7 +27,7 @@ class SimpleTaxIO(object):
 
     reform: None or string or dictionary
         None implies no reform (current-law policy), or
-        string is name of optional REFORM file, or
+        string is name of optional json REFORM file, or
         dictionary suitable for passing to Policy.implement_reform() method.
 
     exact_calculations: boolean
@@ -67,6 +67,7 @@ class SimpleTaxIO(object):
         SimpleTaxIO class constructor.
         """
         # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-branches
         # check that input_filename is a string
         if not isinstance(input_filename, six.string_types):
             msg = 'SimpleTaxIO.ctor input_filename is not a string'
@@ -104,7 +105,11 @@ class SimpleTaxIO(object):
         # implement reform if reform is specified (no behavior or growth)
         if reform:
             if self._using_reform_file:
-                r_pol, _, _ = Calculator.read_json_reform_file(reform)
+                r_pol, r_beh, r_gro = Calculator.read_json_reform_file(reform)
+                if r_beh != {} or r_gro != {}:
+                    msg = ('JSON reform file for simtax.py must '
+                           'have empty "behavior" and "growth" objects')
+                    raise ValueError(msg)
             else:
                 r_pol = reform
             self._policy.implement_reform(r_pol)
@@ -697,5 +702,3 @@ class SimpleTaxIO(object):
         recs.e19200[idx] = ivar[20]  # AMT-nonpreferred deductions
         recs.p22250[idx] = ivar[21]  # short-term capital gains (+/-)
         recs.p23250[idx] = ivar[22]  # long-term capital gains (+/-)
-
-# end SimpleTaxIO class

--- a/taxcalc/taxbrain/reforms.json
+++ b/taxcalc/taxbrain/reforms.json
@@ -3,25 +3,31 @@
 // Each reform below has the following attributes
 // (1) replications -> number of TaxBrain replications
 // (2) start_year -> first of ten years of tax results
-// (3) specification -> TaxBrain style reform spec by parameter, then by year
+// (3) specification -> JSON reform file contents
 {
     "1": {
         "replications": 1,
         "start_year": 2016,
         "specification": {
-            "_STD": {
-                // 2016 clp[[6300, 12600, 6300, 9300, 12600, 6300, 1050]]
-                "2016": [[15000, 30000, 15000, 22150, 0, 0, 0]],
-                "2019": [[20000, 40000, 30000, 30000, 0, 0, 0]]
+            "policy": {
+                "_STD": {
+                    // 2016 clp[[6300, 12600, 6300, 9300, 12600, 6300, 1050]]
+                    "2016": [[15000, 30000, 15000, 22150, 0, 0, 0]],
+                    "2019": [[20000, 40000, 30000, 30000, 0, 0, 0]]
+                },
+                // Eliminate OASDI MTE 2016
+                "_SS_Earnings_c": {
+                    "2017": [1.0E99] // 1.0E999 generates TaxBrain input error
+                },
+                "_II_em": {
+                    "2016": [5000],
+                    "2017": [6000],
+                    "2020": [9000]
+                }
             },
-            // Eliminate OASDI MTE 2016
-            "_SS_Earnings_c": {
-                "2017": [1.0E99] // 1.0E999 generates TaxBrain input error
+            "behavior": {
             },
-            "_II_em": {
-                "2016": [5000],
-                "2017": [6000],
-                "2020": [9000]
+            "growth": {
             }
         }
     }

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -413,3 +413,117 @@ def test_Calculator_using_nonstd_input(rawinputfile):
     exp_mtr_ptax = np.zeros((nonpuf.dim,))
     exp_mtr_ptax.fill(0.153)
     assert np.allclose(mtr_ptax, exp_mtr_ptax)
+
+
+REFORM_CONTENTS = """
+// Example of a reform file suitable for the read_json_reform_file function.
+// This JSON file can contain any number of trailing //-style comments, which
+// will be removed before the contents are converted from JSON to a dictionary.
+// The primary keys are policy parameters and secondary keys are years.
+// Both the primary and secondary key values must be enclosed in quotes (").
+// Boolean variables are specified as true or false (no quotes; all lowercase).
+{
+    "_AMT_brk1": // top of first AMT tax bracket
+    {"2015": [200000],
+     "2017": [300000]
+    },
+    "_EITC_c": // maximum EITC amount by number of qualifying kids (0,1,2,3+)
+    {"2016": [[ 900, 5000,  8000,  9000]],
+     "2019": [[1200, 7000, 10000, 12000]]
+    },
+    "_II_em": // personal exemption amount (see indexing changes below)
+    {"2016": [6000],
+     "2018": [7500],
+     "2020": [9000]
+    },
+    "_II_em_cpi": // personal exemption amount indexing status
+    {"2016": false, // values in future years are same as this year value
+     "2018": true   // values in future years indexed with this year as base
+    },
+    "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
+    {"2016": [300000],
+     "2018": [500000],
+     "2020": [700000]
+    },
+    "_AMT_em_cpi": // AMT exemption amount indexing status
+    {"2017": false, // values in future years are same as this year value
+     "2020": true   // values in future years indexed with this year as base
+    }
+}
+"""
+
+
+@pytest.yield_fixture
+def reform_file():
+    """
+    Temporary reform file for read_json_reform_file function.
+    """
+    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    rfile.write(REFORM_CONTENTS)
+    rfile.close()
+    # must close and then yield for Windows platform
+    yield rfile
+    if os.path.isfile(rfile.name):
+        try:
+            os.remove(rfile.name)
+        except OSError:
+            pass  # sometimes we can't remove a generated temporary file
+
+
+@pytest.mark.parametrize("set_year", [False, True])
+def test_read_json_reform_file_and_implement_reform(reform_file, set_year):
+    """
+    Test reading and translation of reform file into a reform dictionary
+    that is then used to call implement_reform method.
+    NOTE: implement_reform called when policy.current_year == policy.start_year
+    """
+    reform = Calculator.read_json_reform_file(reform_file.name)
+    policy = Policy()
+    if set_year:
+        policy.set_year(2015)
+    policy.implement_reform(reform)
+    syr = policy.start_year
+    amt_brk1 = policy._AMT_brk1
+    assert amt_brk1[2015 - syr] == 200000
+    assert amt_brk1[2016 - syr] > 200000
+    assert amt_brk1[2017 - syr] == 300000
+    assert amt_brk1[2018 - syr] > 300000
+    ii_em = policy._II_em
+    assert ii_em[2016 - syr] == 6000
+    assert ii_em[2017 - syr] == 6000
+    assert ii_em[2018 - syr] == 7500
+    assert ii_em[2019 - syr] > 7500
+    assert ii_em[2020 - syr] == 9000
+    assert ii_em[2021 - syr] > 9000
+    amt_em = policy._AMT_em
+    assert amt_em[2016 - syr, 0] > amt_em[2015 - syr, 0]
+    assert amt_em[2017 - syr, 0] > amt_em[2016 - syr, 0]
+    assert amt_em[2018 - syr, 0] == amt_em[2017 - syr, 0]
+    assert amt_em[2019 - syr, 0] == amt_em[2017 - syr, 0]
+    assert amt_em[2020 - syr, 0] == amt_em[2017 - syr, 0]
+    assert amt_em[2021 - syr, 0] > amt_em[2020 - syr, 0]
+    assert amt_em[2022 - syr, 0] > amt_em[2021 - syr, 0]
+    add4aged = policy._ID_Medical_frt_add4aged
+    assert add4aged[2015 - syr] == -0.025
+    assert add4aged[2016 - syr] == -0.025
+    assert add4aged[2017 - syr] == 0.0
+    assert add4aged[2022 - syr] == 0.0
+
+
+@pytest.yield_fixture
+def badreformfile():
+    # specify JSON text for policy reform
+    txt = """{ // example of incorrect JSON because 'x' must be "x"
+               'x': {"2014": [4000]}
+             }"""
+    f = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    f.write(txt + '\n')
+    f.close()
+    # Must close and then yield for Windows platform
+    yield f
+    os.remove(f.name)
+
+
+def test_read_bad_json_reform_file(badreformfile):
+    with pytest.raises(ValueError):
+        Calculator.read_json_reform_file(badreformfile.name)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -419,7 +419,7 @@ REFORM_CONTENTS = """
 // Example of a reform file suitable for the read_json_reform_file function.
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
-// Within each "policy", "behavior", and "growth" object, the
+// Within each "policy", "behavior", "growth", and "consumption" object, the
 // primary keys are parameters and secondary keys are years.
 // Both the primary and secondary key values must be enclosed in quotes (").
 // Boolean variables are specified as true or false (no quotes; all lowercase).
@@ -458,6 +458,8 @@ REFORM_CONTENTS = """
   "behavior": {
   },
   "growth": {
+  },
+  "consumption": {
   }
 }
 """
@@ -487,7 +489,7 @@ def test_read_json_reform_file_and_implement_reform(reform_file, set_year):
     that is then used to call implement_reform method.
     NOTE: implement_reform called when policy.current_year == policy.start_year
     """
-    reform, _, _ = Calculator.read_json_reform_file(reform_file.name)
+    reform, _, _, _ = Calculator.read_json_reform_file(reform_file.name)
     policy = Policy()
     if set_year:
         policy.set_year(2015)
@@ -531,6 +533,8 @@ def bad1reformfile():
       "behavior": {
       },
       "growth": {
+      },
+      "consumption": {
       }
     }
     """
@@ -553,6 +557,8 @@ def bad2reformfile():
       "behavior": {
       },
       "growthx": {
+      },
+      "consumption": {
       }
     }
     """

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -425,6 +425,9 @@ REFORM_CONTENTS = """
 // Boolean variables are specified as true or false (no quotes; all lowercase).
 {
   "policy": {
+    "param_code": {
+        "ALD_Investment_ec_base_code": "e00300 + e00650 + p23250"
+    },
     "_AMT_brk1": // top of first AMT tax bracket
     {"2015": [200000],
      "2017": [300000]

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -64,14 +64,14 @@ def policyfile():
 
 
 def test_make_Calculator(records_2009):
-    parm = Policy()
-    assert parm.current_year == 2013
+    parm = Policy(start_year=2014, num_years=9)
+    assert parm.current_year == 2014
     recs = records_2009
     consump = Consumption()
     consump.update_consumption({2014: {'_MPC_e20400': [0.05]}})
     assert consump.current_year == 2013
     calc = Calculator(policy=parm, records=recs, consumption=consump)
-    assert calc.current_year == 2013
+    assert calc.current_year == 2014
     # test incorrect Calculator instantiation:
     with pytest.raises(ValueError):
         calc = Calculator(policy=None, records=recs)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -566,3 +566,14 @@ def test_read_bad_json_reform_file(bad1reformfile, bad2reformfile):
         Calculator.read_json_reform_file(bad1reformfile.name)
     with pytest.raises(ValueError):
         Calculator.read_json_reform_file(bad2reformfile.name)
+
+
+def test_convert_reform_dict():
+    with pytest.raises(ValueError):
+        rdict = Calculator.convert_reform_dict({2013: {'2013': [40000]}})
+    with pytest.raises(ValueError):
+        rdict = Calculator.convert_reform_dict({'_II_em': {2013: [40000]}})
+    with pytest.raises(ValueError):
+        rdict = Calculator.convert_reform_dict({4567: {2013: [40000]}})
+    with pytest.raises(ValueError):
+        rdict = Calculator.convert_reform_dict({'_II_em': 40000})

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -168,7 +168,7 @@ def test_1():
     mte = 100000  # lower than current-law to simplify hand calculations
     ssr = 0.124  # current law OASDI ee+er payroll tax rate
     mrr = 0.029  # current law HI ee+er payroll tax rate
-    reform = {
+    policy_reform = {
         2015: {
             '_SS_Earnings_c': [mte],
             '_FICA_ss_trt': [ssr],
@@ -203,7 +203,7 @@ def test_1():
     input_dataframe = pd.read_csv(StringIO(funit))
     inctax = IncomeTaxIO(input_data=input_dataframe,
                          tax_year=2015,
-                         policy_reform=reform,
+                         reform=policy_reform,
                          exact_calculations=False,
                          blowup_input_data=False,
                          output_weights=False,
@@ -231,7 +231,7 @@ def test_2():
     # in order to make the hand calculations easier
     actc_thd = 35000
     mte = 53000
-    reform = {
+    policy_reform = {
         2015: {
             '_ACTC_Income_thd': [actc_thd],
             '_SS_Earnings_c': [mte],
@@ -254,7 +254,7 @@ def test_2():
     input_dataframe = pd.read_csv(StringIO(funit))
     inctax = IncomeTaxIO(input_data=input_dataframe,
                          tax_year=2015,
-                         policy_reform=reform,
+                         reform=policy_reform,
                          exact_calculations=False,
                          blowup_input_data=False,
                          output_weights=False,

--- a/taxcalc/tests/test_growth.py
+++ b/taxcalc/tests/test_growth.py
@@ -23,22 +23,22 @@ def test_update_growth(puf_1991, weights_1991):
     # try incorrect updates
     grow = Growth()
     with pytest.raises(ValueError):
-        grow.update_economic_growth({2013: list()})
+        grow.update_growth({2013: list()})
     with pytest.raises(ValueError):
-        grow.update_economic_growth({2013: {'bad_name': [0.02]}})
+        grow.update_growth({2013: {'bad_name': [0.02]}})
     with pytest.raises(ValueError):
-        grow.update_economic_growth({2013: {'bad_name_cpi': True}})
+        grow.update_growth({2013: {'bad_name_cpi': True}})
     bad_params = {2015: {'_factor_adjustment': [0.01],
                          '_factor_target': [0.08]}}
     with pytest.raises(ValueError):
-        grow.update_economic_growth(bad_params)
+        grow.update_growth(bad_params)
     # try correct updates
     grow_x = Growth()
     factor_x = {2015: {'_factor_target': [0.04]}}
-    grow_x.update_economic_growth(factor_x)
+    grow_x.update_growth(factor_x)
     grow_y = Growth()
     factor_y = {2015: {'_factor_adjustment': [0.01]}}
-    grow_y.update_economic_growth(factor_y)
+    grow_y.update_growth(factor_y)
     # create two Calculators
     recs_x = Records(data=puf_1991, weights=weights_1991, start_year=2009)
     recs_y = Records(data=puf_1991, weights=weights_1991, start_year=2009)
@@ -65,12 +65,12 @@ def test_factor_target(records_2009):
     # specify _factor_target
     ft2015 = 0.04
     factor_target = {2015: {'_factor_target': [ft2015]}}
-    calc.growth.update_economic_growth(factor_target)
+    calc.growth.update_growth(factor_target)
     assert calc.current_year == 2013
     calc.increment_year()
     calc.increment_year()
     assert calc.current_year == 2015
-    distance = ((ft2015 - Growth.default_real_gdp_growth_rate(2015 - 2013)) /
+    distance = ((ft2015 - calc.growth.default_real_gdp_growth_rate()) /
                 calc.records.BF.APOPN[2015])
     AGDPN_post = AGDPN_pre + distance
     ATXPY_post = ATXPY_pre + distance
@@ -85,7 +85,7 @@ def test_factor_adjustment(records_2009):
     # specify _factor_adjustment
     fa2015 = 0.01
     factor_adj = {2015: {'_factor_adjustment': [fa2015]}}
-    calc.growth.update_economic_growth(factor_adj)
+    calc.growth.update_growth(factor_adj)
     assert calc.current_year == 2013
     calc.increment_year()
     calc.increment_year()

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -146,7 +146,7 @@ REFORM_CONTENTS = """
 // Example of a reform file suitable for the read_json_reform_file function.
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
-// Within each "policy", "behavior", and "growth" object, the
+// Within each "policy", "behavior", "growth", and "consumption" object, the
 // primary keys are parameters and secondary keys are years.
 // Both the primary and secondary key values must be enclosed in quotes (").
 // Boolean variables are specified as true or false (no quotes; all lowercase).
@@ -182,6 +182,8 @@ REFORM_CONTENTS = """
   "behavior": {
   },
   "growth": {
+  },
+  "consumption": {
   }
 }
 """

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -143,13 +143,15 @@ def test_2(rawinputfile):  # pylint: disable=redefined-outer-name
 
 
 REFORM_CONTENTS = """
-// Example of a reform suitable for use as an optional IncomeTaxIO reform file.
+// Example of a reform file suitable for the read_json_reform_file function.
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
-// The primary keys are policy parameters and secondary keys are years.
+// Within each "policy", "behavior", and "growth" object, the
+// primary keys are parameters and secondary keys are years.
 // Both the primary and secondary key values must be enclosed in quotes (").
 // Boolean variables are specified as true or false (no quotes; all lowercase).
 {
+  "policy": {
     "_AMT_brk1": // top of first AMT tax bracket
     {"2015": [200000],
      "2017": [300000]
@@ -176,6 +178,11 @@ REFORM_CONTENTS = """
     {"2017": false, // values in future years are same as this year value
      "2020": true   // values in future years indexed with this year as base
     }
+  },
+  "behavior": {
+  },
+  "growth": {
+  }
 }
 """
 

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -65,7 +65,7 @@ def test_incorrect_creation_1(input_data, exact):
         IncomeTaxIO(
             input_data=input_data,
             tax_year=2013,
-            policy_reform=None,
+            reform=None,
             exact_calculations=exact,
             blowup_input_data=True,
             output_weights=False,
@@ -88,7 +88,7 @@ def test_incorrect_creation_2(rawinputfile, year, reform):
         IncomeTaxIO(
             input_data=rawinputfile.name,
             tax_year=year,
-            policy_reform=reform,
+            reform=reform,
             exact_calculations=False,
             blowup_input_data=True,
             output_weights=False,
@@ -111,7 +111,7 @@ def test_creation_with_blowup(rawinputfile, blowup, weights_out):
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
-                         policy_reform=None,
+                         reform=None,
                          exact_calculations=False,
                          blowup_input_data=blowup,
                          output_weights=weights_out,
@@ -132,7 +132,7 @@ def test_2(rawinputfile):  # pylint: disable=redefined-outer-name
     }
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
-                         policy_reform=reform_dict,
+                         reform=reform_dict,
                          exact_calculations=False,
                          blowup_input_data=False,
                          output_weights=False,
@@ -229,7 +229,7 @@ def test_3(rawinputfile, reformfile1):  # pylint: disable=redefined-outer-name
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
-                         policy_reform=reformfile1.name,
+                         reform=reformfile1.name,
                          exact_calculations=False,
                          blowup_input_data=False,
                          output_weights=False,
@@ -249,7 +249,7 @@ def test_4(reformfile2):  # pylint: disable=redefined-outer-name
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=input_dataframe,
                          tax_year=taxyear,
-                         policy_reform=reformfile2.name,
+                         reform=reformfile2.name,
                          exact_calculations=False,
                          blowup_input_data=False,
                          output_weights=False,
@@ -267,7 +267,7 @@ def test_5(rawinputfile):  # pylint: disable=redefined-outer-name
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
-                         policy_reform=None,
+                         reform=None,
                          exact_calculations=False,
                          blowup_input_data=False,
                          output_weights=False,
@@ -285,7 +285,7 @@ def test_6(rawinputfile):  # pylint: disable=redefined-outer-name
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
-                         policy_reform=None,
+                         reform=None,
                          exact_calculations=False,
                          blowup_input_data=False,
                          output_weights=False,

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -500,101 +500,6 @@ def test_parameters_get_default_start_year():
     assert meta_kt_c_age['value'] == [24]
 
 
-REFORM_CONTENTS = """
-// Example of a reform file suitable for Policy read_json_reform_file function.
-// This JSON file can contain any number of trailing //-style comments, which
-// will be removed before the contents are converted from JSON to a dictionary.
-// The primary keys are policy parameters and secondary keys are years.
-// Both the primary and secondary key values must be enclosed in quotes (").
-// Boolean variables are specified as true or false (no quotes; all lowercase).
-{
-    "_AMT_brk1": // top of first AMT tax bracket
-    {"2015": [200000],
-     "2017": [300000]
-    },
-    "_EITC_c": // maximum EITC amount by number of qualifying kids (0,1,2,3+)
-    {"2016": [[ 900, 5000,  8000,  9000]],
-     "2019": [[1200, 7000, 10000, 12000]]
-    },
-    "_II_em": // personal exemption amount (see indexing changes below)
-    {"2016": [6000],
-     "2018": [7500],
-     "2020": [9000]
-    },
-    "_II_em_cpi": // personal exemption amount indexing status
-    {"2016": false, // values in future years are same as this year value
-     "2018": true   // values in future years indexed with this year as base
-    },
-    "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
-    {"2016": [300000],
-     "2018": [500000],
-     "2020": [700000]
-    },
-    "_AMT_em_cpi": // AMT exemption amount indexing status
-    {"2017": false, // values in future years are same as this year value
-     "2020": true   // values in future years indexed with this year as base
-    }
-}
-"""
-
-
-@pytest.yield_fixture
-def reform_file():
-    """
-    Temporary reform file for Policy read_json_reform_file function.
-    """
-    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
-    rfile.write(REFORM_CONTENTS)
-    rfile.close()
-    # must close and then yield for Windows platform
-    yield rfile
-    if os.path.isfile(rfile.name):
-        try:
-            os.remove(rfile.name)
-        except OSError:
-            pass  # sometimes we can't remove a generated temporary file
-
-
-@pytest.mark.parametrize("set_year", [False, True])
-def test_read_json_reform_file_and_implement_reform(reform_file, set_year):
-    """
-    Test reading and translation of reform file into a reform dictionary
-    that is then used to call implement_reform method.
-    NOTE: implement_reform called when policy.current_year == policy.start_year
-    """
-    reform = Policy.read_json_reform_file(reform_file.name)
-    policy = Policy()
-    if set_year:
-        policy.set_year(2015)
-    policy.implement_reform(reform)
-    syr = policy.start_year
-    amt_brk1 = policy._AMT_brk1
-    assert amt_brk1[2015 - syr] == 200000
-    assert amt_brk1[2016 - syr] > 200000
-    assert amt_brk1[2017 - syr] == 300000
-    assert amt_brk1[2018 - syr] > 300000
-    ii_em = policy._II_em
-    assert ii_em[2016 - syr] == 6000
-    assert ii_em[2017 - syr] == 6000
-    assert ii_em[2018 - syr] == 7500
-    assert ii_em[2019 - syr] > 7500
-    assert ii_em[2020 - syr] == 9000
-    assert ii_em[2021 - syr] > 9000
-    amt_em = policy._AMT_em
-    assert amt_em[2016 - syr, 0] > amt_em[2015 - syr, 0]
-    assert amt_em[2017 - syr, 0] > amt_em[2016 - syr, 0]
-    assert amt_em[2018 - syr, 0] == amt_em[2017 - syr, 0]
-    assert amt_em[2019 - syr, 0] == amt_em[2017 - syr, 0]
-    assert amt_em[2020 - syr, 0] == amt_em[2017 - syr, 0]
-    assert amt_em[2021 - syr, 0] > amt_em[2020 - syr, 0]
-    assert amt_em[2022 - syr, 0] > amt_em[2021 - syr, 0]
-    add4aged = policy._ID_Medical_frt_add4aged
-    assert add4aged[2015 - syr] == -0.025
-    assert add4aged[2016 - syr] == -0.025
-    assert add4aged[2017 - syr] == 0.0
-    assert add4aged[2022 - syr] == 0.0
-
-
 def test_pop_the_cap_reform():
     """
     Test eliminating the maximum taxable earnings (MTE)
@@ -661,25 +566,6 @@ def test_misspecified_reforms():
     # 2016 key:value pair in reform2 (2016:{'_II_em...}) overwrites and
     # replaces the first 2016 key:value pair in reform2 (2016:{'_SS_E...})
     assert not reform1 == reform2
-
-
-@pytest.yield_fixture
-def badreformfile():
-    # specify JSON text for policy reform
-    txt = """{ // example of incorrect JSON because 'x' must be "x"
-               'x': {"2014": [4000]}
-             }"""
-    f = tempfile.NamedTemporaryFile(mode='a', delete=False)
-    f.write(txt + '\n')
-    f.close()
-    # Must close and then yield for Windows platform
-    yield f
-    os.remove(f.name)
-
-
-def test_read_bad_json_reform_file(badreformfile):
-    with pytest.raises(ValueError):
-        Policy.read_json_reform_file(badreformfile.name)
 
 
 def test_convert_reform_dictionary():

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -568,22 +568,6 @@ def test_misspecified_reforms():
     assert not reform1 == reform2
 
 
-def test_convert_reform_dictionary():
-    with pytest.raises(ValueError):
-        rdict = Policy.convert_reform_dictionary({2013: {'2013': [40000]}})
-    with pytest.raises(ValueError):
-        rdict = Policy.convert_reform_dictionary({'_II_em': {2013: [40000]}})
-
-
-def test_reform_pkey_year():
-    with pytest.raises(ValueError):
-        rdict = Policy._reform_pkey_year({4567: {2013: [40000]}})
-    with pytest.raises(ValueError):
-        rdict = Policy._reform_pkey_year({'_II_em': 40000})
-    with pytest.raises(ValueError):
-        rdict = Policy._reform_pkey_year({'_II_em': {'2013': [40000]}})
-
-
 def test_current_law_version():
     syr = 2013
     nyrs = 8

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -35,7 +35,7 @@ def test_reforms(reforms_path):  # pylint: disable=redefined-outer-name
         with open(jrf) as jrfile:
             jrf_text = jrfile.read()
         # check that jrf_text can be implemented as a Policy reform
-        jrf_dict, _, _ = Calculator.read_json_reform_text(jrf_text)
+        jrf_dict, _, _, _ = Calculator.read_json_reform_text(jrf_text)
         policy = Policy()
         policy.implement_reform(jrf_dict)
         # identify policy parameters included in jrf after removing //-comments

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -35,7 +35,7 @@ def test_reforms(reforms_path):  # pylint: disable=redefined-outer-name
         with open(jrf) as jrfile:
             jrf_text = jrfile.read()
         # check that jrf_text can be implemented as a Policy reform
-        jrf_dict = Calculator.read_json_reform_text(jrf_text)
+        jrf_dict, _, _ = Calculator.read_json_reform_text(jrf_text)
         policy = Policy()
         policy.implement_reform(jrf_dict)
         # identify policy parameters included in jrf after removing //-comments

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -11,7 +11,7 @@ import glob
 import re
 import json
 import pytest
-from taxcalc import Policy  # pylint: disable=import-error
+from taxcalc import Calculator, Policy  # pylint: disable=import-error
 
 
 @pytest.fixture(scope='session')
@@ -35,7 +35,7 @@ def test_reforms(reforms_path):  # pylint: disable=redefined-outer-name
         with open(jrf) as jrfile:
             jrf_text = jrfile.read()
         # check that jrf_text can be implemented as a Policy reform
-        jrf_dict = Policy.read_json_reform_text(jrf_text)
+        jrf_dict = Calculator.read_json_reform_text(jrf_text)
         policy = Policy()
         policy.implement_reform(jrf_dict)
         # identify policy parameters included in jrf after removing //-comments

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -117,41 +117,7 @@ def test_incorrect_creation(filename, exact):
         )
 
 
-BAD_REFORM_CONTENTS = """
-{
-  "policy": {
-    "_AMT_brk1": {"2015": [200000], "2017": [300000]}
-  },
-  "behavior": {
-    "_BE_sub": {"2013": [0.2]} // non-empty is illegal for SimpleTaxIO class
-  },
-  "growth": {
-  }
-}
-"""
-
-
-@pytest.yield_fixture
-def bad_reform_file():
-    """
-    Temporary reform file for SimpleTaxIO constructor.
-    """
-    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
-    rfile.write(BAD_REFORM_CONTENTS)
-    rfile.close()
-    # must close and then yield for Windows platform
-    yield rfile
-    if os.path.isfile(rfile.name):
-        try:
-            os.remove(rfile.name)
-        except OSError:
-            pass  # sometimes we can't remove a generated temporary file
-
-
-@pytest.mark.parametrize("reform", [
-    'badname.json',
-    list(),
-    bad_reform_file])
+@pytest.mark.parametrize("reform", ['badname.json', list()])
 def test_invalid_creation_w_file(input_file, reform):
     """
     Test incorrect SimpleTaxIO instantiation with input_file

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -117,10 +117,41 @@ def test_incorrect_creation(filename, exact):
         )
 
 
+BAD_REFORM_CONTENTS = """
+{
+  "policy": {
+    "_AMT_brk1": {"2015": [200000], "2017": [300000]}
+  },
+  "behavior": {
+    "_BE_sub": {"2013": [0.2]} // non-empty is illegal for SimpleTaxIO class
+  },
+  "growth": {
+  }
+}
+"""
+
+
+@pytest.yield_fixture
+def bad_reform_file():
+    """
+    Temporary reform file for SimpleTaxIO constructor.
+    """
+    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    rfile.write(BAD_REFORM_CONTENTS)
+    rfile.close()
+    # must close and then yield for Windows platform
+    yield rfile
+    if os.path.isfile(rfile.name):
+        try:
+            os.remove(rfile.name)
+        except OSError:
+            pass  # sometimes we can't remove a generated temporary file
+
+
 @pytest.mark.parametrize("reform", [
     'badname.json',
     list(),
-    {"policy": {}, "behavior": {"_BE_sub": {"2013": [0.2]}}, "growth":{}}])
+    bad_reform_file])
 def test_invalid_creation_w_file(input_file, reform):
     """
     Test incorrect SimpleTaxIO instantiation with input_file

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -24,7 +24,7 @@ REFORM_CONTENTS = """
 // Example of a reform file suitable for the read_json_reform_file function.
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
-// Within each "policy", "behavior", and "growth" object, the
+// Within each "policy", "behavior", "growth", and "consumption" object, the
 // primary keys are parameters and secondary keys are years.
 // Both the primary and secondary key values must be enclosed in quotes (").
 // Boolean variables are specified as true or false (no quotes; all lowercase).
@@ -60,6 +60,8 @@ REFORM_CONTENTS = """
   "behavior": {
   },
   "growth": {
+  },
+  "consumption": {
   }
 }
 """

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -117,7 +117,10 @@ def test_incorrect_creation(filename, exact):
         )
 
 
-@pytest.mark.parametrize("reform", ['badname.json', list()])
+@pytest.mark.parametrize("reform", [
+    'badname.json',
+    list(),
+    {"policy": {}, "behavior": {"_BE_sub": {"2013": [0.2]}}, "growth":{}}])
 def test_invalid_creation_w_file(input_file, reform):
     """
     Test incorrect SimpleTaxIO instantiation with input_file

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -21,13 +21,15 @@ INPUT_CONTENTS = (
     '4 2015 0 2 0 4039 15000 0    0 0 50000 70000 0 0 0 0 0 0 0 0    0 -3000\n'
 )
 REFORM_CONTENTS = """
-// Example of a reform suitable for use as an optional SimpleTaxIO reform file.
+// Example of a reform file suitable for the read_json_reform_file function.
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
-// The primary keys are policy parameters and secondary keys are years.
+// Within each "policy", "behavior", and "growth" object, the
+// primary keys are parameters and secondary keys are years.
 // Both the primary and secondary key values must be enclosed in quotes (").
 // Boolean variables are specified as true or false (no quotes; all lowercase).
 {
+  "policy": {
     "_AMT_brk1": // top of first AMT tax bracket
     {"2015": [200000],
      "2017": [300000]
@@ -54,6 +56,11 @@ REFORM_CONTENTS = """
     {"2017": false, // values in future years are same as this year value
      "2020": true   // values in future years indexed with this year as base
     }
+  },
+  "behavior": {
+  },
+  "growth": {
+  }
 }
 """
 


### PR DESCRIPTION
This pull request generalizes the JSON reform file so that it includes not only a reform's changed policy parameters, but also the reform's behavioral-response parameters, the reform's growth-implication parameters, and the assumed marginal propensities of consumption used when computing marginal tax rates.  When this pull request is merged into the master branch, Tax-Calculator will require JSON reform files that have a slightly different format as described in the revised documentation.  When these changes are incorporated into TaxBrain there will be a broadening of reform file upload capabilities without any need to expand the capabilities of the TaxBrain file upload page.

The revised IncomeTaxIO class constructor and calculate method illustrate how to use the new generalized JSON reform files.

Part of this pull request revises the Growth class so that it works more like other classes that are derived from the ParametersBase class.

This pull request does not cause any change in core tax-calculating logic, and therefore, causes no changes in unit-test results, validation-test results, or reform-comparison-test results.

@MattHJensen @talumbau @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey 
