### PR TITLE
Consumption processing in dropq

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -23,7 +23,6 @@ from .records import Records
 from .behavior import Behavior
 from .growth import Growth
 from .consumption import Consumption
-# import pdb
 
 
 class Calculator(object):
@@ -158,7 +157,6 @@ class Calculator(object):
         # calls all the functions except those in calc_all() function
         if zero_out_calc_vars:
             self.records.zero_out_changing_calculated_vars()
-        # pdb.set_trace()
         EI_PayrollTax(self.policy, self.records)
         DependentCare(self.policy, self.records)
         Adj(self.policy, self.records)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -23,6 +23,7 @@ from .records import Records
 from .behavior import Behavior
 from .growth import Growth
 from .consumption import Consumption
+# import pdb
 
 
 class Calculator(object):
@@ -157,6 +158,7 @@ class Calculator(object):
         # calls all the functions except those in calc_all() function
         if zero_out_calc_vars:
             self.records.zero_out_changing_calculated_vars()
+        # pdb.set_trace()
         EI_PayrollTax(self.policy, self.records)
         DependentCare(self.policy, self.records)
         Adj(self.policy, self.records)

--- a/taxcalc/dropq/dropq.py
+++ b/taxcalc/dropq/dropq.py
@@ -11,6 +11,7 @@ import pandas as pd
 import hashlib
 import copy
 import time
+import collections
 from .dropq_utils import create_dropq_difference_table as dropq_diff_table
 from .dropq_utils import create_dropq_distribution_table as dropq_dist_table
 from .dropq_utils import *
@@ -138,7 +139,8 @@ def get_unknown_parameters(user_mods, start_year):
     growth_dd = growth.Growth.default_data(start_year=start_year)
     policy_dd = policy.Policy.default_data(start_year=start_year)
     consump_dd = Consumption.default_data(start_year=start_year)
-    unknown_params = []
+    param_code_names = policy.Policy.VALID_PARAM_CODE_NAMES
+    unknown_params = collections.defaultdict(list)
     for year, reforms in user_mods.items():
         everything = set(reforms.keys())
         all_cpis = {p for p in reforms.keys() if p.endswith("_cpi")}
@@ -147,11 +149,12 @@ def get_unknown_parameters(user_mods, start_year):
         bad_cpis = all_cpis - all_good_cpis
         remaining = everything - all_cpis
         if bad_cpis:
-            unknown_params += list(bad_cpis)
+            unknown_params['bad_cpis'] += list(bad_cpis)
         pols = (remaining - set(beh_dd.keys()) - set(growth_dd.keys()) -
-                set(policy_dd.keys()) - set(consump_dd.keys()))
+                set(policy_dd.keys()) - set(consump_dd.keys()) -
+                param_code_names)
         if pols:
-            unknown_params += list(pols)
+            unknown_params['policy'] += list(pols)
 
     return unknown_params
 

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -1,5 +1,6 @@
 import os
 import json
+import tempfile
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
@@ -9,6 +10,53 @@ from taxcalc.dropq.dropq_utils import *
 from taxcalc.dropq import *
 from taxcalc import Policy, Records, Calculator
 from taxcalc import multiyear_diagnostic_table
+
+
+REFORM_CONTENTS = """
+// Specify AGI exclusion of some fraction of investment income
+{
+  "policy": {
+    // specify fraction of investment income that can be excluded from AGI
+    "_ALD_Investment_ec_rt": {"2016": [0.50]},
+
+    // specify "investment income" base to mean the sum of three things:
+    // taxable interest (e00300), qualified dividends (e00650), and
+    // long-term capital gains (p23250) [see functions.py for other
+    // types of investment income that can be included in the base]
+    "param_code": {"ALD_Investment_ec_base_code":
+                   "e00300 + e00650 + p23250"},
+
+    "_ALD_Investment_ec_base_code_active": {"2016": [true]}
+    // the dollar exclusion is the product of the base defined by code
+    // and the fraction defined above
+  },
+  "behavior": {
+    "_BE_sub": {"2016": [0.25]}
+  },
+  "growth": {
+  },
+  "consumption": {
+    "_MPC_e20400": {"2016": [0.01]}
+  }
+}
+"""
+
+
+@pytest.yield_fixture
+def reform_file():
+    """
+    Temporary reform file for testing dropq functions with reform file.
+    """
+    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    rfile.write(REFORM_CONTENTS)
+    rfile.close()
+    # must close and then yield for Windows platform
+    yield rfile
+    if os.path.isfile(rfile.name):
+        try:
+            os.remove(rfile.name)
+        except OSError:
+            pass  # sometimes we can't remove a generated temporary file
 
 
 @pytest.fixture(scope='session')
@@ -56,6 +104,28 @@ def test_run_dropq_nth_year(is_strict, rjson, growth_params,
                                                return_json=rjson,
                                                num_years=3)
         assert fiscal_tots is not None
+
+
+def test_run_dropq_nth_year_from_file(puf_1991_path, reform_file):
+
+    user_reform = Calculator.read_json_reform_file(reform_file.name)
+    user_mods = user_reform
+
+    # Create a Public Use File object
+    tax_data = pd.read_csv(puf_1991_path)
+    first = 2016
+    is_strict = False
+    rjson = True
+
+    (_, _, _, _, _, _, _, _,
+     _, _, fiscal_tots) = dropq.run_models(tax_data,
+                                           start_year=first,
+                                           is_strict=is_strict,
+                                           user_mods=user_mods,
+                                           return_json=rjson,
+                                           num_years=3)
+
+    assert fiscal_tots is not None
 
 
 @pytest.mark.requires_pufcsv

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -106,7 +106,8 @@ def test_run_dropq_nth_year(is_strict, rjson, growth_params,
         assert fiscal_tots is not None
 
 
-def test_run_dropq_nth_year_from_file(puf_1991_path, reform_file):
+@pytest.mark.parametrize("is_strict", [True, False])
+def test_run_dropq_nth_year_from_file(is_strict, puf_1991_path, reform_file):
 
     user_reform = Calculator.read_json_reform_file(reform_file.name)
     user_mods = user_reform
@@ -114,7 +115,6 @@ def test_run_dropq_nth_year_from_file(puf_1991_path, reform_file):
     # Create a Public Use File object
     tax_data = pd.read_csv(puf_1991_path)
     first = 2016
-    is_strict = False
     rjson = True
 
     (_, _, _, _, _, _, _, _,
@@ -307,8 +307,11 @@ def test_unknown_parameters_with_cpi():
     first_year = 2013
     user_mods = {first_year: myvars}
     ans = get_unknown_parameters(user_mods, 2015)
+    final_ans = []
+    for a in ans.values():
+        final_ans += a
     exp = set(["NOGOOD_cpi", "NO", "ELASTICITY_GDP_WRT_AMTR"])
-    assert set(ans) == exp
+    assert set(final_ans) == exp
 
 
 def test_format_macro_results():


### PR DESCRIPTION
 Add Consumption parameter processing to dropq

     - handle tuple of reform dictionaries from file
     - process consumption parameters
     - process "code expressions" now allowed in file based reforms