### PR TITLE
Add taxcalc/reforms/adjust0.txt with param_code example

### DIFF
--- a/taxcalc/reforms/REFORMS.md
+++ b/taxcalc/reforms/REFORMS.md
@@ -58,6 +58,12 @@ separate, head of household, widow, separate.
 // Boolean variables are specified as true or false (no quotes; all lowercase).
 {
   "policy": {
+    "param_code": {
+        "ALD_Investment_ec_base_code": "e00300 + e00650 + p23250"
+    },
+    "_ALD_Investment_ec_base_code_active":
+    {"2016": [true]
+    },
     "_AMT_brk1": // top of first AMT tax bracket
     {"2015": [200000],
      "2017": [300000]
@@ -121,7 +127,10 @@ Links will be added here.
 
 ### Adjustments
 
-Links will be added here.
+[Specify AGI exclusion of some fraction of investment
+income](adjust0.txt)
+
+Other links will be added here.
 
 ### Exemptions
 

--- a/taxcalc/reforms/adjust0.txt
+++ b/taxcalc/reforms/adjust0.txt
@@ -1,0 +1,22 @@
+// Specify AGI exclusion of some fraction of investment income
+{
+  "policy": {
+    // specify fraction of investment income that can be excluded from AGI
+    "_ALD_Investment_ec_rt": {"2016": [0.50]}
+    // specify "investment income" base to mean the sum of three things:
+    // taxable interest (e00300), qualified dividends (e00650), and
+    // long-term capital gains (p23250) [see functions.py for other
+    // types of investment income that can be included in the base]
+    "param_code": {"ALD_Investment_ec_base_code":
+                   "e00300 + e00650 + p23250"},
+    "_ALD_Investment_ec_base_code_active": {"2016": [true]},
+    // the dollar exclusion is the product of the base defined by code
+    // and the fraction defined above
+  },
+  "behavior": {
+  },
+  "growth": {
+  },
+  "consumption": {
+  }
+}

--- a/taxcalc/reforms/adjust0.txt
+++ b/taxcalc/reforms/adjust0.txt
@@ -2,14 +2,17 @@
 {
   "policy": {
     // specify fraction of investment income that can be excluded from AGI
-    "_ALD_Investment_ec_rt": {"2016": [0.50]}
+    "_ALD_Investment_ec_rt": {"2016": [0.50]},
+
     // specify "investment income" base to mean the sum of three things:
     // taxable interest (e00300), qualified dividends (e00650), and
     // long-term capital gains (p23250) [see functions.py for other
     // types of investment income that can be included in the base]
     "param_code": {"ALD_Investment_ec_base_code":
                    "e00300 + e00650 + p23250"},
-    "_ALD_Investment_ec_base_code_active": {"2016": [true]},
+    // IMPORTANT NOTE: specify only one "param_code" object in "policy" object.
+
+    "_ALD_Investment_ec_base_code_active": {"2016": [true]}
     // the dollar exclusion is the product of the base defined by code
     // and the fraction defined above
   },

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -25,7 +25,8 @@ def reforms_path(tests_path):
 def test_reforms(reforms_path):  # pylint: disable=redefined-outer-name
     """
     Check that each JSON reform file can be converted into a reform dictionary,
-    which can then be passed to the Policy.implement_reform() method.
+    the policy component part of which can then be passed to the Policy class
+    implement_reform() method.
     While doing this, construct a set of Policy parameters (other than those
     ending in '_cpi') included in the JSON reform files.
     """


### PR DESCRIPTION
This pull request adds an example JSON reform file that use the new param_code feature.