### PR TITLE
Fix #1091 by removing erroneous kwa delim_whitespace

### DIFF
--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -681,8 +681,7 @@ def ascii_output(csv_filename, ascii_filename):
     fstring = '{:' + str(col_size) + '}'
     out = out.applymap(fstring.format)
     # write ascii output to specified ascii_filename
-    out.to_csv(ascii_filename, header=False, index=False,
-               delim_whitespace=True, sep='\t')
+    out.to_csv(ascii_filename, header=False, index=False, sep='\t')
 
 
 def mtr_graph_data(calc1, calc2,


### PR DESCRIPTION
Fixes #1091 by removing erroneous keyword arg `delim_whitespace` in `pd.to_csv()` usage