### PR TITLE
Make file0.json be static reform analysis and add file[1-3].json with responses

### DIFF
--- a/taxcalc/taxbrain/file1.json
+++ b/taxcalc/taxbrain/file1.json
@@ -1,12 +1,12 @@
 // 2022 RESULTS from taxcalc-inctax and taxbrain-upload version 0.7.3
-// INCOME TAX ($B)   1672.23            1,672.2        <-- same
-// PAYROLL TAX ($B)  1485.37            1,485.4        <-- same
+// INCOME TAX ($B)   1651.70            1,651.7        <-- same
+// PAYROLL TAX ($B)  1475.65            1,475.6        <-- same
 // taxcalc-inctax results from:
-//   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file0.json
-//   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file0
-//   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file0
+//   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file1.json
+//   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file1
+//   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file1
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/9461/
+//   http://www.ospc.org/taxbrain/9462/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -35,6 +35,7 @@
         }
     },
     "behavior": {
+        "_BE_sub": {"2018": [0.25]}
     },
     "consumption": {
     },

--- a/taxcalc/taxbrain/file2.json
+++ b/taxcalc/taxbrain/file2.json
@@ -2,11 +2,11 @@
 // INCOME TAX ($B)   1672.23            1,672.2        <-- same
 // PAYROLL TAX ($B)  1485.37            1,485.4        <-- same
 // taxcalc-inctax results from:
-//   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file0.json
-//   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file0
-//   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file0
+//   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file2.json
+//   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file2
+//   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file2
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/9461/
+//   http://www.ospc.org/taxbrain/9465/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -37,6 +37,7 @@
     "behavior": {
     },
     "consumption": {
+        "_MPC_e18400": {"2018": [0.05]}
     },
     "growth": {
     }

--- a/taxcalc/taxbrain/file3.json
+++ b/taxcalc/taxbrain/file3.json
@@ -1,12 +1,12 @@
 // 2022 RESULTS from taxcalc-inctax and taxbrain-upload version 0.7.3
-// INCOME TAX ($B)   1672.23            1,672.2        <-- same
-// PAYROLL TAX ($B)  1485.37            1,485.4        <-- same
+// INCOME TAX ($B)   1659.23            1,650.9        <-- diff
+// PAYROLL TAX ($B)  1478.04            1,475.2        <-- diff
 // taxcalc-inctax results from:
-//   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file0.json
-//   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file0
-//   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file0
+//   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file3.json
+//   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file3
+//   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-file3
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/9461/
+//   http://www.ospc.org/taxbrain/9467/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -35,8 +35,10 @@
         }
     },
     "behavior": {
+        "_BE_sub": {"2018": [0.25]}
     },
     "consumption": {
+        "_MPC_e18400": {"2018": [0.05]}
     },
     "growth": {
     }


### PR DESCRIPTION
Now in the taxcalc/taxbrain directory, `file0.json` contains a static reform analysis.
The `file1.json` file is the same as `file0.json` except adds behavioral response.
The `file2.json` file is the same as `file0.json` except adds consumption response.
The `file3.json` file is the same as `file0.json` except adds the behavioral response from `file1.json` and the consumption response from `file2.json`.

Note that current-law policy aggregate income tax and payroll tax revenues for 2022 are:
1849.58
1338.82
on both TaxBrain and on local computer running `inctax.py` command-line interface to Tax-Calculator.

Note that there is agreement between TaxBrain and local `inctax.py` results for `file0.json`, `file1.json` and `file2.json`, but disagreement between results generated by `file3.json`.  So, there is agreement when doing static reform analysis (`file0.json`), agreement when just behavioral response is added to static analysis (`file1.json`) and agreement when just consumption response is added to static analysis (`file2.json`), but disagreement when both behavioral response and consumption response are added to static analysis (`file3.json`).
Not sure why this is happening.  Appears as if TaxBrain and `inctax.py` may have implemented behavior and/or consumption response in different ways.  I will raise an issue to highlight this discrepancy.

@MattHJensen @feenberg @talumbau @Amy-Xu @andersonfrailey @GoFroggyRun @codykallen 
@zrisher @PeterDSteinberg 


