### PR TITLE
Revise long_name and description for the two Growth class parameters

### DIFF
--- a/taxcalc/growth.json
+++ b/taxcalc/growth.json
@@ -1,7 +1,7 @@
 {
     "_factor_adjustment": {
         "long_name": "Deviation from CBO real GDP growth projection",
-        "description": "The data underlying this model are extrapolated to roughly match the CBO's projection of the economy's development over the 10-year federal budget window, with each type of economic data extrapolated at a different growth rate.  This parameter specifies a (decimal, not percentage) factor that is added to those growth rates for the construction of the economic baseline.  For example if you supply .02 (that is, 2 percent), then 0.02 will be added to the wage and salary growth rate, interest income growth rate, dividend growth rate, schedule E income growth rate, and all other growth rates used to extrapolate the underlying dataset.",
+        "description": "The data underlying this model are extrapolated to roughly match the CBO's projection of the economy's development over the 10-year federal budget window, with each type of economic data extrapolated at a different (decimal, not percentage) growth rate.  This parameter specifies a (decimal, not percentage) factor that is added to those growth rates for the construction of the economic baseline.  For example if you supply 0.02, then 0.02 will be added to the wage and salary growth rate, interest income growth rate, dividend growth rate, schedule E income growth rate, and all other growth rates used to extrapolate the underlying dataset.",
         "irs_ref": "",
         "start_year": 2013,
         "col_var": "",
@@ -13,7 +13,7 @@
 
     "_factor_target": {
         "long_name": "Replacement for CBO real GDP growth projection",
-        "description": "The data underlying this model are extrapolated to roughly match the CBO's projection of the economy's development over the 10-year federal budget window, with each type of economic data extrapolated at a different growth rate.  Annual real GDP growth rates are part of the CBO projection.  This parameter specifies an alternative real GDP growth rate (in decimal, not percentage, terms).  All other growth rates will be modified so that they change by the same amount as the specified change in the real per-capita GDP growth rate.  For more detail, read the growth.py source code file.",
+        "description": "The data underlying this model are extrapolated to roughly match the CBO's projection of the economy's development over the 10-year federal budget window, with each type of economic data extrapolated at a different (decimal, not percentage) growth rate.  Annual real GDP growth rates are part of the CBO projection.  This parameter specifies an alternative real GDP growth rate (in decimal, not percentage, terms).  All other growth rates will be modified so that they change by the same amount as the specified change in the real per-capita GDP growth rate.  For more detail, read the growth.py source code file.",
         "irs_ref": "",
         "start_year": 2013,
         "col_var": "",

--- a/taxcalc/growth.json
+++ b/taxcalc/growth.json
@@ -1,7 +1,7 @@
 {
     "_factor_adjustment": {
-        "long_name": "Deviation from CBO forecast of baseline economic growth (percentage point",
-        "description": "The data underlying this model are extrapolated to roughly match the CBO's projection of the economy's development over the 10-year federal budget window, with each type of economic data extrapolated at a different growth rate. This parameter allows a factor to be subtracted or added to those growth rates for the construction of the economic baseline. For example if you supply .02 (or 2%), then 0.02 will be added to the wage and salary growth rate, interest income growth rate, dividend growth rate, schedule E income growth rate, and all other growth rates used to extrapolate the underlying dataset.",
+        "long_name": "Deviation from CBO real GDP growth projection",
+        "description": "The data underlying this model are extrapolated to roughly match the CBO's projection of the economy's development over the 10-year federal budget window, with each type of economic data extrapolated at a different growth rate.  This parameter specifies a (decimal, not percentage) factor that is added to those growth rates for the construction of the economic baseline.  For example if you supply .02 (that is, 2 percent), then 0.02 will be added to the wage and salary growth rate, interest income growth rate, dividend growth rate, schedule E income growth rate, and all other growth rates used to extrapolate the underlying dataset.",
         "irs_ref": "",
         "start_year": 2013,
         "col_var": "",
@@ -12,8 +12,8 @@
     },
 
     "_factor_target": {
-        "long_name": "Replacement for CBO real GDP growth in economic baseline (percent)",
-        "description": "The data underlying this model are extrapolated to roughly match the CBO's projection of the economy's development over the 10-year federal budget window, with each type of economic data extrapolated at a different growth rate. One of the growth rates taken from the CBO is GDP growth. This parameter allows you to specify a real GDP growth rate, and all other rates will be modified to maintain the distance between them and GDP growth in the CBO baseline. For example, if the CBO growth rate for one year is 0.02 and the user enters 0.018 for this parameter, then 0.002 will be subtracted from every growth rate in the construction of the economic baseline, including wage and salary growth, interest income growth, dividend growth, and many others.",
+        "long_name": "Replacement for CBO real GDP growth projection",
+        "description": "The data underlying this model are extrapolated to roughly match the CBO's projection of the economy's development over the 10-year federal budget window, with each type of economic data extrapolated at a different growth rate.  Annual real GDP growth rates are part of the CBO projection.  This parameter specifies an alternative real GDP growth rate (in decimal, not percentage, terms).  All other growth rates will be modified so that they change by the same amount as the specified change in the real per-capita GDP growth rate.  For more detail, read the growth.py source code file.",
         "irs_ref": "",
         "start_year": 2013,
         "col_var": "",

--- a/taxcalc/tests/test_growth.py
+++ b/taxcalc/tests/test_growth.py
@@ -28,16 +28,16 @@ def test_update_growth(puf_1991, weights_1991):
         grow.update_growth({2013: {'bad_name': [0.02]}})
     with pytest.raises(ValueError):
         grow.update_growth({2013: {'bad_name_cpi': True}})
-    bad_params = {2015: {'_factor_adjustment': [0.01],
-                         '_factor_target': [0.08]}}
+    double_factor_change = {2015: {'_factor_adjustment': [0.01],
+                                    '_factor_target': [0.08]}}
     with pytest.raises(ValueError):
-        grow.update_growth(bad_params)
+        grow.update_growth(double_factor_change)
     # try correct updates
     grow_x = Growth()
     factor_x = {2015: {'_factor_target': [0.04]}}
     grow_x.update_growth(factor_x)
     grow_y = Growth()
-    factor_y = {2015: {'_factor_adjustment': [0.01]}}
+    factor_y = {2017: {'_factor_adjustment': [0.01]}}
     grow_y.update_growth(factor_y)
     # create two Calculators
     recs_x = Records(data=puf_1991, weights=weights_1991, start_year=2009)
@@ -53,7 +53,7 @@ def test_update_growth(puf_1991, weights_1991):
     assert_array_equal(calc_y.growth.factor_adjustment,
                        grow_y.factor_adjustment)
     assert_array_equal(calc_y.growth._factor_adjustment,
-                       np.array([0.0, 0.0, 0.01, 0.01, 0.01, 0.01,
+                       np.array([0.0, 0.0, 0.0, 0.0, 0.01, 0.01,
                                  0.01, 0.01, 0.01, 0.01, 0.01, 0.01,
                                  0.01, 0.01]))
 

--- a/taxcalc/tests/test_growth.py
+++ b/taxcalc/tests/test_growth.py
@@ -29,7 +29,7 @@ def test_update_growth(puf_1991, weights_1991):
     with pytest.raises(ValueError):
         grow.update_growth({2013: {'bad_name_cpi': True}})
     double_factor_change = {2015: {'_factor_adjustment': [0.01],
-                                    '_factor_target': [0.08]}}
+                                   '_factor_target': [0.08]}}
     with pytest.raises(ValueError):
         grow.update_growth(double_factor_change)
     # try correct updates


### PR DESCRIPTION
This pull request resolves the documentation part of issue #1159.  The #1159 discussion about the values of `Growth.REAL_GDP_GROWTH_RATES` is not addressed in this pull request.

@MattHJensen @Amy-Xu @andersonfrailey @codykallen 