### PR TITLE
Describe how to update puf.csv in the TESTING.md file

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -40,6 +40,14 @@ corresponding year.  If you have acquired from IRS the most recent SOI
 PUF file and want to execute the tests that require the `puf.csv`
 file, contact the core development team to discuss your options.
 
+If you have access to the Tax-Calculator `puf.csv` file, you should
+have access to the private GitHub repository `taxpuf`, from which
+updates of the `puf.csv` are distributed.  When you receive a private
+email announcing a new version of the `puf.csv` file, be sure to
+execute a `conda update ... taxpuf` command (as described in the
+`taxpuf` repository's README file) before executing the tests
+described below.
+
 **NO PUF.CSV**: If you do not have access to the `puf.csv` file, run
 the first-phase of testing as follows at the command prompt in the
 tax-calculator directory at the top of the repository directory tree:


### PR DESCRIPTION
Add to the `TESTING.md` file a description of how to use the private `taxpuf` repo to update to a new version of the `puf.csv` file.  @PeterDSteinberg, is this addition accurate?  Can you offer suggestions to improve the added documentation?  Seems like this document should simply refer contributors to the `README.md` page in the `taxpuf` repo rather than repeat the information there.