### PR TITLE
Add personal exemption indexing changes to file0.json reform

### DIFF
--- a/taxcalc/taxbrain/file0.json
+++ b/taxcalc/taxbrain/file0.json
@@ -1,12 +1,12 @@
 // 2022 RESULTS from taxcalc-inctax and taxbrain-upload version 0.7.3
-// INCOME TAX ($B)   1711.31            1,711.3        <-- same
+// INCOME TAX ($B)   1722.68            1,722.7        <-- same
 // PAYROLL TAX ($B)  1485.37            1,485.3        <-- rounding error
 // taxcalc-inctax results from:
 //   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file0.json
 //   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 //   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/9432/
+//   http://www.ospc.org/taxbrain/9435/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -16,6 +16,10 @@
         },
         "_II_em": // personal exemption amount
         {"2018": [8000]
+        },
+        "_II_em_cpi": // personal exemption amount indexing status
+        {"2018": false, // values in future years are same as this year value
+         "2020": true // values in future years indexed with this year as base
         }
     },
     "behavior": {


### PR DESCRIPTION
Expands scope of `file0.json` reform to include indexing change that cannot be specified using standard TaxBrain parameter input web page.