### PR TITLE
Fix Jupyter Notebook warning in behavior.py file

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -186,7 +186,7 @@ class Behavior(ParametersBase):
         neg = 'negative'
         for elast in self._vals:
             values = getattr(self, elast)
-            for year in values:
+            for year in np.ndindex(values.shape):
                 val = values[year]
                 if elast == '_BE_inc':
                     if val > 0.0:

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -110,7 +110,7 @@ def test_run_dropq_nth_year(is_strict, rjson, growth_params,
     if growth_params:
         myvars['_factor_adjustment'] = [0.01]
     if behavior_params:
-        myvars['_BE_inc'] = [0.8]
+        myvars['_BE_inc'] = [-0.8]
     if is_strict:
         myvars['unknown_param'] = [0.01]
     first = 2016


### PR DESCRIPTION
Looking at a [notebook](http://nbviewer.jupyter.org/github/andersonfrailey/Notebook-Uploads/blob/master/Itemized%20Deduction%20Distribution.ipynb) created by @andersonfrailey revealed a warning in the following code:
```
recs = Records()
pol = Policy()
calc = Calculator(records=recs, policy=pol)
calc.advance_to_year(2014)
calc.calc_all()
taxcalc/behavior.py:190: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  val = values[year]
You loaded data for 2009.
Your data have been extrapolated to 2013.
```
This pull request is an attempt to fix this warning.  The one-line change in the Behavior class revealed that the error checking had not been working as intended, and therefore, the error checking was not detecting an illegal behavior specification in the dropq tests.  After the fix, the dropq test failed.  So, the second part of this pull request corrects the behavior specification in the dropq test.

There are no changes in unit test results, validation test results, or in the results of the reform comparisons.

**For those of you who use Notebooks, please do report any warnings that appear.**

@MattHJensen @Amy-Xu @andersonfrailey @GoFroggyRun @codykallen 
