### PR TITLE
Make IncomeTaxIO use Growth object like TaxBrain does

### DIFF
--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -42,14 +42,13 @@ class IncomeTaxIO(object):
     tax_year: integer
         calendar year for which income taxes will be computed for INPUT.
 
-    reform: None or string or dictionary
+    reform: None or string
         None implies no policy reform (current-law policy), or
-        string is name of optional REFORM file, or
-        dictionary suitable for passing to Policy.implement_reform() method.
+        string is name of optional REFORM file.
 
     assump: None or string
-        None implies economic assumptions are baseline and statuc analysis
-        of reform is conducted, or
+        None implies economic assumptions are baseline assumptions and
+        a static analysis of reform is conducted, or
         string is name of optional ASSUMP file.
 
     exact_calculations: boolean
@@ -76,7 +75,7 @@ class IncomeTaxIO(object):
     ------
     ValueError:
         if file specified by input_data string does not exist.
-        if reform is neither None, string, nor dictionary.
+        if reform is neither None nor string.
         if assump is neither None nor string.
         if tax_year before Policy start_year.
         if tax_year after Policy end_year.
@@ -114,34 +113,26 @@ class IncomeTaxIO(object):
         # construct output_filename and delete old output file if it exists
         if assump is None:
             asm = ''
-            self._assump = False
         elif isinstance(assump, six.string_types):
             if assump.endswith('.json'):
                 asm = '-{}'.format(assump[:-5])
             else:
                 asm = '-{}'.format(assump)
-            self._assump = True
         else:
             msg = 'IncomeTaxIO.ctor assump is neither None nor str'
             raise ValueError(msg)
         if reform is None:
-            ref = ''
             self._reform = False
-            self._using_reform_file = True
-        else:
+            ref = ''
+        elif isinstance(reform, six.string_types):
             self._reform = True
-            if isinstance(reform, six.string_types):
-                if reform.endswith('.json'):
-                    ref = '-{}'.format(reform[:-5])
-                else:
-                    ref = '-{}'.format(reform)
-                self._using_reform_file = True
-            elif isinstance(reform, dict):
-                ref = ''
-                self._using_reform_file = False
+            if reform.endswith('.json'):
+                ref = '-{}'.format(reform[:-5])
             else:
-                msg = 'IncomeTaxIO.ctor reform is neither None, str, nor dict'
-                raise ValueError(msg)
+                ref = '-{}'.format(reform)
+        else:
+            msg = 'IncomeTaxIO.ctor reform is neither None nor str'
+            raise ValueError(msg)
         if output_records:
             self._output_filename = '{}.records{}{}'.format(inp, ref, asm)
         elif csv_dump:
@@ -164,21 +155,10 @@ class IncomeTaxIO(object):
         if tax_year > pol.end_year:
             msg = 'tax_year {} greater than policy.end_year {}'
             raise ValueError(msg.format(tax_year, pol.end_year))
-        # implement reform and assump if specified
-        ref_d = dict()
-        beh_d = dict()
-        con_d = dict()
-        gro_d = dict()
-        if self._reform:
-            if self._using_reform_file:
-                (ref_d, beh_d, con_d,
-                 gro_d) = Calculator.read_json_param_files(reform, assump)
-            else:
-                ref_d = reform
-                beh_d = dict()
-                con_d = dict()
-                gro_d = dict()
-            pol.implement_reform(ref_d)
+        # get reform & assump dictionaries and implement reform
+        (ref_d, beh_d, con_d,
+         gro_d) = Calculator.read_json_param_files(reform, assump)
+        pol.implement_reform(ref_d)
         # set tax policy parameters to specified tax_year
         pol.set_year(tax_year)
         # read input file contents into Records object
@@ -203,14 +183,14 @@ class IncomeTaxIO(object):
                                weights=None,
                                start_year=tax_year)
         # create Calculator object
-        if self._reform and self._using_reform_file:
+        con = Consumption()
+        con.update_consumption(con_d)
+        gro = Growth()
+        gro.update_growth(gro_d)
+        if self._reform:
             clp = Policy()
             clp.set_year(tax_year)
             recs_clp = copy.deepcopy(recs)
-            con = Consumption()
-            con.update_consumption(con_d)
-            gro = Growth()
-            gro.update_growth(gro_d)
             self._calc_clp = Calculator(policy=clp, records=recs_clp,
                                         verbose=False,
                                         consumption=con,
@@ -227,6 +207,8 @@ class IncomeTaxIO(object):
         else:
             self._calc = Calculator(policy=pol, records=recs,
                                     verbose=True,
+                                    consumption=con,
+                                    growth=gro,
                                     sync_years=blowup_input_data)
 
     def tax_year(self):
@@ -254,8 +236,7 @@ class IncomeTaxIO(object):
         for varname in Records.USABLE_READ_VARS:
             vardata = getattr(self._calc.records, varname)
             recdf[varname] = vardata
-        writing_possible = self._using_input_file and self._using_reform_file
-        if writing_possible and writing_output_file:
+        if self._using_input_file and writing_output_file:
             recdf.to_csv(self._output_filename,
                          float_format='%.4f', index=False)
 
@@ -277,8 +258,7 @@ class IncomeTaxIO(object):
         for varname in Records.USABLE_READ_VARS | Records.CALCULATED_VARS:
             vardata = getattr(self._calc.records, varname)
             recdf[varname] = vardata
-        writing_possible = self._using_input_file and self._using_reform_file
-        if writing_possible and writing_output_file:
+        if self._using_input_file and writing_output_file:
             recdf.to_csv(self._output_filename,
                          float_format='%.2f', index=False)
 
@@ -320,7 +300,7 @@ class IncomeTaxIO(object):
         (mtr_ptax, mtr_itax,
          _) = self._calc.mtr(wrt_full_compensation=output_mtr_wrt_fullcomp)
         txt = None
-        if self._reform and self._using_reform_file:
+        if self._reform:
             self._calc = Behavior.response(self._calc_clp, self._calc)
             if output_ceeu:
                 if not self._calc.behavior.has_response():
@@ -370,8 +350,7 @@ class IncomeTaxIO(object):
         assert len(output) == self._calc.records.dim
         # handle disposition of calculated output
         olines = ''
-        writing_possible = self._using_input_file and self._using_reform_file
-        if writing_possible and writing_output_file:
+        if self._using_input_file and writing_output_file:
             SimpleTaxIO.write_output_file(output, self._output_filename)
         else:
             for idx in range(0, len(output)):

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -10,9 +10,14 @@ import os
 import re
 import ast
 from io import StringIO
+import tempfile
 import six
+import pytest
 import pandas as pd
 from taxcalc import IncomeTaxIO, Records  # pylint: disable=import-error
+
+
+# for fixture args, pylint: disable=redefined-outer-name
 
 
 class GetFuncDefs(ast.NodeVisitor):
@@ -161,23 +166,34 @@ def test_function_args_usage(tests_path):
         raise ValueError(msg)
 
 
-def test_1():
+@pytest.yield_fixture
+def reformfile1():
+    """
+    specify JSON text for reform
+    """
+    txt = """
+    {
+        "policy": {
+            "_SS_Earnings_c": {"2015": [100000]},
+            "_FICA_ss_trt": {"2015": [0.124]},
+            "_FICA_mc_trt": {"2015": [0.029]}
+        }
+    }
+    """
+    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    rfile.write(txt + '\n')
+    rfile.close()
+    # Must close and then yield for Windows platform
+    yield rfile
+    os.remove(rfile.name)
+
+
+def test_1(reformfile1):
     """
     Test calculation of AGI adjustment for half of Self-Employment Tax,
     which is the payroll tax on self-employment income.
     """
     agi_ovar_num = 10
-    # specify a reform that simplifies the hand calculations
-    mte = 100000  # lower than current-law to simplify hand calculations
-    ssr = 0.124  # current law OASDI ee+er payroll tax rate
-    mrr = 0.029  # current law HI ee+er payroll tax rate
-    policy_reform = {
-        2015: {
-            '_SS_Earnings_c': [mte],
-            '_FICA_ss_trt': [ssr],
-            '_FICA_mc_trt': [mrr]
-        }
-    }
     funit = (
         u'RECID,MARS,e00200,e00200p,e00900,e00900p,e00900s\n'
         u'1,    2,   200000, 200000,200000,      0, 200000\n'
@@ -206,7 +222,7 @@ def test_1():
     input_dataframe = pd.read_csv(StringIO(funit))
     inctax = IncomeTaxIO(input_data=input_dataframe,
                          tax_year=2015,
-                         reform=policy_reform,
+                         reform=reformfile1.name,
                          assump=None,
                          exact_calculations=False,
                          blowup_input_data=False,
@@ -223,7 +239,28 @@ def test_1():
     assert agi == expected_agi_2
 
 
-def test_2():
+@pytest.yield_fixture
+def reformfile2():
+    """
+    specify JSON text for implausible reform to make hand calcs easier
+    """
+    txt = """
+    {
+        "policy": {
+            "_ACTC_Income_thd": {"2015": [35000]},
+            "_SS_Earnings_c": {"2015": [53000]}
+        }
+    }
+    """
+    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    rfile.write(txt + '\n')
+    rfile.close()
+    # Must close and then yield for Windows platform
+    yield rfile
+    os.remove(rfile.name)
+
+
+def test_2(reformfile2):
     """
     Test calculation of Additional Child Tax Credit (CTC) when at least one
     of taxpayer and spouse have wage-and-salary income above the FICA maximum
@@ -231,16 +268,6 @@ def test_2():
     """
     ctc_ovar_num = 22
     actc_ovar_num = 23
-    # specify a contrived example -- implausible policy and a large family ---
-    # in order to make the hand calculations easier
-    actc_thd = 35000
-    mte = 53000
-    policy_reform = {
-        2015: {
-            '_ACTC_Income_thd': [actc_thd],
-            '_SS_Earnings_c': [mte]
-        }
-    }
     funit = (
         u'RECID,MARS,XTOT,n24,e00200,e00200p\n'
         u'1,    2,   9,     7, 60000,  60000\n'
@@ -257,7 +284,7 @@ def test_2():
     input_dataframe = pd.read_csv(StringIO(funit))
     inctax = IncomeTaxIO(input_data=input_dataframe,
                          tax_year=2015,
-                         reform=policy_reform,
+                         reform=reformfile2.name,
                          assump=None,
                          exact_calculations=False,
                          blowup_input_data=False,

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -126,19 +126,36 @@ def test_creation_with_blowup(rawinputfile, blowup, weights_out):
     assert inctax.tax_year() == taxyear
 
 
-def test_2(rawinputfile):
+@pytest.yield_fixture
+def reformfile0():
+    """
+    specify JSON text for reform
+    """
+    txt = """
+    {
+        "policy": {
+            "_SS_Earnings_c": {"2016": [300000],
+                               "2018": [500000],
+                               "2020": [700000]}
+        }
+    }
+    """
+    rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    rfile.write(txt + '\n')
+    rfile.close()
+    # Must close and then yield for Windows platform
+    yield rfile
+    os.remove(rfile.name)
+
+
+def test_2(rawinputfile, reformfile0):
     """
     Test IncomeTaxIO calculate method with no output writing and no blowup.
     """
     taxyear = 2021
-    reform_dict = {
-        2016: {'_SS_Earnings_c': [300000]},
-        2018: {'_SS_Earnings_c': [500000]},
-        2020: {'_SS_Earnings_c': [700000]}
-    }
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
-                         reform=reform_dict,
+                         reform=reformfile0.name,
                          assump=None,
                          exact_calculations=False,
                          blowup_input_data=False,


### PR DESCRIPTION
This pull request changes the use of the Growth object by the IncomeTaxIO class to bring it into line with how TaxBrain uses the Growth object: to alter default blowup factors in **both** current-law policy and reform policy.  There are no changes in any test results because this feature of the IncomeTaxIO class had never been used.  This pull request also simplifies the IncomeTaxIO class constructor (so that a reform dictionary is no longer allowed) which required some non-substantive changes in a few of the unit tests.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @GoFroggyRun @zrisher @codykallen 
