### PR TITLE
Add custom investment income AGI exclusion base to file0.json reform

### DIFF
--- a/taxcalc/taxbrain/file0.json
+++ b/taxcalc/taxbrain/file0.json
@@ -1,12 +1,12 @@
 // 2022 RESULTS from taxcalc-inctax and taxbrain-upload version 0.7.3
-// INCOME TAX ($B)   1655.05            1,655.1        <-- same
+// INCOME TAX ($B)   1672.23            1,672.2        <-- same
 // PAYROLL TAX ($B)  1485.37            1,485.4        <-- same
 // taxcalc-inctax results from:
 //   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file0.json
 //   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 //   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/9439/
+//   http://www.ospc.org/taxbrain/9441/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -23,8 +23,16 @@
         },
         "_ALD_Investment_ec_rt": // investment income AGI exclusion rate
         {"2019": [0.20]
+        },
+        // investment income AGI exclusion base is not all investment income
+        // but rather the sum of taxable interest, qualified dividends, and
+        // long-term capital gains
+        "_ALD_Investment_ec_base_code_active":
+        {"2019": [true]
+        },
+        "param_code":
+        {"ALD_Investment_ec_base_code": "e00300 + e00650 + p23250"
         }
-        // investment income AGI exclusion base is all investment income
     },
     "behavior": {
     },


### PR DESCRIPTION
The custom exclusion base is implemented using parameter code, a feature not available on the standard TaxBrain input web page.