### PR TITLE
Reorganize parameters -- will facilitate TaxBrain updates

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -411,6 +411,28 @@
         "validations": {"min": "default"}
     },
 
+    "_STD_Dep": {
+        "long_name": "Standard deduction for dependents",
+        "description": "This is the maximum standard deduction for dependents.",
+        "section_1": "Standard deduction",
+        "irs_ref": "form 1040, line 40, instructions.",
+        "notes": "This parameter cannot be decreased due to lack of data.",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["dependent"],
+        "value": [ 1000,
+                   1000,
+                   1050,
+                   1050],
+        "validations": {"min": "default"}
+    },
+
     "_STD_Aged": {
         "long_name": "Additional standard deduction for blind and aged",
         "description": "To get the standard deduction for aged or blind individuals, taxpayers need to add this value to regular standard deduction",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1,7 +1,25 @@
 {
-    "_SS_Earnings_c": {
-        "long_name": "Maximum Taxable Earnings for Social Security",
+    "_FICA_ss_trt": {
+        "long_name": "Social Security payroll tax rate",
+        "description": "Social Security FICA rate, including both employer and employee.",
+        "section_1": "Payroll Taxes",
+        "section_2": "Social Security FICA",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.124]
+    },
+
+        "_SS_Earnings_c": {
+        "long_name": "Maximum taxable earnings for Social Security",
         "description": "Only individual earnings below this maximum amount are subjected to Social Security (OASDI) payroll tax.",
+        "section_1": "Payroll Taxes",
+        "section_2": "Social Security FICA",
         "irs_ref": "W-2, Box 4, instructions",
         "notes": "This parameter is indexed by the rate of growth in average wages, not by the inflation rate.",
         "start_year": 2013,
@@ -19,23 +37,11 @@
                   118500]
     },
 
-    "_FICA_ss_trt": {
-        "long_name": "Social Security payroll tax rate",
-        "description": "Social Security FICA rate, including both employer and employee.",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.124]
-    },
-
     "_FICA_mc_trt": {
         "long_name": "Medicare payroll tax rate",
         "description": "Medicare FICA rate, including both employer and employee.",
+        "section_1": "Payroll taxes",
+        "section_2": "Medicare FICA",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -47,9 +53,103 @@
         "value": [0.029]
     },
 
+        "_AMEDT_ec": {
+        "long_name": "Additional Medicare tax earnings exclusion",
+        "description": "The Additional Medicare Tax rate, _AMEDT_rt, applies to all earnings in excess of this excluded amount.",
+        "section_1": "Payroll taxes",
+        "section_2": "Additional Medicare FICA",
+        "irs_ref": "Form 8959, line 5, in-line. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[200000, 250000, 125000, 200000, 200000, 125000]]
+    },
+
+    "_AMEDT_rt": {
+        "long_name": "Additional Medicare tax rate",
+        "description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding the Additional Medicare Tax earning exclusion.",
+        "section_1": "Payroll taxes",
+        "section_2": "Additional Medicare FICA",
+        "irs_ref": "Form 8959, line 7, in-line. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.009]
+    },
+
+
+    "_SS_thd50": {
+        "long_name": "Threshold for Social Security benefit taxability 1",
+        "description": "The first threshold for Social Security benefit taxability: if taxpayers have provisional income greater than this threshold, up to 50% of their Social Security benefit will be subject to tax under current law.",
+        "section_1": "Social Security taxability",
+        "irs_ref": "Form 1040, line 20a&b, calculation (Worksheet, line 8.)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[25000, 32000, 25000, 25000, 25000, 25000]]
+    },
+
+        "_SS_percentage1": {
+        "long_name": "Social Security taxable income decimal fraction 1",
+        "description": "Under current law if their provisional income is above the first threshold for Social Security taxability but below the second threshold, taxpayers need to apply this fraction to both the excess of their provisional income over the first threshold and their Social Security benefits, and then include the smaller one in their AGI.",
+        "section_1": "Social Security taxability",
+        "irs_ref": "Form 1040, line 20b, instructions (Social Security Worksheets, line 2 & 13)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.5]
+    },
+
+    "_SS_thd85": {
+        "long_name": "Threshold for Social Security benefit taxability 2",
+        "description": "The second threshold for Social Security taxability: if taxpayers have provisional income greater than this threshold, up to 85% of their Social Security benefit will be subject to tax under current law.",
+        "section_1": "Social Security taxability",
+        "irs_ref": "Form 1040, line 20a&b, calculation (Worksheet, add line 10 values to line 8).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[34000, 44000, 34000, 34000, 34000, 34000]]
+    },
+
+    "_SS_percentage2": {
+        "long_name": "Social Security taxable income decimal fraction 2",
+        "description": "Under current law if their provisional income is above the second threshold for Social Security taxability, taxpayers need to apply this fraction to both the excess of their provisional income over the second threshold and their social security benefits, and then include the smaller one in their AGI.",
+        "section_1": "Social Security taxability",
+        "irs_ref": "Form 1040, line 20b, instructions (Social Security Worksheets, line 15)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.85]
+    },
+
+
     "_ALD_StudentLoan_hc": {
         "long_name": "Adjustment for student loan interest haircut",
         "description": "This decimal fraction can be applied to limit the student loan interest adjustment allowed. ",
+        "section_1": "Above the line deductions",
+        "section_2": "Misc. adjustment haircuts",
         "irs_ref": "Form 1040, line 33",
         "notes": "The final adjustment amount will be (1- Haircut) * Student Loan Interest. ",
         "start_year": 2013,
@@ -64,6 +164,8 @@
     "_ALD_SelfEmploymentTax_hc": {
         "long_name": "Adjustment for self-employment tax haircut",
         "description": "This decimal fraction, if greater than zero, reduces the employer equivalent portion of self-employment adjustment. ",
+        "section_1": "Above the line deductions",
+        "section_2": "Misc. adjustment haircuts",
         "irs_ref": "Form 1040, line 27",
         "notes": "The final adjustment amount would be (1 - Haircut) * Self Employment Tax Adjustment. ",
         "start_year": 2013,
@@ -78,6 +180,8 @@
     "_ALD_SelfEmp_HealthIns_hc": {
         "long_name": "Adjustment for self employed health insurance haircut",
         "description": "This decimal fraction, if greater than zero, reduces the health insurance adjustment for self-employed taxpayers. ",
+        "section_1": "Above the line deductions",
+        "section_2": "Misc. adjustment haircuts",
         "irs_ref": "Form 1040, line 29",
         "notes": "The final adjustment amount would be (1 - Haircut) * self-employed health insurance adjustment. ",
         "start_year": 2013,
@@ -92,6 +196,8 @@
     "_ALD_KEOGH_SEP_hc": {
         "long_name": "Adjustment for payment to either KEOGH or SEP plan haircut",
         "description": "Under current law, payments to Keogh or SEP plans can be fully deducted from gross income. Taxpayers can use this haircut to limit the adjustment allowed. ",
+        "section_1": "Above the line deductions",
+        "section_2": "Misc. adjustment haircuts",
         "irs_ref": "Form 1040, line 28",
         "notes": "The final adjustment amount is (1 - Haircut) * KEOGH/SEP plan payments",
         "start_year": 2013,
@@ -106,6 +212,8 @@
     "_ALD_EarlyWithdraw_hc": {
         "long_name": "Adjustment for forfeited interest penalty haircut",
         "description": "Under current law, early withdraw penalty can be fully deducted from gross income. Taxpayers can use this haircut to limit the adjustment allowed.",
+        "section_1": "Above the line deductions",
+        "section_2": "Misc. adjustment haircuts",
         "irs_ref": "Form 1040, line 30",
         "notes": "The final adjustment amount is (1 - Haircut) * Early withdraw penalty",
         "start_year": 2013,
@@ -120,6 +228,8 @@
     "_ALD_Alimony_hc": {
         "long_name": "Adjustment for alimony payment haircut",
         "description": "Under current law, the full amount of alimony payment is taken as an adjustment from gross income in arriving at AGI. Taxpayers can use this haircut to limit the deduction allowed.",
+        "section_1": "Above the line deductions",
+        "section_2": "Misc. adjustment haircuts",
         "irs_ref": "Form 1040, line 31",
         "notes": "The final adjustment amount would be (1 - Haircut) * Alimony Payments",
         "start_year": 2013,
@@ -134,6 +244,8 @@
     "_ALD_Investment_ec_rt": {
         "long_name": "Investment income exclusion rate",
         "description": "Decimal fraction of investment income base that can be excluded from AGI.",
+        "section_1": "Above the line deductions",
+        "section_2": "Misc. exclusions",
         "irs_ref": "Form 1040, line 8a",
         "notes": "The final taxable investment income will be (1-_ALD_Investment_ec_rt)*investment_income_base. Even though the excluded portion of investment income is not included in AGI, it still is included in investment income used to calculate the Net Investment Income Tax and Earned Income Tax Credit.",
         "start_year": 2013,
@@ -162,6 +274,8 @@
     "_ALD_Dependents_hc": {
         "long_name": "Deduction for childcare costs",
         "description": "This decimal fraction, if greater than zero, reduces the portion of childcare costs that can be deducted from AGI",
+        "section_1": "Above the line deductions",
+        "section_2": "Child and elderly care",
         "irs_ref": "",
         "notes": "The final adjustment would be (1 - Haircut) * Average childcare costs",
         "start_year": 2013,
@@ -175,6 +289,8 @@
     "_ALD_Dependents_Child_c": {
         "long_name": "National average childcare costs. Ceiling for available childcare deduction.",
         "description": "The weighted average of childcare costs in the US",
+        "section_1": "Above the line deductions",
+        "section_2": "Child and elderly care",
         "irs_ref": "",
         "notes": "This is a weighted average of childcare costs in each state",
         "start_year": 2013,
@@ -188,6 +304,8 @@
     "_ALD_Dependents_Elder_c": {
         "long_name": "Ceiling for elderly care deduction proposed in Trump's tax plan.",
         "description": "A tax payer can take an above the line deduction up to this amount if they have an elderly dependent.",
+        "section_1": "Above the line deductions",
+        "section_2": "Child and elderly care",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -201,6 +319,8 @@
     "_ALD_Dependents_thd": {
         "long_name": "Maximum level of income to qualify for the dependent care deduction",
         "description": "A taxpayer can only claim the dependent care deduction if their total income is below this level",
+        "section_1": "Above the line deductions",
+        "section_2": "Child and elderly care",
         "irs_ref": "Form 2441",
         "note": "",
         "start_year": 2013,
@@ -212,65 +332,10 @@
         "value": [[250000, 500000, 250000, 500000, 500000, 250000]]
     },
 
-    "_SS_thd50": {
-        "long_name": "Threshold for Social Security benefit taxability 1",
-        "description": "The first threshold for Social Security benefit taxability: if taxpayers have provisional income greater than this threshold, up to 50% of their Social Security benefit will be subject to tax under current law.",
-        "irs_ref": "Form 1040, line 20a&b, calculation (Worksheet, line 8.)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[25000, 32000, 25000, 25000, 25000, 25000]]
-    },
-
-    "_SS_thd85": {
-        "long_name": "Threshold for Social Security benefit taxability 2",
-        "description": "The second threshold for Social Security taxability: if taxpayers have provisional income greater than this threshold, up to 85% of their Social Security benefit will be subject to tax under current law.",
-        "irs_ref": "Form 1040, line 20a&b, calculation (Worksheet, add line 10 values to line 8).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[34000, 44000, 34000, 34000, 34000, 34000]]
-    },
-
-    "_SS_percentage1": {
-        "long_name": "Social Security taxable income decimal fraction 1",
-        "description": "Under current law if their provisional income is above the first threshold for Social Security taxability but below the second threshold, taxpayers need to apply this fraction to both the excess of their provisional income over the first threshold and their Social Security benefits, and then include the smaller one in their AGI.",
-        "irs_ref": "Form 1040, line 20b, instructions (Social Security Worksheets, line 2 & 13)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.5]
-    },
-
-    "_SS_percentage2": {
-        "long_name": "Social Security taxable income decimal fraction 2",
-        "description": "Under current law if their provisional income is above the second threshold for Social Security taxability, taxpayers need to apply this fraction to both the excess of their provisional income over the second threshold and their social security benefits, and then include the smaller one in their AGI.",
-        "irs_ref": "Form 1040, line 20b, instructions (Social Security Worksheets, line 15)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.85]
-    },
-
     "_II_em": {
         "long_name": "Personal and dependent exemption amount",
         "description": "Subtracted from AGI in the calculation of taxable income, per taxpayer and dependent.",
+        "section_1": "Personal exemptions",
         "irs_ref": "IRS reference: form 1040, line 42. ",
         "notes": "",
         "start_year": 2013,
@@ -291,6 +356,7 @@
     "_II_em_ps": {
         "long_name": "Personal exemption phaseout starting income",
         "description": "If taxpayers' AGI is above this level, their personal exemption will start to decrease at the personal exemption phaseout rate (PEP provision). ",
+        "section_1": "Personal exemptions",
         "irs_ref": "Form 1040, line 42, instruction (Worksheet).",
         "notes": "",
         "start_year": 2013,
@@ -311,6 +377,7 @@
     "_II_prt": {
         "long_name": "Personal exemption phaseout rate",
         "description": "Personal exemption amount will decrease by this rate for each dollar of AGI exceeding exemption phaseout start.",
+        "section_1": "Personal exemptions",
         "irs_ref": "Form 1040, line 42, instruction (Worksheet).",
         "notes": "",
         "start_year": 2013,
@@ -322,286 +389,10 @@
         "value": [0.02]
     },
 
-    "_ID_ps": {
-        "long_name": "Itemized deduction phaseout AGI start (Pease provision)",
-        "description": "The itemized deductions will be reduced for taxpayers with AGI higher than this level.",
-        "irs_ref": "Form 1040 Schedule A, line 29, instructions.",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[250000, 300000, 150000, 275000, 300000, 150000],
-                  [254200, 305050, 152525, 279650, 305050, 152525],
-                  [258250, 309900, 154950, 284050, 309900, 154950],
-                  [259400, 311300, 155650, 285350, 311300, 155650]]
-    },
-
-    "_ID_crt": {
-        "long_name": "Itemized deduction maximum phaseout as a decimal fraction of total itemized deductions (Pease)",
-        "description": "The phaseout amount is capped at this fraction of the original total deduction. ",
-        "irs_ref": "Form 1040 Schedule A, line 29, instructions. ",
-        "notes": "The ceiling rate cannot be increased above 0.8 due to limited data on non-itemizers.",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.8]
-    },
-
-    "_ID_prt": {
-        "long_name": "Itemized deduction phaseout rate (Pease)",
-        "description": "Taxpayers will not be eligible to deduct the full amount of itemized deduction if their AGI is above the phaseout start. The deductible portion would be decreased at this rate for each dollar exceeding the start.",
-        "irs_ref": "Schedule A, line 29, instructions. ",
-        "notes": "This phaseout rate cannot be lower than 0.03 for each dollar, due to limited data on non-itemizers.",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.03]
-    },
-
-    "_ID_Medical_frt": {
-        "long_name": "Deduction for medical expenses; floor as a decimal fraction of AGI",
-        "description": "Taxpayers are eligible to deduct the portion of their medical expense exceeding this fraction of AGI.",
-        "irs_ref": "Form 1040 Schedule A, line 3, in-line. ",
-        "notes": "This rate cannot be decreased to lower than 0.1 due to limited data on non-itemizers.",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.1],
-        "validations": {"min": "default"}
-    },
-
-    "_ID_Medical_frt_add4aged": {
-        "long_name": "Addon to _ID_Medical_frt for elderly filing units; addon as a decimal fraction of AGI",
-        "description": "Elderly taxpayers have this fraction added to the value of _ID_Medical_frt.",
-        "irs_ref": "Form 1040 Schedule A, line 3, in-line. ",
-        "notes": "This addon cannot be decreased to lower than -0.025 due to limited data on elderly non-itemizers.",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013", "2014", "2015", "2016", "2017"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [-0.025, -0.025, -0.025, -0.025, 0.0],
-        "validations": {"min": -0.025, "max": 0.0}
-    },
-
-    "_ID_Medical_hc": {
-        "long_name": "Medical expense deduction haircut",
-        "description": "This decimal fraction can be applied to limit the amount of medical expense deduction allowed.",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_ID_StateLocalTax_hc": {
-        "long_name": "State and local taxes (Income and Sales) deduction haircut.",
-        "description": "This decimal fraction reduces the state and local tax deduction.",
-        "irs_ref": "",
-        "notes": "This parameter allows for the implementation of Option 51 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_ID_RealEstate_hc": {
-        "long_name": "Real estate taxes deduction haircut.",
-        "description": "This decimal fraction reduces real estate taxes paid eligible to deduct in itemized deduction.",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate real estate taxes paid itemized deduction.",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_ID_InterestPaid_hc": {
-        "long_name": "Interest deduction haircut",
-        "description": "This decimal fraction can be applied to limit the amount of interest deduction allowed.",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_ID_Charity_frt": {
-        "long_name": "Deduction for charitable contributions; floor as a decimal fraction of AGI",
-        "description": "Taxpayers are eligible to deduct the portion of their charitable expense exceeding this fraction of AGI.",
-        "irs_ref": "",
-        "notes": "This parameter allows for implementation of Option 52 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0],
-        "validations": {"min": "default"}
-    },
-
-    "_ID_Charity_crt_all": {
-        "long_name": "Ceiling (as a decimal fraction of AGI) for all charitable contribution deductions",
-        "description": "The total deduction for charity is capped at this fraction of AGI. ",
-        "irs_ref": "Pub. 526, Limits on Deductions: 50% Limit Organizations. ",
-        "notes": "This rate cannot be increased to higher 0.5 due to lack of data. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.5],
-        "validations": {"max": "default"}
-    },
-
-    "_ID_Charity_crt_noncash": {
-        "long_name": "Ceiling (as a decimal fraction of AGI) for noncash charitable contribution deductions",
-        "description": "The deduction for noncash charity contributions is capped at this fraction of AGI. ",
-        "irs_ref": "Pub 526, Limits on Deductions: Special 30% Limit for Capital Gain Property.",
-        "notes": "This rate cannot be increased to higher than 0.3 due to lack of data. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.3],
-        "validations": {"max": "default"}
-    },
-
-    "_ID_Charity_hc": {
-        "long_name": "Charity expense deduction haircut",
-        "description": "This decimal fraction can be applied to limit the amount of charity expense deduction allowed.",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_ID_Casualty_frt": {
-        "long_name": "Deduction for casualty loss; floor as a decimal fraction of AGI",
-        "description": "Taxpayers are eligible to deduct the portion of their casualty loss exceeding this fraction of AGI.",
-        "irs_ref": "Form 4684, line 17, in-line.",
-        "notes": "This rate cannot be decreased to lower than 0.1 due to lack of data. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.1],
-        "validations": {"min": "default"}
-    },
-
-    "_ID_Casualty_hc": {
-        "long_name": "Casualty expense deduction haircut",
-        "description": "This decimal fraction can be applied to limit the amount of casualty expense deduction allowed.",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_ID_Miscellaneous_frt": {
-        "long_name": "Deduction for miscellaneous expenses; floor as a decimal fraction of AGI",
-        "description": "Taxpayers are eligible to deduct the portion of their miscellaneous expense exceeding this fraction of AGI.",
-        "irs_ref": "Form 1040 Schedule A, line 28, instructions. ",
-        "notes": "This rate cannot be decreased to lower than 0.02 due to lack of data. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.02],
-        "validations": {"min": "default"}
-    },
-
-    "_ID_Miscellaneous_hc": {
-        "long_name": "Miscellaneous expense deduction haircut",
-        "description": "This decimal fraction can be applied to limit the amount of miscellaneous expense deduction allowed.",
-        "irs_ref": "",
-        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_AMEDT_ec": {
-        "long_name": "Additional Medicare Tax earnings exclusion",
-        "description": "The Additional Medicare Tax rate, _AMEDT_rt, applies to all earnings in excess of this excluded amount.",
-        "irs_ref": "Form 8959, line 5, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[200000, 250000, 125000, 200000, 200000, 125000]]
-    },
-
-    "_AMEDT_rt": {
-        "long_name": "Additional Medicare Tax rate",
-        "description": "This is the rate applied to the portion of Medicare wages, RRTA compensation and self-employment income exceeding the Additional Medicare Tax earning exclusion.",
-        "irs_ref": "Form 8959, line 7, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.009]
-    },
-
     "_STD": {
         "long_name": "Standard deduction amount",
         "description": "",
+        "section_1": "Standard deduction",
         "irs_ref": "form 1040, line 40, instruction (Formside notes).",
         "notes": "This parameter cannot be decreased due to lack of data.",
         "start_year": 2013,
@@ -623,6 +414,7 @@
     "_STD_Aged": {
         "long_name": "Additional standard deduction for blind and aged",
         "description": "To get the standard deduction for aged or blind individuals, taxpayers need to add this value to regular standard deduction",
+        "section_1": "Standard deduction",
         "irs_ref": "Form 1040, line 40, calculation (the difference of the two tables given in the instruction).",
         "notes": "",
         "start_year": 2013,
@@ -642,8 +434,9 @@
     },
 
     "_II_credit": {
-        "long_name": "Personal refundable credit",
+        "long_name": "Personal refundable credit maximum amount",
         "description": "This credit amount is fully refundable and phased out based on AGI. It is available to tax units who would otherwise not file.",
+        "section_1": "Personal refundable credit",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -658,6 +451,7 @@
     "_II_credit_ps": {
         "long_name": "Personal refundable credit phaseout start",
         "description": "The Personal Refundable credit amount will be reduced for taxpayers with AGI higher than this level.",
+        "section_1": "Personal refundable credit",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -672,6 +466,7 @@
     "_II_credit_prt": {
         "long_name": "Personal refundable credit phaseout rate",
         "description": "The Personal Refundable credit amount will be reduced at this rate for each dollar of AGI exceeding the _II_credit_ps threshold.",
+        "section_1": "Personal refundable credit",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -684,9 +479,690 @@
         "validations": {"min": 0}
     },
 
+    "_ID_Medical_frt": {
+        "long_name": "Deduction for medical expenses; floor as a decimal fraction of AGI",
+        "description": "Taxpayers are eligible to deduct the portion of their medical expense exceeding this fraction of AGI.",
+        "section_1": "Itemized deductions",
+        "section_2": "Medical expenses",
+        "irs_ref": "Form 1040 Schedule A, line 3, in-line. ",
+        "notes": "This rate cannot be decreased to lower than 0.1 due to limited data on non-itemizers.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.1],
+        "validations": {"min": "default"}
+    },
+
+    "_ID_Medical_frt_add4aged": {
+        "long_name": "Addon to _ID_Medical_frt for elderly filing units; addon as a decimal fraction of AGI",
+        "description": "Elderly taxpayers have this fraction added to the value of _ID_Medical_frt.",
+        "section_1": "Itemized deductions",
+        "section_2": "Medical expenses",
+        "irs_ref": "Form 1040 Schedule A, line 3, in-line. ",
+        "notes": "This addon cannot be decreased to lower than -0.025 due to limited data on elderly non-itemizers.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013", "2014", "2015", "2016", "2017"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [-0.025, -0.025, -0.025, -0.025, 0.0],
+        "validations": {"min": -0.025, "max": 0.0}
+    },
+
+    "_ID_Medical_hc": {
+        "long_name": "Medical expense deduction haircut",
+        "description": "This decimal fraction can be applied to limit the amount of medical expense deduction allowed.",
+        "section_1": "Itemized deductions",
+        "section_2": "Medical expenses",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_ID_StateLocalTax_hc": {
+        "long_name": "State and local taxes (Income and Sales) deduction haircut.",
+        "description": "This decimal fraction reduces the state and local tax deduction.",
+        "section_1": "Itemized deductions",
+        "section_2": "State and local income and sales taxes",
+        "irs_ref": "",
+        "notes": "This parameter allows for the implementation of Option 51 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_ID_RealEstate_hc": {
+        "long_name": "Real estate taxes deduction haircut.",
+        "description": "This decimal fraction reduces real estate taxes paid eligible to deduct in itemized deduction.",
+        "section_1": "Itemized deductions",
+        "section_2": "Real estate taxes",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate real estate taxes paid itemized deduction.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_ID_InterestPaid_hc": {
+        "long_name": "Interest deduction haircut",
+        "description": "This decimal fraction can be applied to limit the amount of interest deduction allowed.",
+        "section_1": "Itemized deductions",
+        "section_2": "Interest paid",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+
+    "_ID_Charity_crt_all": {
+        "long_name": "Ceiling (as a decimal fraction of AGI) for all charitable contribution deductions",
+        "description": "The total deduction for charity is capped at this fraction of AGI. ",
+        "section_1": "Itemized deductions",
+        "section_2": "Charity",
+        "irs_ref": "Pub. 526, Limits on Deductions: 50% Limit Organizations. ",
+        "notes": "This rate cannot be increased to higher 0.5 due to lack of data. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.5],
+        "validations": {"max": "default"}
+    },
+
+    "_ID_Charity_crt_noncash": {
+        "long_name": "Ceiling (as a decimal fraction of AGI) for noncash charitable contribution deductions",
+        "description": "The deduction for noncash charity contributions is capped at this fraction of AGI. ",
+        "section_1": "Itemized deductions",
+        "section_2": "Charity",
+        "irs_ref": "Pub 526, Limits on Deductions: Special 30% Limit for Capital Gain Property.",
+        "notes": "This rate cannot be increased to higher than 0.3 due to lack of data. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.3],
+        "validations": {"max": "default"}
+    },
+
+    "_ID_Charity_frt": {
+        "long_name": "Deduction for charitable contributions; floor as a decimal fraction of AGI",
+        "description": "Taxpayers are eligible to deduct the portion of their charitable expense exceeding this fraction of AGI.",
+        "section_1": "Itemized deductions",
+        "section_2": "Charity",
+        "irs_ref": "",
+        "notes": "This parameter allows for implementation of Option 52 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0],
+        "validations": {"min": "default"}
+    },
+
+
+    "_ID_Charity_hc": {
+        "long_name": "Charity expense deduction haircut",
+        "description": "This decimal fraction can be applied to limit the amount of charity expense deduction allowed.",
+        "section_1": "Itemized deductions",
+        "section_2": "Charity",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_ID_Casualty_frt": {
+        "long_name": "Deduction for casualty loss; floor as a decimal fraction of AGI",
+        "description": "Taxpayers are eligible to deduct the portion of their casualty loss exceeding this fraction of AGI.",
+        "section_1": "Itemized deductions",
+        "section_2": "Casualty",
+        "irs_ref": "Form 4684, line 17, in-line.",
+        "notes": "This rate cannot be decreased to lower than 0.1 due to lack of data. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.1],
+        "validations": {"min": "default"}
+    },
+
+    "_ID_Casualty_hc": {
+        "long_name": "Casualty expense deduction haircut",
+        "description": "This decimal fraction can be applied to limit the amount of casualty expense deduction allowed.",
+        "section_1": "Itemized deductions",
+        "section_2": "Casualty",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_ID_Miscellaneous_frt": {
+        "long_name": "Deduction for miscellaneous expenses; floor as a decimal fraction of AGI",
+        "description": "Taxpayers are eligible to deduct the portion of their miscellaneous expense exceeding this fraction of AGI.",
+        "section_1": "Itemized deductions",
+        "section_2": "Miscellaneous",
+        "irs_ref": "Form 1040 Schedule A, line 28, instructions. ",
+        "notes": "This rate cannot be decreased to lower than 0.02 due to lack of data. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.02],
+        "validations": {"min": "default"}
+    },
+
+    "_ID_Miscellaneous_hc": {
+        "long_name": "Miscellaneous expense deduction haircut",
+        "description": "This decimal fraction can be applied to limit the amount of miscellaneous expense deduction allowed.",
+        "section_1": "Itemized deductions",
+        "section_2": "Miscellaneous",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_ID_ps": {
+        "long_name": "Itemized deduction phaseout AGI start (Pease provision)",
+        "description": "The itemized deductions will be reduced for taxpayers with AGI higher than this level.",
+        "section_1": "Itemized deductions",
+        "section_2": "Itemized deduction limitation",
+        "irs_ref": "Form 1040 Schedule A, line 29, instructions.",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[250000, 300000, 150000, 275000, 300000, 150000],
+                  [254200, 305050, 152525, 279650, 305050, 152525],
+                  [258250, 309900, 154950, 284050, 309900, 154950],
+                  [259400, 311300, 155650, 285350, 311300, 155650]]
+    },
+
+    "_ID_prt": {
+        "long_name": "Itemized deduction phaseout rate (Pease)",
+        "description": "Taxpayers will not be eligible to deduct the full amount of itemized deduction if their AGI is above the phaseout start. The deductible portion would be decreased at this rate for each dollar exceeding the start.",
+        "section_1": "Itemized deductions",
+        "section_2": "Itemized deduction limitation",
+        "irs_ref": "Schedule A, line 29, instructions. ",
+        "notes": "This phaseout rate cannot be lower than 0.03 for each dollar, due to limited data on non-itemizers.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.03]
+    },
+
+    "_ID_crt": {
+        "long_name": "Itemized deduction maximum phaseout as a decimal fraction of total itemized deductions (Pease)",
+        "description": "The phaseout amount is capped at this fraction of the original total deduction. ",
+        "section_1": "Itemized deductions",
+        "section_2": "Itemized deduction limitation",
+        "irs_ref": "Form 1040 Schedule A, line 29, instructions. ",
+        "notes": "The ceiling rate cannot be increased above 0.8 due to limited data on non-itemizers.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.8]
+    },
+
+    "_ID_BenefitSurtax_trt": {
+        "long_name": "Surtax rate on the benefits from specified itemized deductions",
+        "description": "The benefit from specified itemized deductions exceeding the credit is taxed at this rate. A surtax rate of 1 strictly limits the benefit from specified itemized deductions to the specified credit. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
+        "section_1": "Itemized deductions",
+        "section_2": "Surtax on itemized deduction benefits",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+
+    "_ID_BenefitSurtax_crt": {
+        "long_name": "Credit on itemized deduction benefit surtax (decimal fraction of AGI)",
+        "description": "The surtax on specified itemized deductions applies to benefits in excess of this fraction of AGI. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
+        "section_1": "Itemized deductions",
+        "section_2": "Surtax on itemized deduction benefits",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [1.0]
+    },
+
+    "_ID_BenefitSurtax_em": {
+        "long_name": "Itemized deduction benefit surtax exemption ",
+        "description": "This amount is subtracted from itemized deduction benefits in the calculation of the itemized deduction benefit surtax. With _ID_BenefitSurtax_crt set to 0.0 and _ID_BenefitSurtax_trt set to 1.0, this amount serves as a dollar limit on the value of itemized deductions.",
+        "section_1": "Itemized deductions",
+        "section_2": "Surtax on itemized deduction benefits above an AGI threshold",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[0, 0, 0, 0, 0, 0]]
+    },
+
+    "_ID_BenefitSurtax_Switch": {
+        "long_name": "Deductions subject to the surtax on itemized deduction benefits",
+        "description": "The surtax on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter. ",
+        "section_1": "Itemized deductions",
+        "section_2": "Surtax on itemized deduction benefits above an AGI threshold",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": ["Medical", "State & Local", "Real Estate", "Casualty", "Miscellaneous", "Interest", "Charity"],
+        "value": [[true, true, true, true, true, true, true]]
+    },
+
+    "_ID_BenefitCap_rt": {
+        "long_name": "Percent cap on the benefits from itemized deductions",
+        "description": "The benefit from specified itemized deductions is capped at this percent of the total deductible expenses.",
+        "section_1": "Itemized deductions",
+        "section_2": "Cap on the benefit of itemized deductions as a percent of deductible expenses",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [1.0]
+    },
+
+
+    "_ID_BenefitCap_Switch": {
+        "long_name": "Deductions subject to the cap on itemized deduction benefits",
+        "description": "The cap on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter. ",
+        "section_1": "Itemized deductions",
+        "section_2": "Cap on the benefit of itemized deductions as a percent of deductible expenses",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": ["Medical", "State & Local", "Real Estate", "Casualty", "Miscellaneous", "Interest", "Charity"],
+        "value": [[true, true, true, true, true, true, true]]
+    },
+
+    "_CG_rt1": {
+        "long_name": "Long term capital gain and qualified dividends (regular/non-AMT) rate 1",
+        "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 1 are taxed at this rate. ",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Regular - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 1040 Schedule D tax worksheet, line 20, in-line. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_CG_brk1": {
+        "long_name": "Top of long-term capital gains and qualified dividends (regular/non-AMT) tax bracket 1",
+        "description": "The gains and dividends (stacked on top of regular income) below this are taxed at capital gain rate 1. ",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Regular - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 1040 Schedule D tax worksheet, line 15, in-line. ",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[36250, 72500, 36250, 48600, 72500, 36250],
+                  [36900, 73800, 36900, 49400, 73800, 36900],
+                  [37450, 74900, 37450, 50200, 74900, 37450],
+                  [37650, 75300, 37650, 50400, 75300, 37650]]
+    },
+
+    "_CG_rt2": {
+        "long_name": "Long term capital gain and qualified dividends (regular/non-AMT) rate 2",
+        "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 2 and above threshold 1 are taxed at this rate. ",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Regular - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 1040 Schedule D tax worksheet, line 29, in-line. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.15]
+    },
+
+    "_CG_brk2": {
+        "long_name": "Top of long-term capital gains and qualified dividends (regular/non-AMT) tax bracket 2",
+        "description": "The gains and dividends (stacked on top of regular income) below this and above top of bracket 1 are taxed at capital gain rate 2.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Regular - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 1040 Schedule D tax worksheet, line 24, in-line. ",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
+                  [406750, 457600, 228800, 432200, 457600, 228800],
+                  [413200, 464850, 232425, 439000, 464850, 232425],
+                  [415050, 466950, 233475, 441000, 466950, 233475]]
+    },
+
+    "_CG_rt3": {
+        "long_name": "Long term capital gain and qualified dividends (regular/non-AMT) rate 3",
+        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 2 and below threshold 3 are taxed at this rate. ",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Regular - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 1040 Schedule D tax worksheet, line 32, in-line. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.20]
+    },
+
+    "_CG_brk3": {
+        "long_name": "Top of long-term capital gains and qualified dividend tax (regular/non-AMT) bracket 3",
+        "description": "The gains and dividends (stacked on top of regular income) below this and above top of bracket 2 are taxed at the capital gain rate 3; above this they are taxed at capital gain rate 4.  Default value is essentially infinity.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Regular - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 1040 Schedule D tax worksheet, line 24, in-line. ",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]]
+    },
+
+    "_CG_rt4": {
+        "long_name": "Long term capital gain and qualified dividends (regular/non-AMT) rate 4",
+        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 3 are taxed at this rate. ",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Regular - Long term capital gains and qualified dividends",
+        "irs_ref": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [1.0]
+    },
+
+
+    "_AMT_CG_rt1": {
+        "long_name": "Long term capital gain and qualified dividends (AMT) rate 1",
+        "description": "Capital gain and qualified dividends (stacked on top of regular income) below threshold 1 are taxed at this rate. ",
+        "section_1": "Capital gains and dividends",
+        "section_2": "AMT - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 6251, line 47, in-line. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_AMT_CG_brk1": {
+        "long_name": "Top of long-term capital gains and qualified dividends (AMT) tax bracket 1",
+        "description": "The gains and dividends, stacked last, of AMT taxable income below this are taxed at AMT capital gain rate 1.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "AMT - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 6251, line 43, in-line. ",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[36250, 72500, 36250, 48600, 72500, 36250],
+                  [36900, 73800, 36900, 49400, 73800, 36900],
+                  [37450, 74900, 37450, 50200, 74900, 37450],
+                  [37650, 75300, 37650, 50400, 75300, 37650]]
+    },
+
+
+    "_AMT_CG_rt2": {
+        "long_name": "Long term capital gain and qualified dividends (AMT) rate 2",
+        "section_1": "Capital gains and dividends",
+        "section_2": "AMT - Long term capital gains and qualified dividends",
+        "description": "Capital gain and qualified dividend (stacked on top of regular income) below threshold 2 and above threshold 1 are taxed at this rate.",
+        "irs_ref": "Form 6251, line 55, in-line. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.15]
+    },
+
+    "_AMT_CG_brk2": {
+        "long_name": "Top of long-term capital gains and qualified dividends (AMT) tax bracket 2",
+        "description": "The gains and dividends, stacked last, of AMT taxable income below this threshold and above bracket 1 are taxed at AMT capital gain rate 2.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "AMT - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 6251, line 49, in-line. ",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
+                  [406750, 457600, 228800, 432200, 457600, 228800],
+                  [413200, 464850, 232425, 439000, 464850, 223425],
+                  [415050, 466950, 233475, 441000, 466950, 233475]]
+    },
+
+    "_AMT_CG_rt3": {
+        "long_name": "Long term capital gain and qualified dividends (AMT) rate 3",
+        "description": "The capital gain and qualified dividend (stacked on top of regular income) above threshold 2 and below threshold 3 are taxed at this rate.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "AMT - Long term capital gains and qualified dividends",
+        "irs_ref": "Form 6251, line 58, in-line. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.20]
+    },
+
+    "_AMT_CG_brk3": {
+        "long_name": "Long term capital gain and qualified dividends (AMT) threshold 3",
+        "description": "The gains and dividends, stacked last, of AMT taxable income below this and above bracket 2 are taxed at capital gain rate 3; above thisthey are taxed at AMT capital gain rate 4.  Default value is essentially infinity.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "AMT - Long term capital gains and qualified dividends",
+        "irs_ref": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]]
+    },
+
+    "_AMT_CG_rt4": {
+        "long_name": "Long term capital gain and qualified dividends (AMT) rate 4",
+        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 3 are taxed at this rate.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "AMT - Long term capital gains and qualified dividends",
+        "irs_ref": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [1.0]
+    },
+
+
+    "_CG_nodiff": {
+        "long_name": "Long term capital gains and qualified dividends taxed no differently than regular taxable income",
+        "description": "Specifies whether or not long term capital gains and qualified dividends are taxed like regular taxable income.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Tax all capital gains and dividends the same as regular taxable income",
+        "irs_ref": "Current-law value is zero implying different tax treatment in Schedule D and AMT; a value of one implies same tax treatment in both regular and alternative minimum tax rules, but the same treatment can differ for regular and AMT.",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [false]
+    },
+
+    "_CG_ec": {
+        "long_name": "Dollar amount of all capital gains and qualified dividends that are excluded from AGI.",
+        "description": "Positive value used only if long term capital gains and qualified dividends taxed no differently than regular taxable income.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Tax all capital gains and dividends the same as regular taxable income",
+        "irs_ref": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_CG_reinvest_ec_rt": {
+        "long_name": "Fraction of all capital gains and qualified dividends in excess of the dollar exclusion that are excluded from AGI.",
+        "description": "Positive value used only if long term capital gains and qualified dividends taxed no differently than regular taxable income.  To limit the exclusion to capital gains and dividends invested within 1 year, set to statutory exclusion rate times the fraction of capital gains and qualified dividends in excess of the exclusion that are assumed to be reinvested within the year.",
+        "section_1": "Capital gains and dividends",
+        "section_2": "Tax all capital gains and dividends the same as regular taxable income",
+        "irs_ref": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
     "_II_rt1": {
-        "long_name": "Personal income tax rate 1",
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 1",
         "description": "The lowest tax rate, applied to the portion of taxable income below tax bracket 1. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -698,107 +1174,11 @@
         "value": [0.1]
     },
 
-    "_II_rt2": {
-        "long_name": "Personal income tax rate 2",
-        "description": "The second lowest tax rate, applied to the portion of taxable income below tax bracket 2 and above tax bracket 1. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.15]
-    },
-
-    "_II_rt3": {
-        "long_name": "Personal income tax rate 3",
-        "description": "The third lowest tax rate, applied to the portion of taxable income below tax bracket 3 and above tax bracket 2. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.25]
-    },
-
-    "_II_rt4": {
-        "long_name": "Personal income tax rate 4",
-        "description": "The tax rate applied to the portion of taxable income below tax bracket 4 and above tax bracket 3. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.28]
-    },
-
-    "_II_rt5": {
-        "long_name": "Personal income tax rate 5",
-        "description": "The third highest tax rate, applied to the portion of taxable income below tax bracket 5 and above tax bracket 4. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.33]
-    },
-
-    "_II_rt6": {
-        "long_name": "Personal income tax rate 6",
-        "description": "The second higher tax rate, applied to the portion of taxable income below tax bracket 6 and above tax bracket 5. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.35]
-    },
-
-    "_II_rt7": {
-        "long_name": "Personal income tax rate 7",
-        "description": "The tax rate applied to the portion of taxable income below tax bracket 7 and above tax bracket 6. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.396]
-    },
-
-    "_II_rt8": {
-        "long_name": "Personal income tax rate 8",
-        "description": "The tax rate applied to the portion of taxable income above tax bracket 7.",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [1.0]
-    },
-
     "_II_brk1": {
-        "long_name": "Personal income tax bracket (upper threshold) 1",
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 1",
         "description": "Taxable income below this threshold is taxed at tax rate 1. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -817,9 +1197,28 @@
         "validations": {"min": 0, "max": "_II_brk2"}
     },
 
+    "_II_rt2": {
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 2",
+        "description": "The second lowest tax rate, applied to the portion of taxable income below tax bracket 2 and above tax bracket 1. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.15]
+    },
+
+
     "_II_brk2": {
-        "long_name": "Personal income tax bracket (upper threshold) 2",
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 2",
         "description": "Income below this threshold and above tax bracket 1 is taxed at tax rate 2. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -838,9 +1237,27 @@
         "validations": {"min": "_II_brk1", "max": "_II_brk3"}
     },
 
+    "_II_rt3": {
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 3",
+        "description": "The third lowest tax rate, applied to the portion of taxable income below tax bracket 3 and above tax bracket 2. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.25]
+    },
+
     "_II_brk3": {
-        "long_name": "Personal income tax bracket (upper threshold) 3",
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 3",
         "description": "Income below this threshold and above tax bracket 2 is taxed at tax rate 3.",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -859,9 +1276,27 @@
         "validations": {"min": "_II_brk2", "max": "_II_brk4"}
     },
 
+    "_II_rt4": {
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 4",
+        "description": "The tax rate applied to the portion of taxable income below tax bracket 4 and above tax bracket 3. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.28]
+    },
+
     "_II_brk4": {
-        "long_name": "Personal income tax bracket (upper threshold) 4",
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 4",
         "description": "Income below this threshold and above tax bracket 3 is taxed at tax rate 4.",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -880,9 +1315,27 @@
         "validations": {"min": "_II_brk3", "max": "_II_brk5"}
     },
 
+    "_II_rt5": {
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 5",
+        "description": "The third highest tax rate, applied to the portion of taxable income below tax bracket 5 and above tax bracket 4. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.33]
+    },
+
     "_II_brk5": {
-        "long_name": "Personal income tax bracket (upper threshold) 5",
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 5",
         "description": "Income below this threshold and above tax bracket 4 is taxed at tax rate 5.",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -901,9 +1354,28 @@
         "validations": {"min": "_II_brk4", "max": "_II_brk6"}
     },
 
+
+    "_II_rt6": {
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 6",
+        "description": "The second higher tax rate, applied to the portion of taxable income below tax bracket 6 and above tax bracket 5. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.35]
+    },
+
     "_II_brk6": {
-        "long_name": "Personal income tax bracket 6",
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket 6",
         "description": "Income below this threshold and above tax bracket 5 is taxed at tax rate 6.",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -922,9 +1394,27 @@
         "validations": {"min": "_II_brk5", "max": "_II_brk7"}
     },
 
+    "_II_rt7": {
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 7",
+        "description": "The tax rate applied to the portion of taxable income below tax bracket 7 and above tax bracket 6. ",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.396]
+    },
+
     "_II_brk7": {
-        "long_name": "Personal income tax bracket 7",
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket 7",
         "description": "Income below this threshold and above tax bracket 6 is taxed at tax rate 7; income above this threshold is taxed at tax rate 8.  Default value is essentially infinity",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -943,88 +1433,13 @@
         "validations": {"min": "_II_brk6"}
     },
 
-    "_CG_nodiff": {
-        "long_name": "Long term capital gains and qualified dividends taxed no differently than other income",
-        "description": "Specifies whether or not long term capital gains and qualified dividends are taxed like other income.",
-        "irs_ref": "Current-law value is zero implying different tax treatment in Schedule D and AMT; a value of one implies same tax treatment in both regular and alternative minimum tax rules, but the same treatment can differ for regular and AMT.",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [false]
-    },
-
-    "_CG_ec": {
-        "long_name": "Dollar amount of all capital gains and qualified dividends that are excluded from AGI.",
-        "description": "Current-law value is zero; positive value used only if _CG_nodiff is non-zero.",
-        "irs_ref": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": true,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_CG_reinvest_ec_rt": {
-        "long_name": "Fraction of all capital gains and qualified dividends in excess of _CG_ec that are excluded from AGI.",
-        "description": "Current-law value is zero; positive value used only if _CG_nodiff is non-zero.  If positive, set to statutory exclusion rate times the fraction of capital gains and qualified dividends in excess of _CG_ec that are assumed to be reinvested within the year.",
-        "irs_ref": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_CG_rt1": {
-        "long_name": "Long term capital gain and qualified dividends rate 1",
-        "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 1 are taxed at this rate. ",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 20, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_CG_rt2": {
-        "long_name": "Long term capital gain and qualified dividends rate 2",
-        "description": "The capital gain and dividends (stacked on top of regular income) that are below threshold 2 and above threshold 1 are taxed at this rate. ",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 29, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.15]
-    },
-
-    "_CG_rt3": {
-        "long_name": "Long term capital gain and qualified dividends rate 3",
-        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 2 and below threshold 3 are taxed at this rate. ",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 32, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.20]
-    },
-
-    "_CG_rt4": {
-        "long_name": "Long term capital gain and qualified dividends rate 4",
-        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 3 are taxed at this rate. ",
-        "irs_ref": "",
+    "_II_rt8": {
+        "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 8",
+        "description": "The tax rate applied to the portion of taxable income above tax bracket 7.",
+        "section_1": "Personal income",
+        "section_2": "Regular - non-AMT, non-pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
@@ -1032,63 +1447,6 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [1.0]
-    },
-
-    "_CG_brk1": {
-        "long_name": "Top of long-term capital gains and qualified dividends tax bracket 1",
-        "description": "The gains and dividends (stacked on top of regular income) below this are taxed at capital gain rate 1. ",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 15, in-line. ",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[36250, 72500, 36250, 48600, 72500, 36250],
-                  [36900, 73800, 36900, 49400, 73800, 36900],
-                  [37450, 74900, 37450, 50200, 74900, 37450],
-                  [37650, 75300, 37650, 50400, 75300, 37650]]
-    },
-
-    "_CG_brk2": {
-        "long_name": "Top of long-term capital gains and qualified dividends tax bracket 2",
-        "description": "The gains and dividends (stacked on top of regular income) below this and above top of bracket 1 are taxed at capital gain rate 2.",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 24, in-line. ",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
-                  [406750, 457600, 228800, 432200, 457600, 228800],
-                  [413200, 464850, 232425, 439000, 464850, 232425],
-                  [415050, 466950, 233475, 441000, 466950, 233475]]
-    },
-
-    "_CG_brk3": {
-        "long_name": "Top of long-term capital gains and qualified dividend tax bracket 3",
-        "description": "The gains and dividends (stacked on top of regular income) below this and above top of bracket 2 are taxed at the capital gain rate 3; above this they are taxed at capital gain rate 4.  Default value is essentially infinity.",
-        "irs_ref": "Form 1040 Schedule D tax worksheet, line 24, in-line. ",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]]
     },
 
     "_AGI_surtax_thd": {
@@ -1286,115 +1644,6 @@
         "col_label": "",
         "value": [238550,
                   242450]
-    },
-
-    "_AMT_CG_rt1": {
-        "long_name": "Long term capital gain and qualified dividend rate1",
-        "description": "Capital gain and qualified dividends (stacked on top of regular income) below threshold 1 are taxed at this rate. ",
-        "irs_ref": "Form 6251, line 47, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_AMT_CG_rt2": {
-        "long_name": "Long term capital gain and qualified dividend rate2",
-        "description": "Capital gain and qualified dividend (stacked on top of regular income) below threshold 2 and above threshold 1 are taxed at this rate.",
-        "irs_ref": "Form 6251, line 55, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.15]
-    },
-
-    "_AMT_CG_rt3": {
-        "long_name": "Long term capital gain and qualified dividend rate 3",
-        "description": "The capital gain and qualified dividend (stacked on top of regular income) above threshold 2 and below threshold 3 are taxed at this rate.",
-        "irs_ref": "Form 6251, line 58, in-line. ",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.20]
-    },
-
-    "_AMT_CG_rt4": {
-        "long_name": "Long term capital gain and qualified dividend rate 4",
-        "description": "The capital gain and dividends (stacked on top of regular income) that are above threshold 3 are taxed at this rate.",
-        "irs_ref": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [1.0]
-    },
-
-    "_AMT_CG_brk1": {
-        "long_name": "Top of long-term capital gains and qualified dividends AMT tax bracket 1",
-        "description": "The gains and dividends, stacked last, of AMT taxable income below this are taxed at AMT capital gain rate 1.",
-        "irs_ref": "Form 6251, line 43, in-line. ",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[36250, 72500, 36250, 48600, 72500, 36250],
-                  [36900, 73800, 36900, 49400, 73800, 36900],
-                  [37450, 74900, 37450, 50200, 74900, 37450],
-                  [37650, 75300, 37650, 50400, 75300, 37650]]
-    },
-
-    "_AMT_CG_brk2": {
-        "long_name": "Top of long-term capital gains and qualified dividends AMT tax bracket 2",
-        "description": "The gains and dividends, stacked last, of AMT taxable income below this threshold and above bracket 1 are taxed at AMT capital gain rate 2.",
-        "irs_ref": "Form 6251, line 49, in-line. ",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
-                  [406750, 457600, 228800, 432200, 457600, 228800],
-                  [413200, 464850, 232425, 439000, 464850, 223425],
-                  [415050, 466950, 233475, 441000, 466950, 233475]]
-    },
-
-    "_AMT_CG_brk3": {
-        "long_name": "Long term capital gain and qualified dividend threshold 3",
-        "description": "The gains and dividends, stacked last, of AMT taxable income below this and above bracket 2 are taxed at capital gain rate 3; above thisthey are taxed at AMT capital gain rate 4.  Default value is essentially infinity.",
-        "irs_ref": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]]
     },
 
     "_NIIT_thd": {
@@ -1905,89 +2154,6 @@
         "validations": {"min": 0}
     },
 
-    "_ID_BenefitSurtax_Switch": {
-        "long_name": "Deductions subject to the surtax on itemized deduction benefits",
-        "description": "The surtax on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter. ",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": ["Medical", "State & Local", "Real Estate", "Casualty", "Miscellaneous", "Interest", "Charity"],
-        "value": [[true, true, true, true, true, true, true]]
-    },
-
-    "_ID_BenefitSurtax_crt": {
-        "long_name": "Credit on itemized deduction benefit surtax (decimal fraction of AGI)",
-        "description": "The surtax on specified itemized deductions applies to benefits in excess of this fraction of AGI. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [1.0]
-    },
-
-    "_ID_BenefitSurtax_em": {
-        "long_name": "Itemized deduction benefit surtax exemption ",
-        "description": "This amount is subtracted from itemized deduction benefits in the calculation of the itemized deduction benefit surtax. With _ID_BenefitSurtax_crt set to 0.0 and _ID_BenefitSurtax_trt set to 1.0, this amount serves as a dollar limit on the value of itemized deductions.",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[0, 0, 0, 0, 0, 0]]
-    },
-
-    "_ID_BenefitSurtax_trt": {
-        "long_name": "Surtax rate on the benefits from specified itemized deductions",
-        "description": "The benefit from specified itemized deductions exceeding the credit is taxed at this rate. A surtax rate of 1 strictly limits the benefit from specified itemized deductions to the specified credit. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
-    "_ID_BenefitCap_Switch": {
-        "long_name": "Deductions subject to the cap on itemized deduction benefits",
-        "description": "The cap on itemized deduction benefits applies to the benefits derived from the itemized deductions specified with this parameter. ",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": ["Medical", "State & Local", "Real Estate", "Casualty", "Miscellaneous", "Interest", "Charity"],
-        "value": [[true, true, true, true, true, true, true]]
-    },
-
-    "_ID_BenefitCap_rt": {
-        "long_name": "Percent cap on the benefits from itemized deductions",
-        "description": "The benefit from specified itemized deductions is capped at this percent of the total deductible expenses.",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [1.0]
-    },
 
     "_PT_rt1": {
         "long_name": "Pass-through income tax rate 1",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1162,7 +1162,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 1",
         "description": "The lowest tax rate, applied to the portion of taxable income below tax bracket 1. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -1178,7 +1178,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 1",
         "description": "Taxable income below this threshold is taxed at tax rate 1. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -1201,7 +1201,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 2",
         "description": "The second lowest tax rate, applied to the portion of taxable income below tax bracket 2 and above tax bracket 1. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -1218,7 +1218,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 2",
         "description": "Income below this threshold and above tax bracket 1 is taxed at tax rate 2. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -1241,7 +1241,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 3",
         "description": "The third lowest tax rate, applied to the portion of taxable income below tax bracket 3 and above tax bracket 2. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -1257,7 +1257,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 3",
         "description": "Income below this threshold and above tax bracket 2 is taxed at tax rate 3.",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -1280,7 +1280,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 4",
         "description": "The tax rate applied to the portion of taxable income below tax bracket 4 and above tax bracket 3. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -1296,7 +1296,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 4",
         "description": "Income below this threshold and above tax bracket 3 is taxed at tax rate 4.",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -1319,7 +1319,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 5",
         "description": "The third highest tax rate, applied to the portion of taxable income below tax bracket 5 and above tax bracket 4. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -1335,7 +1335,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket (upper threshold) 5",
         "description": "Income below this threshold and above tax bracket 4 is taxed at tax rate 5.",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -1359,7 +1359,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 6",
         "description": "The second higher tax rate, applied to the portion of taxable income below tax bracket 6 and above tax bracket 5. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -1375,7 +1375,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket 6",
         "description": "Income below this threshold and above tax bracket 5 is taxed at tax rate 6.",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -1398,7 +1398,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 7",
         "description": "The tax rate applied to the portion of taxable income below tax bracket 7 and above tax bracket 6. ",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -1414,7 +1414,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax bracket 7",
         "description": "Income below this threshold and above tax bracket 6 is taxed at tax rate 7; income above this threshold is taxed at tax rate 8.  Default value is essentially infinity",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
@@ -1437,7 +1437,7 @@
         "long_name": "Personal income (regular/non-AMT/non-pass-through) tax rate 8",
         "description": "The tax rate applied to the portion of taxable income above tax bracket 7.",
         "section_1": "Personal income",
-        "section_2": "Regular - non-AMT, non-pass-through",
+        "section_2": "Regular: non-AMT, non-pass-through",
         "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
@@ -1449,39 +1449,14 @@
         "value": [1.0]
     },
 
-    "_AGI_surtax_thd": {
-        "long_name": "Threshold for surtax on AGI",
-        "description": "The aggregate gross income above this AGI surtax threshold is taxed at surtax rate on AGI.",
-        "irs_ref": "",
-        "note": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "",
-        "row_label": ["2013"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99]]
-    },
 
-    "_AGI_surtax_trt": {
-        "long_name": "Surtax rate on AGI",
-        "description": "The surtax rate applied to the portion of aggregate gross income above the AGI surtax threshold.",
-        "irs_ref": "",
-        "note": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0],
-        "validations": {"min": 0.0}
-    },
 
-    "_KT_c_Age": {
-        "long_name": "Maximum age subject to Kiddie Tax",
-        "description": "At or under this age, the individual is subject to Kiddie Tax.",
-        "irs_ref": "Form 6251, line 28, instruction.",
+    "_PT_rt1": {
+        "long_name": "Pass-through income tax rate 1",
+        "description": "The lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 1. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
         "col_var": "",
@@ -1489,48 +1464,291 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [24]
+        "value": [0.1]
     },
 
-    "_AMT_brk1": {
-        "long_name": "AMT tax bracket (upper threshold) 1",
-        "description": "AMT taxable income below this is subject to _AMT_rt1 and above it is subject to _AMT_rt1 + _AMT_rt2.",
-        "irs_ref": "Form 6251, line 31, instruction.",
+     "_PT_brk1": {
+        "long_name": "Pass-through income tax bracket (upper threshold) 1",
+        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold is taxed at tax rate 1. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
         "notes": "",
         "start_year": 2013,
-        "col_var": "",
+        "col_var": "MARS",
         "row_var": "FLPDYR",
         "row_label": ["2013",
                       "2014",
                       "2015",
                       "2016"],
         "cpi_inflated": true,
-        "col_label": "",
-        "value": [179500,
-                  182500,
-                  185400,
-                  186300]
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[8925, 17850, 8925, 12750, 17850, 8925],
+                  [9075, 18150, 9075, 12950, 18150, 9075],
+                  [9225, 18450, 9225, 13150, 18450, 9225],
+                  [9275, 18550, 9275, 13250, 18550, 9275]],
+        "validations": {"min": 0, "max": "_PT_brk2"}
     },
 
-    "_AMT_thd_MarriedS": {
-        "long_name": "Extra alminc for married sep",
-        "description": "",
-        "irs_ref": "Form 6251, line 28, instruction.",
+    "_PT_rt2": {
+        "long_name": "Pass-through income tax rate 2",
+        "description": "The second lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 2 and above tax bracket 1. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
         "notes": "",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014"],
-        "cpi_inflated": true,
+        "row_label": ["2013"],
+        "cpi_inflated": false,
         "col_label": "",
-        "value": [40400,
-                  41050]
+        "value": [0.15]
     },
+
+
+    "_PT_brk2": {
+        "long_name": "Pass-through income tax bracket (upper threshold) 2",
+        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 1 is taxed at tax rate 2. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[36250, 72500, 36250, 48600, 72500, 36250],
+                  [36900, 73800, 36900, 49400, 73800, 36900],
+                  [37450, 74900, 37450, 50200, 74900, 37450],
+                  [37650, 75300, 37650, 50400, 75300, 37650]],
+        "validations": {"min": "_PT_brk1", "max": "_PT_brk3"}
+    },
+
+    "_PT_rt3": {
+        "long_name": "Pass-through income tax rate 3",
+        "description": "The third lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 3 and above tax bracket 2. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.25]
+    },
+
+    "_PT_brk3": {
+        "long_name": "Pass-through income tax bracket (upper threshold) 3",
+        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 2 is taxed at tax rate 3.",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[87850, 146400, 73200, 125450, 146400, 73200],
+                  [89350, 148850, 74425, 127550, 148850, 74425],
+                  [90750, 151200, 75600, 129600, 151200, 75600],
+                  [91150, 151900, 75950, 130150, 151900, 75950]],
+        "validations": {"min": "_PT_brk2", "max": "_PT_brk4"}
+    },
+
+    "_PT_rt4": {
+        "long_name": "Pass-through income tax rate 4",
+        "description": "The tax rate applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 4 and above tax bracket 3. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.28]
+    },
+
+    "_PT_brk4": {
+        "long_name": "Pass-through income tax bracket (upper threshold) 4",
+        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 3 is taxed at tax rate 4.",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[183250, 223050, 111525, 203150, 223050, 111525],
+                  [186350, 226850, 113425, 206600, 226850, 113425],
+                  [189300, 230450, 115225, 209850, 230450, 115225],
+                  [190150, 231450, 115725, 210800, 231450, 115725]],
+        "validations": {"min": "_PT_brk3", "max": "_PT_brk5"}
+    },
+
+    "_PT_rt5": {
+        "long_name": "Pass-through income tax rate 5",
+        "description": "The third highest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 5 and above tax bracket 4. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.33]
+    },
+
+    "_PT_brk5": {
+        "long_name": "Pass-through income tax bracket (upper threshold) 5",
+        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 4 is taxed at tax rate 5.",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[398350, 398350, 199175, 398350, 398350, 199175],
+                  [405100, 405100, 202550, 405100, 405100, 202550],
+                  [411500, 411500, 205750, 411500, 411500, 205750],
+                  [413350, 413350, 206675, 413350, 413350, 206675]],
+        "validations": {"min": "_PT_brk4", "max": "_PT_brk6"}
+    },
+
+    "_PT_rt6": {
+        "long_name": "Pass-through income tax rate 6",
+        "description": "The second higher tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 6 and above tax bracket 5. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.35]
+    },
+
+    "_PT_brk6": {
+        "long_name": "Pass-through income tax bracket (upper threshold) 6",
+        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 5 is taxed at tax rate 6.",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
+                  [406750, 457600, 228800, 432200, 457600, 228800],
+                  [413200, 464850, 232425, 439000, 464850, 232425],
+                  [415050, 466950, 233475, 441000, 466950, 233475]],
+        "validations": {"min": "_PT_brk5", "max": "_PT_brk7"}
+    },
+
+    "_PT_rt7": {
+        "long_name": "Pass-through income tax rate 7",
+        "description": "The highest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 7 and above tax bracket 6. ",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.396]
+    },
+
+    "_PT_brk7": {
+        "long_name": "Extra pass-through income tax bracket",
+        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 6 is taxed at tax rate 7. Default value is essentially infinity",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]],
+        "validations": {"min": "_PT_brk6"}
+    },
+
+    "_PT_rt8": {
+        "long_name": "Extra pass-through income tax rate",
+        "description": "The extra tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations above the tax bracket 7.",
+        "section_1": "Personal income",
+        "section_2": "Pass-through",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [1.0]
+
+    },
+
 
     "_AMT_em": {
         "long_name": "AMT exemption amount",
         "description": "The amount of AMT taxable income exempted from AMT.",
+        "section_1": "Personal income",
+        "section_2": "Alternative minimum tax",
+        "section_3": "Exemption",
         "irs_ref": "Form 1040, line 45, instruction (Worksheet).",
         "notes": "",
         "start_year": 2013,
@@ -1551,6 +1769,9 @@
     "_AMT_prt": {
         "long_name": "AMT exemption phaseout rate",
         "description": "AMT exemption will decrease at this rate for each dollar of AMT taxable income exceeding AMT phaseout start. ",
+        "section_1": "Personal income",
+        "section_2": "Alternative minimum tax",
+        "section_3": "Exemption",
         "irs_ref": "Form 6251, line 29, instructions. ",
         "notes": "",
         "start_year": 2013,
@@ -1562,32 +1783,27 @@
         "value": [0.25]
     },
 
-    "_AMT_rt1": {
-        "long_name": "AMT rate for AMT taxable income below _AMT_brk1",
-        "description": "The tax rate applied to the portion of AMT taxable income below the surtax threshold, _AMT_brk1.",
-        "irs_ref": "Form 6251, line 31, in-line. ",
+    "_AMT_em_ps": {
+        "long_name": "AMT exemption phaseout start",
+        "description": "AMT exemption starts to decrease when AMT taxable income goes beyond this threshold.",
+        "section_1": "Personal income",
+        "section_2": "Alternative minimum tax",
+        "section_3": "Exemption",
+        "irs_ref": "Form 1040, line 45, instruction (Worksheet).",
         "notes": "",
         "start_year": 2013,
-        "col_var": "",
+        "col_var": "MARS",
         "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.26]
-    },
-
-    "_AMT_rt2": {
-        "long_name": "Additional AMT rate for AMT taxable income above _AMT_brk1",
-        "description": "The additional tax rate applied to the portion of AMT income above the _AMT_brk1.",
-        "irs_ref": "Form 6251, line 31, in-line. ",
-        "notes": "This is the additional tax rate (on top of _AMT_rt1) for AMT income above _AMT_brk1",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.02]
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[115400, 153900, 76950, 115400, 153900, 76950],
+                  [117300, 156500, 78250, 117300, 156500, 78250],
+                  [119200, 158900, 79450, 119200, 158900, 79450],
+                  [119700, 159700, 79850, 119700, 159700, 79850]]
     },
 
     "_AMT_Child_em": {
@@ -1610,25 +1826,93 @@
                   7400]
     },
 
-    "_AMT_em_ps": {
-        "long_name": "AMT exemption phaseout start",
-        "description": "AMT exemption starts to decrease when AMT taxable income goes beyond this threshold.",
-        "irs_ref": "Form 1040, line 45, instruction (Worksheet).",
+       "_AMT_KT_c_Age": {
+        "long_name": "Maximum age subject to Kiddie Tax",
+        "description": "At or under this age, the individual is subject to Kiddie Tax.",
+        "irs_ref": "Form 6251, line 28, instruction.",
         "notes": "",
         "start_year": 2013,
-        "col_var": "MARS",
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [24]
+    },
+
+    "_AMT_rt1": {
+        "long_name": "AMT rate for AMT taxable income below _AMT_brk1",
+        "description": "The tax rate applied to the portion of AMT taxable income below the surtax threshold, _AMT_brk1.",
+        "section_1": "Personal income",
+        "section_2": "Alternative minimum tax",
+        "section_3": "Tax rates",
+        "irs_ref": "Form 6251, line 31, in-line. ",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.26]
+    },
+
+    "_AMT_brk1": {
+        "long_name": "AMT tax bracket (upper threshold) 1",
+        "description": "AMT taxable income below this is subject to _AMT_rt1 and above it is subject to _AMT_rt1 + _AMT_rt2.",
+        "section_1": "Personal income",
+        "section_2": "Alternative minimum tax",
+        "section_3": "Tax rates",
+        "irs_ref": "Form 6251, line 31, instruction.",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
         "row_var": "FLPDYR",
         "row_label": ["2013",
                       "2014",
                       "2015",
                       "2016"],
         "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[115400, 153900, 76950, 115400, 153900, 76950],
-                  [117300, 156500, 78250, 117300, 156500, 78250],
-                  [119200, 158900, 79450, 119200, 158900, 79450],
-                  [119700, 159700, 79850, 119700, 159700, 79850]]
+        "col_label": "",
+        "value": [179500,
+                  182500,
+                  185400,
+                  186300]
     },
+
+    "_AMT_rt2": {
+        "long_name": "Additional AMT rate for AMT taxable income above _AMT_brk1",
+        "description": "The additional tax rate applied to the portion of AMT income above the _AMT_brk1.",
+        "section_1": "Personal income",
+        "section_2": "Alternative minimum tax",
+        "section_3": "Tax rates",
+        "irs_ref": "Form 6251, line 31, in-line. ",
+        "notes": "This is the additional tax rate (on top of _AMT_rt1) for AMT income above _AMT_brk1",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.02]
+    },
+
+    "_AMT_thd_MarriedS": {
+        "long_name": "Extra alminc for married sep",
+        "description": "",
+        "irs_ref": "Form 6251, line 28, instruction.",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014"],
+        "cpi_inflated": true,
+        "col_label": "",
+        "value": [40400,
+                  41050]
+    },
+
 
     "_AMT_em_pe": {
         "long_name": "AMT exemption phaseout ending AMT taxable income (Married filling Separately)",
@@ -1646,51 +1930,11 @@
                   242450]
     },
 
-    "_NIIT_thd": {
-        "long_name": "Net Investment Income Tax modified AGI threshold",
-        "description": "If modified AGI is more than this threshold, filing unit is subject to the Net Investment Income Tax.",
-        "irs_ref": "Form 8960, line 14, instructions. ",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[200000, 250000, 125000, 200000, 250000, 125000]]
-    },
-
-    "_NIIT_PT_taxed": {
-        "long_name": "Whether or not partnership and S-corp income is in NIIT base",
-        "description": "false ==> e26270 excluded from NIIT base; true ==> e26270 is in NIIT base",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [false]
-    },
-
-    "_NIIT_rt": {
-        "long_name": "Net Investment Income Tax rate",
-        "description": "If modified AGI exceeds _NIIT_thd, all net investment income is taxed at this rate.",
-        "irs_ref": "Form 8960, line 21, in-line. ",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.038]
-    },
-
     "_CDCC_c": {
         "long_name": "Maximum child & dependent care credit per dependent",
         "description": "The maximum amount of credit allowed for each qualifying dependent.",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Child and dependent care",
         "irs_ref": "Form 2441, line 3, in-line.",
         "notes": "",
         "start_year": 2013,
@@ -1705,6 +1949,8 @@
     "_CDCC_ps": {
         "long_name": "Child & dependent care credit phaseout start",
         "description": "For taxpayers with AGI over this amount, the credit is reduced by one percentage point each $2000 of AGI over this amount. ",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Child and dependent care",
         "start_year": 2013,
         "col_var": "",
         "row_var": "FLPDYR",
@@ -1717,6 +1963,8 @@
     "_CDCC_crt": {
         "long_name": "Child & dependent care credit phaseout percentage rate ceiling",
         "description": "The maximum percentage rate in the AGI phaseout; this percentage rate decreases as AGI rises above the _CDCC_ps level.",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Child and dependent care",
         "irs_ref": "Form 2241, line 8, in-line.",
         "notes": "",
         "start_year": 2013,
@@ -1728,9 +1976,107 @@
         "value": [35]
     },
 
-    "_EITC_indiv": {
-        "long_name": "EITC is individual-based rather than filing-unit based",
-        "description": "Current-law value is false implying EITC is filing-unit based; a value of true implies EITC is computed for each individual wage earner.  The phase-out of the credit works slightly differently between the two.  Individual-based calculation ignore investment income and age eligibilty rules used in filing-unit-based calculations.",
+     "_CTC_c": {
+        "long_name": "Maximum child tax credit per child",
+        "description": "The maximum amount of credit allowed for each child. ",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Child tax credit",
+        "irs_ref": "form 1040, line 52, instructions (child tax credit worksheet, line 1).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [1000]
+    },
+
+    "_CTC_c_under5_bonus": {
+        "long_name": "Bonus child tax credit maximum for qualifying children under five",
+        "description": "The maximum amount of child tax credit allowed for each child is increased by this amount for qualifying children under 5 years old. ",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Child tax credit",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_CTC_ps": {
+        "long_name": "Child tax credit phaseout MAGI start",
+        "description": "Child tax credit begins to decrease when MAGI is above this level.",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Child tax credit",
+        "irs_ref": "Form 1040, line 52, instruction (Worksheet, line 3).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[75000, 110000, 55000, 75000, 75000, 55000]]
+    },
+
+    "_CTC_prt": {
+        "long_name": "Child tax credit phaseout rate",
+        "description": "The amount of credit starts to decrease at this rate if MAGI is higher than child tax credit phaseout start. ",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Child tax credit",
+        "irs_ref": "Form 1040, line 52, instruction (child tax credit worksheet, line 5)",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.05]
+    },
+
+    "_DependentCredit_c": {
+        "long_name": "Nonrefundable credit for dependents",
+        "description": "This nonrefundable credit is applied to dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Child tax credit",
+        "irs_ref": "",
+        "notes": "The Ryan-Brady tax plan sets this at $500",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0]
+    },
+
+    "_NIIT_thd": {
+        "long_name": "Net Investment Income Tax modified AGI threshold",
+        "description": "If modified AGI is more than this threshold, filing unit is subject to the Net Investment Income Tax.",
+        "section_1": "Other taxes",
+        "section_2": "Net investment income tax",
+        "irs_ref": "Form 8960, line 14, instructions. ",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[200000, 250000, 125000, 200000, 250000, 125000]]
+    },
+
+    "_NIIT_PT_taxed": {
+        "long_name": "Whether or not partnership and S-corp income is in NIIT base",
+        "description": "false ==> partnership and S-corp income excluded from NIIT base; true ==> partnership and s-corp income is in NIIT base",
+        "section_1": "Other taxes",
+        "section_2": "Net investment income tax",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -1742,49 +2088,27 @@
         "value": [false]
     },
 
-    "_EITC_ps": {
-        "long_name": "Earned income credit phaseout AGI start",
-        "description": "If AGI is higher than this threshold, the amount of EITC will start to decrease. ",
-        "irs_ref": "Form 1040, line 66a&b, instructions.",
+    "_NIIT_rt": {
+        "long_name": "Net Investment Income Tax rate",
+        "description": "If modified AGI exceeds _NIIT_thd, all net investment income is taxed at this rate.",
+        "section_1": "Other taxes",
+        "section_2": "Net investment income tax",
+        "irs_ref": "Form 8960, line 21, in-line. ",
         "notes": "",
         "start_year": 2013,
-        "col_var": "EIC",
+        "col_var": "",
         "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["0kids", "1kid", "2kids", "3+kids"],
-        "value": [[7970, 17530, 17530, 17530],
-                  [8110, 17830, 17830, 17830],
-                  [8250, 18150, 18150, 18150],
-                  [8270, 18190, 18190, 18190]]
-    },
-
-    "_EITC_ps_MarriedJ": {
-        "long_name": "EITC Phaseout Starting AGI (Married filling Jointly)",
-        "description": "This is the additional amount added on the regular EITC phaseout start, only for taxpayers with filling status of married filling jointly. ",
-        "irs_ref": "Form 1040, line 66a&b, calculation (the difference between EIC phaseout bases of married jointly fillers and other fillers).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "EIC",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["0kids", "1kid", "2kids", "3+kids"],
-        "value": [[5340, 5340, 5340, 5340],
-                  [5430, 5430, 5430, 5430],
-                  [5500, 5500, 5500, 5500],
-                  [5550, 5550, 5550, 5550]]
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.038]
     },
 
     "_EITC_c": {
         "long_name": "Maximum earned income credit",
         "description": "This is the maximum amount of earned income credit taxpayers are eligible for; it depends on how many kids they have. ",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
         "irs_ref": "IRS reference: form 1040, line 66a&b, instruction (table).",
         "notes": "",
         "start_year": 2013,
@@ -1805,6 +2129,8 @@
     "_EITC_rt": {
         "long_name": "Earned income credit rate",
         "description": "If one taxpayer's AGI is below AGI phaseout start, he can apply this rate to his earned income to calculate the credit amount eligible. ",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
         "irs_ref": "Form 1040, line 66a&b, calculation (table: Max_EIC/Max_EIC_base_income).",
         "notes": "Range of this parameter is between zero and one. ",
         "start_year": 2013,
@@ -1816,9 +2142,12 @@
         "value": [[0.0765, 0.3400, 0.4000, 0.4500]]
     },
 
+
     "_EITC_prt": {
         "long_name": "Earned income credit phaseout rate",
         "description": "Earned income credit will decrease at the this rate when AGI is higher than EITC phaseout start. ",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
         "irs_ref": "Form 1040, line 66a&b, calculation (table: Max_EIC_base_income/Phaseout_Base).",
         "notes": "",
         "start_year": 2013,
@@ -1830,9 +2159,88 @@
         "value": [[0.0765, 0.1598, 0.2106, 0.2106]]
     },
 
+    "_EITC_ps": {
+        "long_name": "Earned income credit phaseout AGI start",
+        "description": "If AGI is higher than this threshold, the amount of EITC will start to decrease. ",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
+        "irs_ref": "Form 1040, line 66a&b, instructions.",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "EIC",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["0kids", "1kid", "2kids", "3+kids"],
+        "value": [[7970, 17530, 17530, 17530],
+                  [8110, 17830, 17830, 17830],
+                  [8250, 18150, 18150, 18150],
+                  [8270, 18190, 18190, 18190]]
+    },
+
+    "_EITC_ps_MarriedJ": {
+        "long_name": "EITC Phaseout Starting AGI (Married filling Jointly)",
+        "description": "This is the additional amount added on the regular EITC phaseout start, only for taxpayers with filling status of married filling jointly. ",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
+        "irs_ref": "Form 1040, line 66a&b, calculation (the difference between EIC phaseout bases of married jointly fillers and other fillers).",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "EIC",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016"],
+        "cpi_inflated": true,
+        "col_label": ["0kids", "1kid", "2kids", "3+kids"],
+        "value": [[5340, 5340, 5340, 5340],
+                  [5430, 5430, 5430, 5430],
+                  [5500, 5500, 5500, 5500],
+                  [5550, 5550, 5550, 5550]]
+    },
+
+    "_EITC_MinEligAge": {
+        "long_name": "Minimum Age for Childless EITC Eligibility",
+        "description": "For a childless filling unit, at least one individual's age needs to be no less than this age (but no greater than the EITC_MaxEligAge) in order to be eligible for an earned income tax credit.",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
+        "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [25]
+    },
+
+    "_EITC_MaxEligAge": {
+        "long_name": "Maximum Age for Childless EITC Eligibility",
+        "description": "For a childless filling unit, at least one individual's age needs to be no greater than this age (but no less than the EITC_MinEligAge) in order to be eligible for an earned income tax credit.",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
+        "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [64]
+    },
+
+
     "_EITC_InvestIncome_c": {
         "long_name": "Max disqualifying income for EITC",
         "description": "The earned income credit may not be claimed by taxpayers whose investment income exceeds this limit.",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
         "irs_ref": "Form 1040, line 66a&b, instruction(step2)",
         "notes": "",
         "start_year": 2013,
@@ -1850,51 +2258,11 @@
                   3400]
     },
 
-    "_EITC_MinEligAge": {
-        "long_name": "Minimum Age for Childless EITC Eligibility",
-        "description": "For a childless filling unit, at least one individual's age needs to be no less than this age (but no greater than the EITC_MaxEligAge) in order to be eligible for an earned income tax credit.",
-        "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [25]
-    },
-
-    "_EITC_MaxEligAge": {
-        "long_name": "Maximum Age for Childless EITC Eligibility",
-        "description": "For a childless filling unit, at least one individual's age needs to be no greater than this age (but no less than the EITC_MinEligAge) in order to be eligible for an earned income tax credit.",
-        "irs_ref": "Form 1040, line 66a&b, step 4, instructions.",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [64]
-    },
-
-    "_CTC_c": {
-        "long_name": "Maximum child tax credit per child",
-        "description": "The maximum amount of credit allowed for each child. ",
-        "irs_ref": "form 1040, line 52, instructions (child tax credit worksheet, line 1). ",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [1000]
-    },
-
-    "_CTC_c_under5_bonus": {
-        "long_name": "Bonus child tax credit maximum for qualifying children under five",
-        "description": "The maximum amount of child tax credit allowed for each child is increased by this amount for qualifying children under 5 years old. ",
+    "_EITC_indiv": {
+        "long_name": "EITC is individual-based rather than filing-unit based",
+        "description": "Current-law value is false implying EITC is filing-unit based; a value of true implies EITC is computed for each individual wage earner.  The phase-out of the credit works slightly differently between the two.  Individual-based calculation ignore investment income and age eligibilty rules used in filing-unit-based calculations.",
+        "section_1": "Refundable credits",
+        "section_2": "Earned income tax credit",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -1903,49 +2271,7 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [0.0]
-    },
-
-    "_CTC_ps": {
-        "long_name": "Child tax credit phaseout MAGI start",
-        "description": "Child tax credit begins to decrease when MAGI is above this level.",
-        "irs_ref": "Form 1040, line 52, instruction (Worksheet, line 3).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[75000, 110000, 55000, 75000, 75000, 55000]]
-    },
-
-    "_CTC_prt": {
-        "long_name": "Child tax credit phaseout rate",
-        "description": "The amount of credit starts to decrease at this rate if MAGI is higher than child tax credit phaseout start. ",
-        "irs_ref": "Form 1040, line 52, instruction (child tax credit worksheet, line 5)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.05]
-    },
-
-    "_DependentCredit_c": {
-        "long_name": "Nonrefundable credit for dependents",
-        "description": "This nonrefundable credit is applied to dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
-        "irs_ref": "",
-        "notes": "The Ryan-Brady tax plan sets this at $500",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0]
+        "value": [false]
     },
 
     "_LLC_Expense_c": {
@@ -1998,38 +2324,11 @@
                   130]
     },
 
-    "_ACTC_Income_thd": {
-        "long_name": "Additional Child Tax Credit income threshold",
-        "description": "The portion of earned income below this threshold does not count as base for the Additional Child Tax Credit.",
-        "irs_ref": "Form 2441, line 3, in-line.",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [3000]
-    },
-
-
-    "_ACTC_rt_bonus_under5family": {
-        "long_name": "Bonus additional child tax credit rate for families with qualifying children under 5",
-        "description": "For families with qualifying children under 5 years old, this bonus rate is added to the fraction of earnings used in calculating the ACTC (_ACTC_rt).",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
     "_ACTC_rt": {
         "long_name": "Additional Child Tax Credit rate",
         "description": "This is the fraction of earnings used in calculating the ACTC, which is a partially refundable credit that supplements the CTC for some taxpayers. ",
+        "section_1": "Refundable credits",
+        "section_2": "Additional child tax credit",
         "irs_ref": "Form 8812, line 8, inline.",
         "notes": "",
         "start_year": 2013,
@@ -2041,9 +2340,43 @@
         "value": [0.15]
     },
 
+    "_ACTC_rt_bonus_under5family": {
+        "long_name": "Bonus additional child tax credit rate for families with qualifying children under 5",
+        "description": "For families with qualifying children under 5 years old, this bonus rate is added to the fraction of earnings (additional child tax credit rate) used in calculating the ACTC.",
+        "section_1": "Refundable credits",
+        "section_2": "Additional child tax credit",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_ACTC_Income_thd": {
+        "long_name": "Additional Child Tax Credit income threshold",
+        "description": "The portion of earned income below this threshold does not count as base for the Additional Child Tax Credit.",
+        "section_1": "Refundable credits",
+        "section_2": "Additional child tax credit",
+        "irs_ref": "Form 2441, line 3, in-line.",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [3000]
+    },
+
     "_ACTC_ChildNum": {
         "long_name": "Additional Child Tax Credit minimum number of qualified children",
         "description": "Families with this number of qualified children or more may qualify for the Additional Child Tax Credit, which is a partially refundable credit that supplements the Child Tax Credit for some taxpayers.",
+        "section_1": "Refundable credits",
+        "section_2": "Additional child tax credit",
         "irs_ref": "Form 8812, Part III. ",
         "notes": "",
         "start_year": 2013,
@@ -2058,6 +2391,8 @@
     "_CTC_new_c": {
         "long_name": "New refundable child tax credit maximum amount per child",
         "description": "In addition to all credits currently available for dependents, this parameter gives each qualifying child a new refundable credit with this maximum amount.",
+        "section_1": "Refundable credits",
+        "section_2": "New refundable child tax credit",
         "irs_ref": "",
         "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
         "start_year": 2013,
@@ -2073,6 +2408,8 @@
     "_CTC_new_c_under5_bonus": {
         "long_name": "Bonus new refundable child tax credit maximum for qualifying children under five",
         "description": "The maximum amount of the new refundable child tax credit allowed for each child is increased by this amount for qualifying children under 5 years old. ",
+        "section_1": "Refundable credits",
+        "section_2": "New refundable child tax credit",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -2087,6 +2424,8 @@
     "_CTC_new_rt": {
         "long_name": "New refundable child tax credit amount phasein rate",
         "description": "The total amount of the new child tax credit is increased at this rate per dollar of AGI until _CTC_new_c times the number of qualified children is reached.",
+        "section_1": "Refundable credits",
+        "section_2": "New refundable child tax credit",
         "irs_ref": "",
         "notes": "Child age qualification for the new child tax credit is the same as under current-law Child Tax Credit.",
         "start_year": 2013,
@@ -2101,6 +2440,8 @@
     "_CTC_new_ps": {
         "long_name": "New refundable child tax credit phaseout starting AGI",
         "description": "The total amount of new child tax credit is reduced for taxpayers with AGI higher than this level.",
+        "section_1": "Refundable credits",
+        "section_2": "New refundable child tax credit",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -2114,6 +2455,8 @@
     "_CTC_new_prt": {
         "long_name": "New refundable child tax credit amount phaseout rate",
         "description": "The total amount of the new child tax credit is reduced at this rate per dollar exceeding the phaseout starting AGI, _CTC_new_ps.",
+        "section_1": "Refundable credits",
+        "section_2": "New refundable child tax credit",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -2128,6 +2471,8 @@
     "_CTC_new_refund_limited": {
         "long_name": "New child tax credit refund limited to a decimal fraction of payroll taxes",
         "description": "Specifies whether the new child tax credit refund is limited by the new child tax credit refund limit rate (_CTC_new_refund_limit_payroll_rt)",
+        "section_1": "Refundable credits",
+        "section_2": "New refundable child tax credit",
         "irs_ref": "",
         "notes": "Set this parameter to true to limit the refundability or false to allow full refundability for all taxpayers.",
         "start_year": 2013,
@@ -2142,6 +2487,8 @@
     "_CTC_new_refund_limit_payroll_rt": {
         "long_name": "New child tax credit refund limit rate (decimal fraction of payroll taxes)",
         "description": "The fraction of payroll taxes (employee plus employer shares, but excluding all Medicare payroll taxes) that serves as a limit to the amount of new child tax credit that can be refunded.",
+        "section_1": "Refundable credits",
+        "section_2": "New refundable child tax credit",
         "irs_ref": "",
         "notes": "Set this parameter to zero for no refundability; set it to 9e99 for unlimited refundability for taxpayers with payroll tax liabilities.",
         "start_year": 2013,
@@ -2154,284 +2501,11 @@
         "validations": {"min": 0}
     },
 
-
-    "_PT_rt1": {
-        "long_name": "Pass-through income tax rate 1",
-        "description": "The lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 1. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.1]
-    },
-
-    "_PT_rt2": {
-        "long_name": "Pass-through income tax rate 2",
-        "description": "The second lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 2 and above tax bracket 1. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.15]
-    },
-
-    "_PT_rt3": {
-        "long_name": "Pass-through income tax rate 3",
-        "description": "The third lowest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 3 and above tax bracket 2. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.25]
-    },
-
-    "_PT_rt4": {
-        "long_name": "Pass-through income tax rate 4",
-        "description": "The tax rate applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 4 and above tax bracket 3. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.28]
-    },
-
-    "_PT_rt5": {
-        "long_name": "Pass-through income tax rate 5",
-        "description": "The third highest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 5 and above tax bracket 4. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.33]
-    },
-
-    "_PT_rt6": {
-        "long_name": "Pass-through income tax rate 6",
-        "description": "The second higher tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 6 and above tax bracket 5. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.35]
-    },
-
-    "_PT_rt7": {
-        "long_name": "Pass-through income tax rate 7",
-        "description": "The highest tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations below tax bracket 7 and above tax bracket 6. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ)",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.396]
-    },
-
-    "_PT_rt8": {
-        "long_name": "Extra pass-through income tax rate",
-        "description": "The extra tax rate, applied to the portion of income from sole proprietorships, partnerships and S corporations above the tax bracket 7.",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [1.0]
-
-    },
-
-    "_PT_brk1": {
-        "long_name": "Pass-through income tax bracket (upper threshold) 1",
-        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold is taxed at tax rate 1. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[8925, 17850, 8925, 12750, 17850, 8925],
-                  [9075, 18150, 9075, 12950, 18150, 9075],
-                  [9225, 18450, 9225, 13150, 18450, 9225],
-                  [9275, 18550, 9275, 13250, 18550, 9275]],
-        "validations": {"min": 0, "max": "_PT_brk2"}
-    },
-
-    "_PT_brk2": {
-        "long_name": "Pass-through income tax bracket (upper threshold) 2",
-        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 1 is taxed at tax rate 2. ",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[36250, 72500, 36250, 48600, 72500, 36250],
-                  [36900, 73800, 36900, 49400, 73800, 36900],
-                  [37450, 74900, 37450, 50200, 74900, 37450],
-                  [37650, 75300, 37650, 50400, 75300, 37650]],
-        "validations": {"min": "_PT_brk1", "max": "_PT_brk3"}
-    },
-
-    "_PT_brk3": {
-        "long_name": "Pass-through income tax bracket (upper threshold) 3",
-        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 2 is taxed at tax rate 3.",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[87850, 146400, 73200, 125450, 146400, 73200],
-                  [89350, 148850, 74425, 127550, 148850, 74425],
-                  [90750, 151200, 75600, 129600, 151200, 75600],
-                  [91150, 151900, 75950, 130150, 151900, 75950]],
-        "validations": {"min": "_PT_brk2", "max": "_PT_brk4"}
-    },
-
-    "_PT_brk4": {
-        "long_name": "Pass-through income tax bracket (upper threshold) 4",
-        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 3 is taxed at tax rate 4.",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[183250, 223050, 111525, 203150, 223050, 111525],
-                  [186350, 226850, 113425, 206600, 226850, 113425],
-                  [189300, 230450, 115225, 209850, 230450, 115225],
-                  [190150, 231450, 115725, 210800, 231450, 115725]],
-        "validations": {"min": "_PT_brk3", "max": "_PT_brk5"}
-    },
-
-    "_PT_brk5": {
-        "long_name": "Pass-through income tax bracket (upper threshold) 5",
-        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 4 is taxed at tax rate 5.",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[398350, 398350, 199175, 398350, 398350, 199175],
-                  [405100, 405100, 202550, 405100, 405100, 202550],
-                  [411500, 411500, 205750, 411500, 411500, 205750],
-                  [413350, 413350, 206675, 413350, 413350, 206675]],
-        "validations": {"min": "_PT_brk4", "max": "_PT_brk6"}
-    },
-
-    "_PT_brk6": {
-        "long_name": "Pass-through income tax bracket (upper threshold) 6",
-        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 5 is taxed at tax rate 6.",
-        "irs_ref": "Form 1040, line 44, instruction (Schedule XYZ).",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[400000, 450000, 225000, 425000, 450000, 225000],
-                  [406750, 457600, 228800, 432200, 457600, 228800],
-                  [413200, 464850, 232425, 439000, 464850, 232425],
-                  [415050, 466950, 233475, 441000, 466950, 233475]],
-        "validations": {"min": "_PT_brk5", "max": "_PT_brk7"}
-    },
-
-    "_PT_brk7": {
-        "long_name": "Extra pass-through income tax bracket",
-        "description": "Income from sole proprietorships, partnerships and S corporations below this threshold and above tax bracket 6 is taxed at tax rate 7. Default value is essentially infinity",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "MARS",
-        "row_var": "FLPDYR",
-        "row_label": ["2013",
-                      "2014",
-                      "2015",
-                      "2016"],
-        "cpi_inflated": true,
-        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
-        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99],
-                  [9e99, 9e99, 9e99, 9e99, 9e99, 9e99]],
-        "validations": {"min": "_PT_brk6"}
-    },
-
-    "_LST": {
-        "long_name": "Dollar amount of lump-sum tax",
-        "description": "Lump-sum tax is included only in combined taxes; it is not included in income or payroll taxes.",
-        "irs_ref": "",
-        "notes": "",
-        "start_year": 2013,
-        "col_var": "",
-        "row_var": "",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-
     "_FST_AGI_trt": {
-        "long_name": "Rate applied to AGI to determine full Fair Share Tax",
-        "description": "The result of multiplying AGI by this is full FST (before credit for income tax and employee share of payroll taxes).",
+        "long_name": "New minimum tax; rate as a decimal fraction of AGI",
+        "description": "Individual income taxes and the employee share of payroll taxes are credited against this minimum tax, so the surtax is the difference between the tax rate times AGI and the credited taxes. The new minimum tax is similar to the Fair Share Tax, except that no credits are exempted from the base.",
+        "section_1": "Surtaxes",
+        "section_2": "New minimum tax",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -2445,8 +2519,10 @@
     },
 
     "_FST_AGI_thd_lo": {
-        "long_name": "Minimum AGI needed to be subject to Fair Share Tax",
-        "description": "A taxpayer is only subject to the FST if they exceed this level of AGI",
+        "long_name": "Minimum AGI needed to be subject to the new minimum tax",
+        "description": "A taxpayer is only subject to the new minimum tax if they exceed this level of AGI",
+        "section_1": "Surtaxes",
+        "section_2": "New minimum tax",
         "irs_ref": "",
         "note": "",
         "start_year": 2013,
@@ -2460,8 +2536,10 @@
     },
 
     "_FST_AGI_thd_hi": {
-        "long_name": "AGI level at which the Fair Share Tax is fully phased in",
-        "description": "The FST will be fully phased in at this level of AGI. If there is no phase-in, this upper threshold should be set equal to the lower AGI threshold",
+        "long_name": "AGI level at which the New Minimum Tax is fully phased in",
+        "description": "The new minimum tax will be fully phased in at this level of AGI. If there is no phase-in, this upper threshold should be set equal to the lower AGI threshold",
+        "section_1": "Surtaxes",
+        "section_2": "New minimum tax",
         "irs_ref": "",
         "note": "",
         "start_year": 2013,
@@ -2472,5 +2550,57 @@
         "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
         "value": [[2.0e6, 2.0e6, 1.0e6, 2.0e6, 2.0e6, 1.0e6]],
         "validations": {"min": "_FST_AGI_thd_lo"}
+    },
+
+
+    "_AGI_surtax_trt": {
+        "long_name": "New AGI surtax rate",
+        "description": "The surtax rate is applied to the portion of Adjusted Gross Income above the AGI surtax threshold.",
+        "section_1": "Surtaxes",
+        "section_2": "New AGI surtax",
+        "irs_ref": "",
+        "note": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0],
+        "validations": {"min": 0.0}
+    },
+
+    "_AGI_surtax_thd": {
+        "long_name": "Threshold for the new AGI surtax",
+        "description": "The aggregate gross income above this AGI surtax threshold is taxed at surtax rate on AGI.",
+        "section_1": "Surtaxes",
+        "section_2": "New AGI surtax",
+        "irs_ref": "",
+        "note": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "value": [[9e99, 9e99, 9e99, 9e99, 9e99, 9e99]]
+    },
+
+    "_LST": {
+        "long_name": "Dollar amount of lump-sum tax",
+        "description": "The lump-sum tax is available to every member of a tax filing unit. The lump-sum tax is included only in combined taxes; it is not included in income or payroll taxes.",
+        "section_1": "Surtaxes",
+        "section_2": "Lump-sum tax",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
     }
 }
+
+

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -708,7 +708,7 @@ def AGIsurtax(c00100, MARS, AGI_surtax_trt, AGI_surtax_thd, _taxbc, _surtax):
 def AMT(e07300, dwks13, _standard, f6251, c00100, c18300, _taxbc,
         c04470, c17000, c20800, c21040, e24515, MARS, _sep, dwks19,
         dwks14, c05700, e62900, e00700, dwks10, age_head, _earned, cmbtp,
-        KT_c_Age, AMT_brk1, AMT_thd_MarriedS,
+        AMT_KT_c_Age, AMT_brk1, AMT_thd_MarriedS,
         AMT_em, AMT_prt, AMT_rt1, AMT_rt2,
         AMT_Child_em, AMT_em_ps, AMT_em_pe,
         AMT_CG_brk1, AMT_CG_brk2, AMT_CG_brk3, AMT_CG_rt1, AMT_CG_rt2,
@@ -739,7 +739,7 @@ def AMT(e07300, dwks13, _standard, f6251, c00100, c18300, _taxbc,
     # Form 6251, Part II top
     line29 = max(0., AMT_em[MARS - 1] - AMT_prt *
                  max(0., c62100 - AMT_em_ps[MARS - 1]))
-    if age_head != 0 and age_head < KT_c_Age:
+    if age_head != 0 and age_head < AMT_KT_c_Age:
         line29 = min(line29, _earned + AMT_Child_em)
     line30 = max(0., c62100 - line29)
     line3163 = (AMT_rt1 * line30 +

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -450,7 +450,7 @@ def AdditionalMedicareTax(e00200, MARS,
 
 
 @iterate_jit(nopython=True)
-def StdDed(DSI, _earned, STD, age_head, age_spouse, STD_Aged,
+def StdDed(DSI, _earned, STD, age_head, age_spouse, STD_Aged, STD_Dep,
            MARS, MIDR, blind_head, blind_spouse, _standard):
     """
     StdDed function:
@@ -464,6 +464,8 @@ def StdDed(DSI, _earned, STD, age_head, age_spouse, STD_Aged,
     -----
     Tax Law Parameters:
         STD : Standard deduction amount, filing status dependent
+
+        STD_Dep : Standard deduction for dependents
 
         STD_Aged : Additional standard deduction for blind and aged
 
@@ -489,7 +491,7 @@ def StdDed(DSI, _earned, STD, age_head, age_spouse, STD_Aged,
     """
     # calculate deduction for dependents
     if DSI == 1:
-        c15100 = max(350. + _earned, STD[6])
+        c15100 = max(350. + _earned, STD_Dep)
         basic_stded = min(STD[MARS - 1], c15100)
     else:
         c15100 = 0.

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -494,7 +494,7 @@ def test_parameters_get_default_start_year():
     should_be = 41050 * (1.0 + Policy.default_inflation_rates()[2014])
     meta_amt_thd_marrieds['value'] == should_be
     # 1D data, doesn't have 2015 values, is not CPI inflated
-    meta_kt_c_age = paramdata['_KT_c_Age']
+    meta_kt_c_age = paramdata['_AMT_KT_c_Age']
     assert meta_kt_c_age['start_year'] == 2015
     assert meta_kt_c_age['row_label'] == ['2015']
     assert meta_kt_c_age['value'] == [24]


### PR DESCRIPTION
In #1074, I described several disconnects between TaxBrain and current_law_policy.json:

> 
> 1. Sections and subsections
> - TB is organized by sections and subsections, (e.g Refundable Credits: EITC), whereas `current_law_policy.json` parameters are only informally grouped into sections by reference in the title name. 
> 
> 2. Order of the parameters. 
>   - TB is ordered roughly by where the params appear in the tax forms, while TC's `current_law_policy.json` is roughly ordered by where the parameters appear in `taxcalc/functions.py.`
> 
> 3. "Principle" parameters 
> - The TB input page does not include every parameter from `current_law_policy.json`, rather it only includes parameters of principle importance. 
> 
> 4. 1-2 relationships between TB fields and TC params
> - Two sets of fields on the TaxBrain input page have a 1-2 relationship with parameters in Tax-Calculator. 
>     - The personal income tax rate and brackets fields on TaxBrain govern both `II_rt`s and `II_brk`s as well as `PT_rt`s and `PT_brk`s
>     - the long term capital gains and qualified dividends fields on TaxBrain govern both `CG_rt`s and `CG_bk`s as well as `AMT_CG_rt`s and `AMT_CG_brk`s.
> 

This PR resolves those disconnects by 

1. Adding `section_1`, `section_2`, and in some cases `section_3` fields that specify the conceptual relationship among parameters and therefore how they ought to be grouped on TaxBrain. 

2. Sorting the parameters in current_law_policy.json to be easier to use.  (I have not written down/formalized this schema, but I hope it will be fairly easy to stick to by looking at the examples). 

3. Specifying which parameters *should not* be included in TaxBrain by leaving off the section fields. My intent was to include every parameter on TaxBrain, but some have not received any attention for a long time, and I figure they might need to be dusted off. 

4. Updating the names and descriptions of parameters such as II_rts and PT_rts to make their relationships more obvious and thereby allow us to do away with the 1-2 relationships between TaxBrain inputs and Tax-Calculator parameters.

One of the core motivations for this project is to get to the point where we can fully specify the content and layout of the TaxBrain input page's tax-law parameters with the information in current_law_policy.json plus a set of translation rules. Once that is done, then the tax-calculator team should be able to trigger changes (whether manual or automated) to the TaxBrain input page by making a change to `current_law_policy.json`. @talumbau @PeterDSteinberg @brendancol  I'd particularly appreciate feedback on that aspect of the project and which additional steps might be needed. 

cc, @martinholmer, @feenberg, @GoFroggyRun, @zrisher, @codykallen, @andersonfrailey, @Amy-Xu 