### PR TITLE
Add growth response to file0.json reform

### DIFF
--- a/taxcalc/taxbrain/file0.json
+++ b/taxcalc/taxbrain/file0.json
@@ -1,12 +1,12 @@
 // 2022 RESULTS from taxcalc-inctax and taxbrain-upload version 0.7.3
-// INCOME TAX ($B)   1651.70            1,651.7        <-- same
-// PAYROLL TAX ($B)  1475.65            1,475.6        <-- same
+// INCOME TAX ($B)   1637.93            1,637.9        <-- same
+// PAYROLL TAX ($B)  1468.79            1,468.7        <-- rounding error
 // taxcalc-inctax results from:
 //   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file0.json
 //   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 //   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/9444/
+//   http://www.ospc.org/taxbrain/9447/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -40,5 +40,6 @@
     "consumption": {
     },
     "growth": {
+        "_factor_adjustment": {"2013": [0.0], "2018": [-0.001]}
     }
 }


### PR DESCRIPTION
Shows TaxBrain file upload capability gives same results as `inctax.py` command-line interface to Tax-Calculator running on local computer when both a behavioral response and a growth response to a reform are assumed.