### PR TITLE
Add investment income AGI exclusion to file0.json reform

### DIFF
--- a/taxcalc/taxbrain/file0.json
+++ b/taxcalc/taxbrain/file0.json
@@ -1,12 +1,12 @@
 // 2022 RESULTS from taxcalc-inctax and taxbrain-upload version 0.7.3
-// INCOME TAX ($B)   1722.68            1,722.7        <-- same
-// PAYROLL TAX ($B)  1485.37            1,485.3        <-- rounding error
+// INCOME TAX ($B)   1655.05            1,655.1        <-- same
+// PAYROLL TAX ($B)  1485.37            1,485.4        <-- same
 // taxcalc-inctax results from:
 //   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file0.json
 //   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 //   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/9435/
+//   http://www.ospc.org/taxbrain/9439/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -20,7 +20,11 @@
         "_II_em_cpi": // personal exemption amount indexing status
         {"2018": false, // values in future years are same as this year value
          "2020": true // values in future years indexed with this year as base
+        },
+        "_ALD_Investment_ec_rt": // investment income AGI exclusion rate
+        {"2019": [0.20]
         }
+        // investment income AGI exclusion base is all investment income
     },
     "behavior": {
     },


### PR DESCRIPTION
Reform uses all investment income as the base of the exclusion, which is the default assumption.