### PR TITLE
Remove growth response from file0.json reform

### DIFF
--- a/taxcalc/taxbrain/file0.json
+++ b/taxcalc/taxbrain/file0.json
@@ -1,12 +1,12 @@
 // 2022 RESULTS from taxcalc-inctax and taxbrain-upload version 0.7.3
-// INCOME TAX ($B)   1637.93            1,637.9        <-- same
-// PAYROLL TAX ($B)  1468.79            1,468.7        <-- rounding error
+// INCOME TAX ($B)   1651.70            1,651.7        <-- same
+// PAYROLL TAX ($B)  1475.65            1,475.6        <-- same
 // taxcalc-inctax results from:
 //   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file0.json
 //   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 //   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file0
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/9447/
+//   http://www.ospc.org/taxbrain/9458/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -40,6 +40,5 @@
     "consumption": {
     },
     "growth": {
-        "_factor_adjustment": {"2013": [0.0], "2018": [-0.001]}
     }
 }


### PR DESCRIPTION
Simplify `file0.json` file so that the only response is behavioral; that is, there is no consumption response and no growth response.