### PR TITLE
EMTR on charitable contributions

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -250,7 +250,7 @@ class Calculator(object):
                            'e02000', 'e02400',
                            'p22250', 'p23250',
                            'e18500', 'e19200',
-                           'e26270']
+                           'e26270', 'e19800']
 
     def mtr(self, variable_str='e00200p',
             negative_finite_diff=False,
@@ -314,7 +314,8 @@ class Calculator(object):
         'p23250',  long-term capital gains;
         'e18500',  Schedule A real-estate-tax deduction;
         'e19200',  Schedule A total-interest deduction;
-        'e26270',  S-corporation/partnership income (also included in e02000).
+        'e26270',  S-corporation/partnership income (also included in e02000);
+        'e19800',  Charity cash contributions.
         """
         # check validity of variable_str parameter
         if variable_str not in Calculator.MTR_VALID_VARIABLES:

--- a/taxcalc/tests/pufcsv_mtr_expect.txt
+++ b/taxcalc/tests/pufcsv_mtr_expect.txt
@@ -49,3 +49,6 @@ PTAX and ITAX mtr histogram bin counts for e19200:
 PTAX and ITAX mtr histogram bin counts for e26270:
 219814 : 219814      0      0      0      0      0      0      0      0      0
 219814 :      0      0      0      0  53606  69554  46063  28185  21699    707
+PTAX and ITAX mtr histogram bin counts for e19800:
+219814 : 219814      0      0      0      0      0      0      0      0      0
+219814 :  33386  29253  18977   5269 132929      0      0      0      0      0


### PR DESCRIPTION
This PR adds the ability to calculate the EMTR on charitable contributions. Since this is negative, this should be interpreted as the effective marginal subsidy on charitable contributions. 

Due to limited data on non-itemizers, this MTR should only be considered valid when called on a current law calculator or a reform that reduces or limits itemized deductions. It should also be considered valid only for small values of finite_diff (e.g. the default value of finite_diff of 0.01). 

This MTR is useful for estimating the impact of a reform on charitable giving. A reform that limits itemized deductions also reduces the marginal subsidy for charitable contributions, causing individuals to reduce charitable giving.

