### PR TITLE
add dollar limit on itemized deductions

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -356,7 +356,7 @@
         "value": [0.8]
     },
 
-    "_ID_cap": {
+    "_ID_c": {
         "long_name": "Itemized deduction cap",
         "description": "The amount of itemized deductions is capped at this dollar amount. ",
         "irs_ref": "",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -356,6 +356,26 @@
         "value": [0.8]
     },
 
+    "_ID_cap": {
+        "long_name": "Itemized deduction cap",
+        "description": "The amount of itemized deductions is capped at this dollar amount. ",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[1e99, 1e99, 1e99, 1e99, 1e99, 1e99],
+                  [1e99, 1e99, 1e99, 1e99, 1e99, 1e99],
+                  [1e99, 1e99, 1e99, 1e99, 1e99, 1e99],
+                  [1e99, 1e99, 1e99, 1e99, 1e99, 1e99]]
+    },
+
     "_ID_prt": {
         "long_name": "Itemized deduction phaseout rate (Pease)",
         "description": "Taxpayers will not be eligible to deduct the full amount of itemized deduction if their AGI is above the phaseout start. The deductible portion would be decreased at this rate for each dollar exceeding the start.",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -357,8 +357,8 @@
     },
 
     "_ID_c": {
-        "long_name": "Itemized deduction cap",
-        "description": "The amount of itemized deductions is capped at this dollar amount. ",
+        "long_name": "Itemized deduction ceiling",
+        "description": "The amount of itemized deductions is limited to this dollar amount. ",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -290,7 +290,7 @@ def ItemDed(e17500, e18400, e18500,
             ID_Casualty_frt_in_pufcsv_year,
             ID_Casualty_frt, ID_Casualty_hc, ID_Miscellaneous_frt,
             ID_Miscellaneous_hc, ID_Charity_crt_all, ID_Charity_crt_noncash,
-            ID_prt, ID_crt, ID_cap, ID_StateLocalTax_hc, ID_Charity_frt,
+            ID_prt, ID_crt, ID_c, ID_StateLocalTax_hc, ID_Charity_frt,
             ID_Charity_hc, ID_InterestPaid_hc, ID_RealEstate_hc):
     """
     ItemDed function: itemized deductions, Form 1040, Schedule A
@@ -305,7 +305,7 @@ def ItemDed(e17500, e18400, e18500,
 
         ID_prt : Itemized deduction phaseout rate (Pease)
         
-        ID_cap: Dollar limit on itemized deductions
+        ID_c: Dollar limit on itemized deductions
 
         ID_Medical_frt : Deduction for medical expenses;
         floor as a decimal fraction of AGI
@@ -390,7 +390,7 @@ def ItemDed(e17500, e18400, e18500,
     else:
         c21040 = 0.
         c04470 = c21060
-    c04470 = min(c04470, ID_cap[MARS - 1])
+    c04470 = min(c04470, ID_c[MARS - 1])
     return (c17000, c18300, c19200, c20500, c20800, c21040, c21060, c04470,
             c19700)
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -304,7 +304,7 @@ def ItemDed(e17500, e18400, e18500,
         as a decimal fraction of total itemized deduction (Pease)
 
         ID_prt : Itemized deduction phaseout rate (Pease)
-        
+
         ID_c: Dollar limit on itemized deductions
 
         ID_Medical_frt : Deduction for medical expenses;

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -290,7 +290,7 @@ def ItemDed(e17500, e18400, e18500,
             ID_Casualty_frt_in_pufcsv_year,
             ID_Casualty_frt, ID_Casualty_hc, ID_Miscellaneous_frt,
             ID_Miscellaneous_hc, ID_Charity_crt_all, ID_Charity_crt_noncash,
-            ID_prt, ID_crt, ID_StateLocalTax_hc, ID_Charity_frt,
+            ID_prt, ID_crt, ID_cap, ID_StateLocalTax_hc, ID_Charity_frt,
             ID_Charity_hc, ID_InterestPaid_hc, ID_RealEstate_hc):
     """
     ItemDed function: itemized deductions, Form 1040, Schedule A
@@ -304,6 +304,8 @@ def ItemDed(e17500, e18400, e18500,
         as a decimal fraction of total itemized deduction (Pease)
 
         ID_prt : Itemized deduction phaseout rate (Pease)
+        
+        ID_cap: Dollar limit on itemized deductions
 
         ID_Medical_frt : Deduction for medical expenses;
         floor as a decimal fraction of AGI
@@ -388,6 +390,7 @@ def ItemDed(e17500, e18400, e18500,
     else:
         c21040 = 0.
         c04470 = c21060
+    c04470 = min(c04470, ID_cap[MARS - 1])
     return (c17000, c18300, c19200, c20500, c20800, c21040, c21060, c04470,
             c19700)
 
@@ -493,11 +496,11 @@ def StdDed(DSI, _earned, STD, age_head, age_spouse, STD_Aged,
 
 
 @iterate_jit(nopython=True)
-def TaxInc(c00100, _standard, c21060, c21040, c04600, c04800):
+def TaxInc(c00100, _standard, c04470, c04600, c04800):
     """
     TaxInc function: ...
     """
-    c04800 = max(0., c00100 - max(c21060 - c21040, _standard) - c04600)
+    c04800 = max(0., c00100 - max(c04470, _standard) - c04600)
     return c04800
 
 


### PR DESCRIPTION
This PR adds the ability to limit the amount of itemized deductions taken by a filer. The Trump plan sets this at $200,000 for married filing jointly and $100,000 for all others.