### PR TITLE
[NO MERGE] Round sample weight variable, s006, to two decimal places

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -225,6 +225,7 @@ class Records(object):
         wt_colname = 'WT{}'.format(self.current_year)
         if wt_colname in self.WT.columns:
             self.s006 = self.WT[wt_colname] * 0.01
+            self.s006.round(2)
 
     @property
     def current_year(self):
@@ -245,6 +246,7 @@ class Records(object):
         wt_colname = 'WT{}'.format(self.current_year)
         if wt_colname in self.WT.columns:
             self.s006 = self.WT[wt_colname] * 0.01
+            self.s006.round(2)
 
     def set_current_year(self, new_current_year):
         """


### PR DESCRIPTION
This pull request adds just two weight-rounding statements to the `records.py` file.  The addition of these two statements causes no change in the unit test results (including the `requires_pufcsv` tests) and no changes in the reform comparison tests (all of which use weights to calculate reform-induced changes in aggregate revenue).  The fact that the rounding of the `s006` variable to two decimal digits (which is equivalent to rounding all the values in the `WEIGHTS.csv` file to the nearest integer) causes no changes in Tax-Calculator results shows that the size of the very large `WEIGHTS.csv` file can be reduced substantially.

Here is what the first two rows of the `WEIGHTS.csv` file looks like:
```
$ head -2 taxcalc/WEIGHTS.csv 
WT2009,WT2010,WT2011,WT2012,WT2013,WT2014,WT2015,WT2016,WT2017,WT2018,WT2019,WT2020,WT2021,WT2022,WT2023,WT2024,WT2025,WT2026
905.37,920.851827,702.58975425,933.979692,949.552056,945.930576,526.834803,544.88063784,564.15777588,562.93009416,539.97081633,587.53533465,584.0722944,558.97272189,586.53942765,593.11241385,599.7351954,606.45756765
$ 
```
So, for the first filing unit in the `puf.csv` sample, the `WEIGHTS.csv` file has for 2026 a weight of 
606.45756765.  That is eight decimal digits of precision.  And don't forget that the Records class divides this number by 100 in order to get the `s006` weight for the first filing unit.  That means a value of 6.0645756765 for the first unit's weight.  The proposed code change in this pull request rounds that value to 6.06.  And does the same rounding for all the other filing units.  As a result, there is no change in any test results.

So, it would seem there is an excessive degree of precision in the values in the `WEIGHTS.csv` file, which probably more than doubles the size of that file yet contributes nothing to the precision of Tax-Calculator results.

What are the implications of these findings?  It seems to me that a new `WEIGHTS.csv` file should be created in which the values are integers (that is, the rounded values in the current file).  The pull request that adds that integer-value `WEiGHTS.csv` file can also drop the two statements added in this pull request, and all the results should remain unchanged.

@MattHJensen @andersonfrailey @Amy-Xu @zrisher 
