### PR TITLE
Fix bug in IncomeTaxIO class constructor

### DIFF
--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -182,20 +182,22 @@ class IncomeTaxIO(object):
             clp = Policy()
             clp.set_year(tax_year)
             recs_clp = copy.deepcopy(recs)
+            con = Consumption()
+            con.update_consumption(r_con)
+            gro = Growth()
+            gro.update_growth(r_gro)
             self._calc_clp = Calculator(policy=clp, records=recs_clp,
                                         verbose=False,
+                                        consumption=con,
+                                        growth=gro,
                                         sync_years=blowup_input_data)
             beh = Behavior()
             beh.update_behavior(r_beh)
-            gro = Growth()
-            gro.update_growth(r_gro)
-            con = Consumption()
-            con.update_consumption(r_con)
             self._calc = Calculator(policy=pol, records=recs,
                                     verbose=True,
                                     behavior=beh,
-                                    growth=gro,
                                     consumption=con,
+                                    growth=gro,
                                     sync_years=blowup_input_data)
         else:
             self._calc = Calculator(policy=pol, records=recs,

--- a/taxcalc/taxbrain/file3.json
+++ b/taxcalc/taxbrain/file3.json
@@ -1,6 +1,6 @@
 // 2022 RESULTS from taxcalc-inctax and taxbrain-upload version 0.7.3
-// INCOME TAX ($B)   1659.23            1,650.9        <-- diff
-// PAYROLL TAX ($B)  1478.04            1,475.2        <-- diff
+// INCOME TAX ($B)   1650.91            1,650.9        <-- same
+// PAYROLL TAX ($B)  1475.24            1,475.2        <-- same
 // taxcalc-inctax results from:
 //   python ../../inctax.py puf.csv 2022 --blowup --weights --reform file3.json
 //   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-file3


### PR DESCRIPTION
This pull request fixes IncomeTaxIO class constructor logic so that the same Consumption object is used in both the current-law and reform Calculator objects (not just in the reform Calculator object).  This brings IncomeTaxIO logic into line with the logic used in TaxBrain, which is described in [TaxBrain issue 433](https://github.com/OpenSourcePolicyCenter/webapp-public/issues/433)).

This logic fix causes no changes to the unit test results, to the validation test results, or to the reform comparison results, but it does resolve issue #1133 (@talumbau, thanks for all the help on ascertaining the cause of the differences in #1133).

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @GoFroggyRun @zrisher @codykallen 
