### PR TITLE
Fix #1093 by moving requirements into environment.yml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-pandas
-numpy >= 1.7
-numba
-six
-toolz


### PR DESCRIPTION
To fix #1093:
* I removed the contradicting `pandas` and `numpy` lines in `requirements.txt`. 
* I then found that `numba == 0.26.0` also implicity declares `numpy>=1.7`. Numba was also in the `environment.yml`, but without a version constraint, so I moved this there.
* `six` and `toolz` were declared in both places, so I removed them

That made `requirements.txt` empty, so I removed it. Happy to keep it in if preferred!