### PR TITLE
Add ce_aftertax_income() utility function and test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -50,7 +50,7 @@ py.test -m "not requires_pufcsv"
 ```
 
 This will start executing a pytest suite containing about 300 tests,
-but will skip the four tests that require the `puf.csv` file as input.
+but will skip the three tests that require the `puf.csv` file as input.
 Depending on your computer, the execution time for this incomplete
 suite of tests is roughly two minutes.
 
@@ -66,7 +66,7 @@ py.test
 ```
 
 This will start executing a pytest suite containing about 300 tests,
-including the four tests that require the `puf.csv` file as input.
+including the three tests that require the `puf.csv` file as input.
 Depending on your computer, the execution time for this complete suite
 of unit tests is roughly four minutes.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -49,8 +49,8 @@ cd taxcalc
 py.test -m "not requires_pufcsv"
 ```
 
-This will start executing a pytest suite containing about 300 tests,
-but will skip the three tests that require the `puf.csv` file as input.
+This will start executing a pytest suite containing hundreds of tests,
+but will skip the few tests that require the `puf.csv` file as input.
 Depending on your computer, the execution time for this incomplete
 suite of tests is roughly two minutes.
 
@@ -65,8 +65,8 @@ cd taxcalc
 py.test
 ```
 
-This will start executing a pytest suite containing about 300 tests,
-including the three tests that require the `puf.csv` file as input.
+This will start executing a pytest suite containing hundreds of tests,
+including the few tests that require the `puf.csv` file as input.
 Depending on your computer, the execution time for this complete suite
 of unit tests is roughly four minutes.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -50,7 +50,7 @@ py.test -m "not requires_pufcsv"
 ```
 
 This will start executing a pytest suite containing about 300 tests,
-but will skip the few tests that require the `puf.csv` file as input.
+but will skip the four tests that require the `puf.csv` file as input.
 Depending on your computer, the execution time for this incomplete
 suite of tests is roughly two minutes.
 
@@ -66,9 +66,9 @@ py.test
 ```
 
 This will start executing a pytest suite containing about 300 tests,
-including the few tests that require the `puf.csv` file as input.
+including the four tests that require the `puf.csv` file as input.
 Depending on your computer, the execution time for this complete suite
-of unit tests is roughly three minutes.
+of unit tests is roughly four minutes.
 
 Testing with validation/tests
 -----------------------------

--- a/inctax.py
+++ b/inctax.py
@@ -89,6 +89,15 @@ def main():
                               'with respect to full compensation'),
                         default=False,
                         action="store_true")
+    parser.add_argument('--ceeu',
+                        help=('optional flag that causes normative welfare '
+                              'statistics, including certainty-equivalent '
+                              'expected-utility values for different '
+                              'constant-relative-risk-aversion parameter '
+                              'values, to be written to stdout.  No --ceeu '
+                              'option implies nothing is written to stdout'),
+                        default=False,
+                        action="store_true")
     output = parser.add_mutually_exclusive_group(required=False)
     output.add_argument('--records',
                         help=('optional flag that causes the output file to '
@@ -152,13 +161,15 @@ def main():
         inctax.calculate(writing_output_file=False,
                          exact_output=args.exact,
                          output_weights=args.weights,
-                         output_mtr_wrt_fullcomp=args.fullcomp)
+                         output_mtr_wrt_fullcomp=args.fullcomp,
+                         output_ceeu=args.ceeu)
         inctax.csv_dump(writing_output_file=True)
     else:
         inctax.calculate(writing_output_file=True,
                          exact_output=args.exact,
                          output_weights=args.weights,
-                         output_mtr_wrt_fullcomp=args.fullcomp)
+                         output_mtr_wrt_fullcomp=args.fullcomp,
+                         output_ceeu=args.ceeu)
     # return no-error exit code
     return 0
 # end of main function code

--- a/inctax.py
+++ b/inctax.py
@@ -92,10 +92,14 @@ def main():
     parser.add_argument('--ceeu',
                         help=('optional flag that causes normative welfare '
                               'statistics, including certainty-equivalent '
-                              'expected-utility values for different '
-                              'constant-relative-risk-aversion parameter '
-                              'values, to be written to stdout.  No --ceeu '
-                              'option implies nothing is written to stdout'),
+                              'expected-utility of after-tax income values '
+                              'for different constant-relative-risk-aversion '
+                              'parameter values, to be written to stdout.  '
+                              'No --ceeu option implies nothing is written '
+                              'to stdout.  Note that --reform  option must '
+                              'be specified and aggregate combined taxes '
+                              'under that reform must be same as under '
+                              'current-law policy for this option to work'),
                         default=False,
                         action="store_true")
     output = parser.add_mutually_exclusive_group(required=False)

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -298,7 +298,13 @@ class IncomeTaxIO(object):
                 if not self._calc.behavior.has_response():
                     self._calc_clp.calc_all()
                 cedict = ce_aftertax_income(self._calc_clp, self._calc)
-                print cedict
+                for key in sorted(cedict.keys()):
+                    if key not in ['crra', 'ceeu1', 'ceeu2']:
+                        print "{} {:.3f}".format(key, cedict[key])
+                for crra, ceeu1, ceeu2 in zip(cedict['crra'],
+                                              cedict['ceeu1'],
+                                              cedict['ceeu2']):
+                    print "{} {:9.2f} {:9.2f}".format(crra, ceeu1, ceeu2)
         for idx in range(0, self._calc.records.dim):
             ovar = SimpleTaxIO.extract_output(self._calc.records, idx,
                                               exact=exact_output,

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -288,7 +288,7 @@ class IncomeTaxIO(object):
             empty string if OUTPUT lines are written to a file;
             otherwise output_lines contain all OUTPUT lines
         """
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments,too-many-locals
         output = {}  # dictionary indexed by Records index for filing unit
         (mtr_ptax, mtr_itax,
          _) = self._calc.mtr(wrt_full_compensation=output_mtr_wrt_fullcomp)
@@ -298,24 +298,25 @@ class IncomeTaxIO(object):
                 if not self._calc.behavior.has_response():
                     self._calc_clp.calc_all()
                 cedict = ce_aftertax_income(self._calc_clp, self._calc)
-                str = 'Aggregate {} Pre-Tax Income and Tax Revenue ($billion)'
-                print(str.format(cedict['year']))
-                str = '          baseline    reform   difference'
-                print(str)
-                str = '{}   {:9.1f} {:9.1f}    {:9.1f}'
-                print(str.format('income', cedict['inc1'], cedict['inc2'],
+                # pylint: disable=superfluous-parens
+                msg = 'Aggregate {} Pre-Tax Income and Tax Revenue ($billion)'
+                print(msg.format(cedict['year']))
+                msg = '          baseline    reform   difference'
+                print(msg)
+                msg = '{}   {:9.1f} {:9.1f}    {:9.1f}'
+                print(msg.format('income', cedict['inc1'], cedict['inc2'],
                                  cedict['inc2'] - cedict['inc1']))
-                print(str.format('alltax', cedict['tax1'], cedict['tax2'],
+                print(msg.format('alltax', cedict['tax1'], cedict['tax2'],
                                  cedict['tax2'] - cedict['tax1']))
-                str = 'Certainty-Equivalent After-Tax Expanded Income ($)\n'
-                str += '(assuming consumption equals after-tax income)\n'
-                str += 'crra    baseline    reform    pctdiff'
-                print(str)
-                str = '{} {:14.2f} {:9.2f} {:10.2f}'
+                msg = 'Certainty-Equivalent After-Tax Expanded Income ($)\n'
+                msg += '(assuming consumption equals after-tax income)\n'
+                msg += 'crra    baseline    reform    pctdiff'
+                print(msg)
+                msg = '{} {:14.2f} {:9.2f} {:10.2f}'
                 for crra, ceeu1, ceeu2 in zip(cedict['crra'],
                                               cedict['ceeu1'],
                                               cedict['ceeu2']):
-                    print(str.format(crra, ceeu1, ceeu2,
+                    print(msg.format(crra, ceeu1, ceeu2,
                                      100.0 * (ceeu2 - ceeu1) / ceeu1))
         for idx in range(0, self._calc.records.dim):
             ovar = SimpleTaxIO.extract_output(self._calc.records, idx,

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -299,24 +299,24 @@ class IncomeTaxIO(object):
                     self._calc_clp.calc_all()
                 cedict = ce_aftertax_income(self._calc_clp, self._calc)
                 # pylint: disable=superfluous-parens
-                msg = 'Aggregate {} Pre-Tax Income and Tax Revenue ($billion)'
-                print(msg.format(cedict['year']))
-                msg = '          baseline    reform   difference'
-                print(msg)
-                msg = '{}   {:9.1f} {:9.1f}    {:9.1f}'
-                print(msg.format('income', cedict['inc1'], cedict['inc2'],
+                txt = 'Aggregate {} Pre-Tax Income and Tax Revenue ($billion)'
+                print(txt.format(cedict['year']))
+                txt = '          baseline    reform   difference'
+                print(txt)
+                txt = '{}   {:9.1f} {:9.1f}    {:9.1f}'
+                print(txt.format('income', cedict['inc1'], cedict['inc2'],
                                  cedict['inc2'] - cedict['inc1']))
-                print(msg.format('alltax', cedict['tax1'], cedict['tax2'],
+                print(txt.format('alltax', cedict['tax1'], cedict['tax2'],
                                  cedict['tax2'] - cedict['tax1']))
-                msg = 'Certainty-Equivalent After-Tax Expanded Income ($)\n'
-                msg += '(assuming consumption equals after-tax income)\n'
-                msg += 'crra    baseline    reform    pctdiff'
-                print(msg)
-                msg = '{} {:14.2f} {:9.2f} {:10.2f}'
+                txt = 'Certainty-Equivalent After-Tax Expanded Income ($)\n'
+                txt += '(assuming consumption equals after-tax income)\n'
+                txt += 'crra    baseline    reform    pctdiff'
+                print(txt)
+                txt = '{} {:14.2f} {:9.2f} {:10.2f}'
                 for crra, ceeu1, ceeu2 in zip(cedict['crra'],
                                               cedict['ceeu1'],
                                               cedict['ceeu2']):
-                    print(msg.format(crra, ceeu1, ceeu2,
+                    print(txt.format(crra, ceeu1, ceeu2,
                                      100.0 * (ceeu2 - ceeu1) / ceeu1))
         for idx in range(0, self._calc.records.dim):
             ovar = SimpleTaxIO.extract_output(self._calc.records, idx,

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -298,13 +298,25 @@ class IncomeTaxIO(object):
                 if not self._calc.behavior.has_response():
                     self._calc_clp.calc_all()
                 cedict = ce_aftertax_income(self._calc_clp, self._calc)
-                for key in sorted(cedict.keys()):
-                    if key not in ['crra', 'ceeu1', 'ceeu2']:
-                        print "{} {:.3f}".format(key, cedict[key])
+                str = 'Aggregate {} Pre-Tax Income and Tax Revenue ($billion)'
+                print(str.format(cedict['year']))
+                str = '          baseline    reform   difference'
+                print(str)
+                str = '{}   {:9.1f} {:9.1f}    {:9.1f}'
+                print(str.format('income', cedict['inc1'], cedict['inc2'],
+                                 cedict['inc2'] - cedict['inc1']))
+                print(str.format('alltax', cedict['tax1'], cedict['tax2'],
+                                 cedict['tax2'] - cedict['tax1']))
+                str = 'Certainty-Equivalent After-Tax Expanded Income ($)\n'
+                str += '(assuming consumption equals after-tax income)\n'
+                str += 'crra    baseline    reform    pctdiff'
+                print(str)
+                str = '{} {:14.2f} {:9.2f} {:10.2f}'
                 for crra, ceeu1, ceeu2 in zip(cedict['crra'],
                                               cedict['ceeu1'],
                                               cedict['ceeu2']):
-                    print "{} {:9.2f} {:9.2f}".format(crra, ceeu1, ceeu2)
+                    print(str.format(crra, ceeu1, ceeu2,
+                                     100.0 * (ceeu2 - ceeu1) / ceeu1))
         for idx in range(0, self._calc.records.dim):
             ovar = SimpleTaxIO.extract_output(self._calc.records, idx,
                                               exact=exact_output,

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -318,7 +318,6 @@ def test_7(rawinputfile, reformfile1):  # pylint: disable=redefined-outer-name
     assert inctax.tax_year() == taxyear
 
 
-@pytest.mark.one
 def test_8(reformfile1):  # pylint: disable=redefined-outer-name
     """
     Test IncomeTaxIO calculate method with no output writing using ceeu option.
@@ -337,3 +336,4 @@ def test_8(reformfile1):  # pylint: disable=redefined-outer-name
                          csv_dump=False)
     output = inctax.calculate(writing_output_file=False, output_ceeu=True)
     assert inctax.tax_year() == taxyear
+    assert len(output) > 0

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -302,9 +302,22 @@ def test_7(rawinputfile, reformfile1):  # pylint: disable=redefined-outer-name
     Test IncomeTaxIO calculate method with no output writing using ceeu option.
     """
     taxyear = 2020
+    # test using reformfile1
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
                          reform=reformfile1.name,
+                         exact_calculations=False,
+                         blowup_input_data=False,
+                         output_weights=False,
+                         output_records=False,
+                         csv_dump=False)
+    inctax.calculate(writing_output_file=False, output_ceeu=True)
+    assert inctax.tax_year() == taxyear
+    # test using reform dictionary
+    reformdict = {2013: {'_LST': [500]}}
+    inctax = IncomeTaxIO(input_data=rawinputfile.name,
+                         tax_year=taxyear,
+                         reform=reformdict,
                          exact_calculations=False,
                          blowup_input_data=False,
                          output_weights=False,

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -23,6 +23,7 @@ RAWINPUTFILE_CONTENTS = (
     u'    4,   6\n'
 )
 
+
 EXPECTED_OUTPUT = (  # from using RAWINPUTFILE_CONTENTS as input
     '1. 2021 0 0.00 0.00 0.00 -7.65 0.00 15.30 0.00 0.00 0.00 0.00 0.00 '
     '0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00\n'
@@ -177,6 +178,9 @@ REFORM_CONTENTS = """
     "_AMT_em_cpi": // AMT exemption amount indexing status
     {"2017": false, // values in future years are same as this year value
      "2020": true   // values in future years indexed with this year as base
+    },
+    "_LST": // Lump-Sum Tax
+    {"2013": [500]
     }
   },
   "behavior": {
@@ -302,7 +306,6 @@ def test_7(rawinputfile, reformfile1):  # pylint: disable=redefined-outer-name
     Test IncomeTaxIO calculate method with no output writing using ceeu option.
     """
     taxyear = 2020
-    # test using reformfile1
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
                          reform=reformfile1.name,
@@ -313,15 +316,24 @@ def test_7(rawinputfile, reformfile1):  # pylint: disable=redefined-outer-name
                          csv_dump=False)
     inctax.calculate(writing_output_file=False, output_ceeu=True)
     assert inctax.tax_year() == taxyear
-    # test using reform dictionary
-    reformdict = {2013: {'_LST': [500]}}
-    inctax = IncomeTaxIO(input_data=rawinputfile.name,
+
+
+@pytest.mark.one
+def test_8(reformfile1):  # pylint: disable=redefined-outer-name
+    """
+    Test IncomeTaxIO calculate method with no output writing using ceeu option.
+    """
+    # test using reform dictionary and weights
+    taxyear = 2020
+    recdict = {'RECID': 1, 'MARS': 1, 's006': 99}
+    recdf = pd.DataFrame(data=recdict, index=[0])
+    inctax = IncomeTaxIO(input_data=recdf,
                          tax_year=taxyear,
-                         reform=reformdict,
+                         reform=reformfile1.name,
                          exact_calculations=False,
                          blowup_input_data=False,
-                         output_weights=False,
+                         output_weights=True,
                          output_records=False,
                          csv_dump=False)
-    inctax.calculate(writing_output_file=False, output_ceeu=True)
+    output = inctax.calculate(writing_output_file=False, output_ceeu=True)
     assert inctax.tax_year() == taxyear

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -295,3 +295,20 @@ def test_6(rawinputfile):  # pylint: disable=redefined-outer-name
                          csv_dump=True)
     inctax.csv_dump(writing_output_file=False)
     assert inctax.tax_year() == taxyear
+
+
+def test_7(rawinputfile, reformfile1):  # pylint: disable=redefined-outer-name
+    """
+    Test IncomeTaxIO calculate method with no output writing using ceeu option.
+    """
+    taxyear = 2020
+    inctax = IncomeTaxIO(input_data=rawinputfile.name,
+                         tax_year=taxyear,
+                         reform=reformfile1.name,
+                         exact_calculations=False,
+                         blowup_input_data=False,
+                         output_weights=False,
+                         output_records=False,
+                         csv_dump=False)
+    inctax.calculate(writing_output_file=False, output_ceeu=True)
+    assert inctax.tax_year() == taxyear

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -721,3 +721,38 @@ def test_string_to_number():
     assert string_to_number('1') == 1
     assert string_to_number('1.') == 1.
     assert string_to_number('1.23') == 1.23
+
+
+@pytest.fixture(scope='session')
+def puf_path(tests_path):
+    """
+    The path to the puf.csv taxpayer data file at repo root
+    """
+    return os.path.join(tests_path, '..', '..', 'puf.csv')
+
+
+@pytest.mark.requires_pufcsv
+def test_ce_aftertax_income(puf_path):
+    cyr = 2020
+    # specify calc1 and calc_all() for cyr
+    pol1 = Policy()
+    rec1 = Records(data=puf_path)
+    num_rec1 = rec1.dim
+    calc1 = Calculator(policy=pol1, records=rec1)
+    calc1.advance_to_year(cyr)
+    calc1.calc_all()
+    # specify calc2 and calc_all() for cyr
+    pol2 = Policy()
+    reform = {2018: {'_II_em': [0.0], '_LST': [-551.313]}}
+    pol2.implement_reform(reform)
+    rec2 = Records(data=puf_path)
+    num_rec2 = rec2.dim
+    assert num_rec1 == num_rec2
+    calc2 = Calculator(policy=pol2, records=rec2)
+    calc2.advance_to_year(cyr)
+    calc2.calc_all()
+    cedict = ce_aftertax_income(calc1, calc2)
+    assert cedict['year'] == cyr
+    assert cedict['crra'] == 2
+    assert round(cedict['ce2zero'], 3) == round(cedict['ce1zero'], 3)
+    assert cedict['ce2crra'] > cedict['ce1crra']

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -723,36 +723,30 @@ def test_string_to_number():
     assert string_to_number('1.23') == 1.23
 
 
-@pytest.fixture(scope='session')
-def puf_path(tests_path):
-    """
-    The path to the puf.csv taxpayer data file at repo root
-    """
-    return os.path.join(tests_path, '..', '..', 'puf.csv')
-
-
-@pytest.mark.requires_pufcsv
-def test_ce_aftertax_income(puf_path):
+@pytest.mark.one
+def test_ce_aftertax_income(puf_1991, weights_1991):
+    # test with require_no_agg_tax_change equal to False
     cyr = 2020
     # specify calc1 and calc_all() for cyr
     pol1 = Policy()
-    rec1 = Records(data=puf_path)
+    rec1 = Records(data=puf_1991, weights=weights_1991, start_year=2009)
     num_rec1 = rec1.dim
     calc1 = Calculator(policy=pol1, records=rec1)
     calc1.advance_to_year(cyr)
     calc1.calc_all()
     # specify calc2 and calc_all() for cyr
     pol2 = Policy()
-    reform = {2018: {'_II_em': [0.0], '_LST': [-551.313]}}
+    reform = {2018: {'_II_em': [0.0], '_LST': [0.0]}}
     pol2.implement_reform(reform)
-    rec2 = Records(data=puf_path)
+    rec2 = Records(data=puf_1991, weights=weights_1991, start_year=2009)
     num_rec2 = rec2.dim
     assert num_rec1 == num_rec2
     calc2 = Calculator(policy=pol2, records=rec2)
     calc2.advance_to_year(cyr)
     calc2.calc_all()
-    cedict = ce_aftertax_income(calc1, calc2)
+    cedict = ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=False)
     assert cedict['year'] == cyr
     assert cedict['crra'] == 2
-    assert round(cedict['ce2zero'], 3) == round(cedict['ce1zero'], 3)
-    assert cedict['ce2crra'] > cedict['ce1crra']
+    # test with require_no_agg_tax_change equal to True
+    with pytest.raises(ValueError):
+        ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -747,10 +747,12 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     calc2 = Calculator(policy=pol2, records=rec2)
     calc2.advance_to_year(cyr)
     calc2.calc_all()
-    cedict = ce_aftertax_income(calc1, calc2, crra_value=crra,
-                                require_no_agg_tax_change=False)
+    cedict = ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=False)
     assert cedict['year'] == cyr
-    assert cedict['crra'] == crra
     # test with require_no_agg_tax_change equal to True
     with pytest.raises(ValueError):
         ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True)
+    params = {'crra_list': [0, 2], 'cmin_value': 2000}
+    with pytest.raises(ValueError):
+        ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True,
+                           custom_params=params)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -724,16 +724,17 @@ def test_string_to_number():
 
 
 def test_ce_aftertax_income(puf_1991, weights_1991):
-    # test certainty_equivalen() function
-    assert 1.0e4 == round(certainty_equivalent(1.0e4, 0, 1.0e3), 3)
-    assert 1.0e4 > round(certainty_equivalent(9.2, 1, 1.0e3), 3)
+    # test certainty_equivalent() function
+    con = 10000
+    cmin = 1000
+    assert con == round(certainty_equivalent(con, 0, cmin), 6)
+    assert con > round(certainty_equivalent((math.log(con) - 0.1), 1, cmin), 6)
     # test with require_no_agg_tax_change equal to False
     cyr = 2020
     crra = 1
     # specify calc1 and calc_all() for cyr
     pol1 = Policy()
     rec1 = Records(data=puf_1991, weights=weights_1991, start_year=2009)
-    num_rec1 = rec1.dim
     calc1 = Calculator(policy=pol1, records=rec1)
     calc1.advance_to_year(cyr)
     calc1.calc_all()
@@ -742,8 +743,6 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     reform = {2018: {'_II_em': [0.0]}}
     pol2.implement_reform(reform)
     rec2 = Records(data=puf_1991, weights=weights_1991, start_year=2009)
-    num_rec2 = rec2.dim
-    assert num_rec1 == num_rec2
     calc2 = Calculator(policy=pol2, records=rec2)
     calc2.advance_to_year(cyr)
     calc2.calc_all()
@@ -752,6 +751,7 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     # test with require_no_agg_tax_change equal to True
     with pytest.raises(ValueError):
         ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True)
+    # test with require_no_agg_tax_change equal to False and custom_params
     params = {'crra_list': [0, 2], 'cmin_value': 2000}
     with pytest.raises(ValueError):
         ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True,

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -723,10 +723,10 @@ def test_string_to_number():
     assert string_to_number('1.23') == 1.23
 
 
-@pytest.mark.one
 def test_ce_aftertax_income(puf_1991, weights_1991):
     # test with require_no_agg_tax_change equal to False
     cyr = 2020
+    crra = 1
     # specify calc1 and calc_all() for cyr
     pol1 = Policy()
     rec1 = Records(data=puf_1991, weights=weights_1991, start_year=2009)
@@ -736,7 +736,7 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     calc1.calc_all()
     # specify calc2 and calc_all() for cyr
     pol2 = Policy()
-    reform = {2018: {'_II_em': [0.0], '_LST': [0.0]}}
+    reform = {2018: {'_II_em': [0.0]}}
     pol2.implement_reform(reform)
     rec2 = Records(data=puf_1991, weights=weights_1991, start_year=2009)
     num_rec2 = rec2.dim
@@ -744,9 +744,10 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     calc2 = Calculator(policy=pol2, records=rec2)
     calc2.advance_to_year(cyr)
     calc2.calc_all()
-    cedict = ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=False)
+    cedict = ce_aftertax_income(calc1, calc2, crra_value=crra,
+                                require_no_agg_tax_change=False)
     assert cedict['year'] == cyr
-    assert cedict['crra'] == 2
+    assert cedict['crra'] == crra
     # test with require_no_agg_tax_change equal to True
     with pytest.raises(ValueError):
         ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -724,6 +724,8 @@ def test_string_to_number():
 
 
 def test_ce_aftertax_income(puf_1991, weights_1991):
+    # test certainty_equivalen() function
+    assert 1.0e4 == round(certainty_equivalent(1.0e4, 0, 1.0e3), 3)
     # test with require_no_agg_tax_change equal to False
     cyr = 2020
     crra = 1
@@ -744,12 +746,6 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     calc2 = Calculator(policy=pol2, records=rec2)
     calc2.advance_to_year(cyr)
     calc2.calc_all()
-    cedict = ce_aftertax_income(calc1, calc2, crra_value=crra,
-                                require_no_agg_tax_change=False)
-    assert cedict['year'] == cyr
-    assert cedict['crra'] == crra
-    # test with require_no_agg_tax_change equal to False and higher income
-    calc2.records._expanded_income += 1.0e5
     cedict = ce_aftertax_income(calc1, calc2, crra_value=crra,
                                 require_no_agg_tax_change=False)
     assert cedict['year'] == cyr

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -726,6 +726,7 @@ def test_string_to_number():
 def test_ce_aftertax_income(puf_1991, weights_1991):
     # test certainty_equivalen() function
     assert 1.0e4 == round(certainty_equivalent(1.0e4, 0, 1.0e3), 3)
+    assert 1.0e4 > round(certainty_equivalent(9.2, 1, 1.0e3), 3)
     # test with require_no_agg_tax_change equal to False
     cyr = 2020
     crra = 1

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -748,6 +748,12 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
                                 require_no_agg_tax_change=False)
     assert cedict['year'] == cyr
     assert cedict['crra'] == crra
+    # test with require_no_agg_tax_change equal to False and higher income
+    calc2.records._expanded_income += 1.0e5
+    cedict = ce_aftertax_income(calc1, calc2, crra_value=crra,
+                                require_no_agg_tax_change=False)
+    assert cedict['year'] == cyr
+    assert cedict['crra'] == crra
     # test with require_no_agg_tax_change equal to True
     with pytest.raises(ValueError):
         ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True)

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1119,6 +1119,28 @@ def string_to_number(string):
         return float(string)
 
 
+def certainty_equivalent(exputil, crra, c_min):
+    """
+    Return certainty-equivalent consumption for the specified value of
+    expected utility, exputil, and the specified constant-relative-risk-
+    aversion, crra, of an isoelastic utility function.
+    Note: exputil and crra and c_min are floats
+    Note: returned certainty equivalent value is a float
+    """
+    if crra == 1.0:
+        tu_at_c_min = math.log(c_min)
+    else:
+        tu_at_c_min = math.pow(c_min, (1.0 - crra)) / (1.0 - crra)
+    if exputil >= tu_at_c_min:
+        if crra == 1.0:
+            return math.exp(exputil)
+        else:
+            return math.pow((exputil * (1.0 - crra)), (1.0 / (1.0 - crra)))
+    else:
+        mu_at_c_min = math.pow(c_min, -crra)
+        return ((exputil - tu_at_c_min) / mu_at_c_min) + c_min
+
+
 def ce_aftertax_income(calc1, calc2,
                        crra_value=2,
                        require_no_agg_tax_change=True,
@@ -1177,27 +1199,6 @@ def ce_aftertax_income(calc1, calc2,
         utility = consumption.apply(isoelastic_utility_function, args=(crra,))
         return np.inner(utility, probability)
 
-    def certainty_equivalent(exputil, crra):
-        """
-        Return certainty-equivalent consumption for the specified value of
-        expected utility, exputil, and the specified constant-relative-risk-
-        aversion, crra, of an isoelastic utility function.
-        Note: exputil and crra are floats
-        Note: returned certainty equivalent value is a float
-        """
-        if crra == 1.0:
-            tu_at_c_min = math.log(c_min)
-        else:
-            tu_at_c_min = math.pow(c_min, (1.0 - crra)) / (1.0 - crra)
-        if exputil >= tu_at_c_min:
-            if crra == 1.0:
-                return math.exp(exputil)
-            else:
-                return math.pow((exputil * (1.0 - crra)), (1.0 / (1.0 - crra)))
-        else:
-            mu_at_c_min = math.pow(c_min, -crra)
-            return ((exputil - tu_at_c_min) / mu_at_c_min) + c_min
-
     # extract calc_all() data from calc1 and calc2
     record_columns = ['s006', '_payrolltax', '_iitax',
                       '_combined', '_expanded_income']
@@ -1232,14 +1233,14 @@ def ce_aftertax_income(calc1, calc2,
     # calculate certainty-equivaluent after-tax income in calc1 and calc2
     crra = 0
     e_u = expected_utility(ati1, prob, crra)
-    cedict['ce1zero'] = certainty_equivalent(e_u, crra)
+    cedict['ce1zero'] = certainty_equivalent(e_u, crra, c_min)
     e_u = expected_utility(ati2, prob, crra)
-    cedict['ce2zero'] = certainty_equivalent(e_u, crra)
+    cedict['ce2zero'] = certainty_equivalent(e_u, crra, c_min)
     crra = crra_value
     cedict['crra'] = crra_value
     e_u = expected_utility(ati1, prob, crra)
-    cedict['ce1crra'] = certainty_equivalent(e_u, crra)
+    cedict['ce1crra'] = certainty_equivalent(e_u, crra, c_min)
     e_u = expected_utility(ati2, prob, crra)
-    cedict['ce2crra'] = certainty_equivalent(e_u, crra)
+    cedict['ce2crra'] = certainty_equivalent(e_u, crra, c_min)
     # return cedict
     return cedict

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1128,10 +1128,10 @@ def isoelastic_utility_function(consumption, crra, cmin):
     consumption : float
       consumption for a filing unit
 
-    crra : float
+    crra : non-negative float
       constant relative risk aversion parameter
 
-    cmin : float
+    cmin : positive float
       consumption level below which marginal utility is assumed to be constant
 
     Returns
@@ -1165,10 +1165,10 @@ def expected_utility(consumption, probability, crra, cmin):
     probability : numpy array
       samplying probability of each filing unit
 
-    crra : float
+    crra : non-negative float
       constant relative risk aversion parameter of isoelastic utility function
 
-    cmin : float
+    cmin : positive float
       consumption level below which marginal utility is assumed to be constant
 
     Returns
@@ -1190,10 +1190,10 @@ def certainty_equivalent(exputil, crra, cmin):
     exputil : float
       expected utility value
 
-    crra : float
+    crra : non-negative float
       constant relative risk aversion parameter of isoelastic utility function
 
-    cmin : float
+    cmin : positive float
       consumption level below which marginal utility is assumed to be constant
 
     Returns
@@ -1218,12 +1218,12 @@ def ce_aftertax_income(calc1, calc2,
                        custom_params=None,
                        require_no_agg_tax_change=True):
     """
-    Return dictionary that contains certainty-equivalent after-tax income
-    computed for two constant-relative-risk-aversion parameter values
-    (zero and the specified crra_value) for each of two specified
-    Calculator objects: calc1, which represents the pre-reform situation,
-    and calc2, which represents the post-reform situation, both of which
-    MUST have had calc_call() called before being passed to this function.
+    Return dictionary that contains certainty-equivalent of the expected
+    utility of after-tax income computed for constant-relative-risk-aversion
+    parameter values for each of two Calculator objects: calc1, which
+    represents the pre-reform situation, and calc2, which represents the
+    post-reform situation, both of which MUST have had calc_call() called
+    before being passed to this function.
 
     IMPORTANT NOTES: These normative welfare calculations are very simple.
     It is assumed that utility is a function of only consumption, and that

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1231,10 +1231,8 @@ def ce_aftertax_income(calc1, calc2,
             msg += '\n taxes2= {:9.3f}'
             msg += '\n txdiff= {:9.3f}'
             raise ValueError(msg.format(cedict['tax1'], cedict['tax2'], diff))
-    inc = weighted_sum(df1, '_expanded_income') * billion
-    cedict['ati1'] = inc - cedict['tax1']
-    inc = weighted_sum(df2, '_expanded_income') * billion
-    cedict['ati2'] = inc - cedict['tax2']
+    cedict['inc1'] = weighted_sum(df1, '_expanded_income') * billion
+    cedict['inc2'] = weighted_sum(df2, '_expanded_income') * billion
     # calculate sample-weighted probability of each filing unit
     prob_raw = np.divide(df1['s006'], df1['s006'].sum())
     prob = np.divide(prob_raw, prob_raw.sum())  # handle any rounding error

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1265,7 +1265,7 @@ def ce_aftertax_income(calc1, calc2,
     cedict['tax2'] = weighted_sum(df2, '_combined') * billion
     if require_no_agg_tax_change:
         diff = cedict['tax2'] - cedict['tax1']
-        if abs(diff) > 0.0005:
+        if abs(diff) >= 0.0005:
             msg = 'Aggregate taxes not equal when required_... arg is True:'
             msg += '\n            taxes1= {:9.3f}'
             msg += '\n            taxes2= {:9.3f}'

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1266,10 +1266,12 @@ def ce_aftertax_income(calc1, calc2,
     if require_no_agg_tax_change:
         diff = cedict['tax2'] - cedict['tax1']
         if abs(diff) > 0.0005:
-            msg = 'Aggregate taxes not equal when required is True:'
-            msg += '\n taxes1= {:9.3f}'
-            msg += '\n taxes2= {:9.3f}'
-            msg += '\n txdiff= {:9.3f}'
+            msg = 'Aggregate taxes not equal when required_... arg is True:'
+            msg += '\n            taxes1= {:9.3f}'
+            msg += '\n            taxes2= {:9.3f}'
+            msg += '\n            txdiff= {:9.3f}'
+            msg += ('\n(adjust _LST or other parameter to bracket txdiff=0 '
+                    'and then interpolate)')
             raise ValueError(msg.format(cedict['tax1'], cedict['tax2'], diff))
     cedict['inc1'] = weighted_sum(df1, '_expanded_income') * billion
     cedict['inc2'] = weighted_sum(df2, '_expanded_income') * billion

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1123,7 +1123,9 @@ def certainty_equivalent(exputil, crra, c_min):
     """
     Return certainty-equivalent consumption for the specified value of
     expected utility, exputil, and the specified constant-relative-risk-
-    aversion, crra, of an isoelastic utility function.
+    aversion, crra, of an isoelastic utility function.  The c_min value
+    is the consumption level below which marginal utility is considered
+    to be constant.
     Note: exputil and crra and c_min are floats
     Note: returned certainty equivalent value is a float
     """
@@ -1166,6 +1168,10 @@ def ce_aftertax_income(calc1, calc2,
     assert crra_value > 0.0
     assert minimum_ati > 0.0
     c_min = minimum_ati
+    # The c_min==minimum_ati value is the consumption level below which
+    # marginal utility is considered to be constant.  This allows the
+    # handling of filing units with very low or even negative after-tax
+    # income in the expected-utility and certainty-equivalent calculations.
 
     def isoelastic_utility_function(consumption, crra):
         """


### PR DESCRIPTION
The pull request implements as an optional utility function the kind of expected-utility normative welfare analysis discussed in issue #1050, which was raised by @gleiserson (Greg Leiserson).

This pull request also adds to the `inctax.py` command-line inteface to Tax-Calculator an option called `--ceeu` that uses the new utility function to compute certainty-equivalent expected-utility results for the specified reform.

Comments and suggestions are welcome.

@MattHJensen @feenberg @Amy-Xu @GoFroggyRun @andersonfrailey @zrisher @codykallen