### PR TITLE
Add new test comparing hard-coded and implied rates

### DIFF
--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -121,7 +121,6 @@ def test_for_duplicate_names():
         assert varname in Records.USABLE_READ_VARS
 
 
-@pytest.mark.one
 def test_hard_coded_rates_vs_blowup_factor_implied_rates(puf_1991):
     """
     Check that default real GDP growth rates, default wage growth rates, and
@@ -215,7 +214,6 @@ def test_hard_coded_rates_vs_blowup_factor_implied_rates(puf_1991):
     # --TEMP--                   Growth.REAL_GDP_GROWTH_RATES)
 
 
-@pytest.mark.one
 def test_default_rates_and_those_implied_by_blowup_factors(puf_1991):
     """
     Check that default GDP growth rates, default wage growth rates, and

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -121,6 +121,101 @@ def test_for_duplicate_names():
         assert varname in Records.USABLE_READ_VARS
 
 
+@pytest.mark.one
+def test_hard_coded_rates_vs_blowup_factor_implied_rates(puf_1991):
+    """
+    Check that default real GDP growth rates, default wage growth rates, and
+    default price inflation rates, are consistent with the rates implied by
+    the default blowup factors (BF) in the Records class.
+    """
+    rec = Records(data=puf_1991)
+    # Note Records._read_blowup makes a population-growth adjustment for
+    #                             the wagebill-blowup-factor and for the
+    #                             the nominal-GDP-blowup-factor, and then
+    #                           applies Pandas DataFrame 1+pct_change() to all
+    policy = Policy()
+    # Note policy object contains hard-coded default price inflation rates and
+    #                             hard-coded default wage growth rates
+    # Note Growth.REAL_GDP_GROWTH_RATES list contains those hard-coded values
+    syr = Policy.JSON_START_YEAR
+    nyrs = Policy.LAST_BUDGET_YEAR - syr + 1
+    numyrs = Policy.LAST_BUDGET_YEAR - Records.PUF_YEAR + 1
+
+    # price inflation rates
+    implied_pir = np.zeros(nyrs)
+    for idx in range(0, nyrs):
+        year = syr + idx
+        implied_pir[idx] = rec.BF.ACPIU[year] - 1.0
+    assert_array_equal(np.round(implied_pir, 4),
+                       policy._inflation_rates)
+
+    # nominal wage growth rates (i.e., growth rates in the average wage rate)
+    implied_wgr = np.zeros(nyrs)
+    for idx in range(0, nyrs):
+        year = syr + idx
+        implied_wgr[idx] = rec.BF.AWAGE[year] - 1.0
+    DIRECT_WGR_COMPARE = True
+    if DIRECT_WGR_COMPARE:
+        direct_wgr = np.zeros(nyrs)
+        s1filename = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                  '..', 'StageIFactors.csv')
+        s1df = pd.read_csv(s1filename)
+        pc_wage = np.zeros(numyrs)  # per-capita wagebill (i.e., average wage)
+        for indx in range(0, numyrs):
+            pc_wage[indx] = s1df['AWAGE'][indx] / s1df['APOPN'][indx]
+            year = Records.PUF_YEAR + indx
+            if year >= Policy.JSON_START_YEAR:
+                idx = year - Policy.JSON_START_YEAR
+                direct_wgr[idx] = pc_wage[indx] / pc_wage[indx - 1] - 1.0
+        assert_array_equal(np.round(implied_wgr, 4), np.round(direct_wgr, 4))
+    # --TEMP--assert_array_equal(np.round(implied_wgr, 4),
+    # --TEMP--                   policy._wage_growth_rates)
+
+    # real GDP growth rates
+    # .. convert pct_changes to indexes
+    gdp_index = np.zeros(numyrs)
+    gdp_index[0] = 1.0
+    pop_index = np.zeros(numyrs)
+    pop_index[0] = 1.0
+    cpi_index = np.zeros(numyrs)
+    cpi_index[0] = 1.0
+    for indx in range(1, numyrs):
+        year = Records.PUF_YEAR + indx
+        gdp_index[indx] = rec.BF.AGDPN[year] * gdp_index[indx - 1]
+        pop_index[indx] = rec.BF.APOPN[year] * pop_index[indx - 1]
+        cpi_index[indx] = rec.BF.ACPIU[year] * cpi_index[indx - 1]
+    # .. convert per-capita gdp index to aggregate gdp index
+    for indx in range(0, numyrs):
+        gdp_index[indx] *= pop_index[indx]
+    # .. convert nominal aggregate gdp index to real aggregate gdp index
+    for indx in range(0, numyrs):
+        gdp_index[indx] /= cpi_index[indx]
+    # .. convert real aggregate gdp index to real gdp growth rate
+    implied_rgr = np.zeros(nyrs)
+    for indx in range(0, numyrs):
+        year = Records.PUF_YEAR + indx
+        if year >= Policy.JSON_START_YEAR:
+            idx = year - Policy.JSON_START_YEAR
+            implied_rgr[idx] = gdp_index[indx] / gdp_index[indx - 1] - 1.0
+    DIRECT_RGR_COMPARE = True
+    if DIRECT_RGR_COMPARE:
+        direct_rgr = np.zeros(nyrs)
+        s1filename = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                  '..', 'StageIFactors.csv')
+        s1df = pd.read_csv(s1filename)
+        real_gdp = np.zeros(numyrs)
+        for indx in range(0, numyrs):
+            real_gdp[indx] = s1df['AGDPN'][indx] / s1df['ACPIU'][indx]
+            year = Records.PUF_YEAR + indx
+            if year >= Policy.JSON_START_YEAR:
+                idx = year - Policy.JSON_START_YEAR
+                direct_rgr[idx] = real_gdp[indx] / real_gdp[indx - 1] - 1.0
+        assert_array_equal(np.round(implied_rgr, 4), np.round(direct_rgr, 4))
+    # --TEMP--assert_array_equal(np.round(implied_rgr, 4),
+    # --TEMP--                   Growth.REAL_GDP_GROWTH_RATES)
+
+
+@pytest.mark.one
 def test_default_rates_and_those_implied_by_blowup_factors(puf_1991):
     """
     Check that default GDP growth rates, default wage growth rates, and


### PR DESCRIPTION
**Background**

@martinholmer raised issue #1159 about misleading documentation of the two Growth class parameters.  @codykallen agreed (and #1160 fixed the documentation in `growth.json`), but asked why the values in the `Growth.REAL_GDP_GROWTH_RATES` list did not correspond to any recent CBO assumptions.  @andersonfrailey said those list values were derived from a formula.  When @martinholmer pointed out that the formula was not correct, @andersonfrailey agreed and said that `test_default_rates_and_those_implied_by_blowup_factors` should be reviewed because the formula was from there.  And finally, @martinholmer found in the git history that the initial version of this test was introduced in #424, and that the values in the list (which was then called `Growth.REAL_GDP_GROWTH`) were specified to pass the test.

**Pull Request**

This pull request creates a new test that compares three sets of hard-coded rates with the rates implied by the information in the `StageIfactors.csv` file, the contents of which are read and transformed by the `Records._read_blowup` method called by the Records class constructor.  Using the information in the `BF` DataFrame to construct the implied rates is complicated, so the new test derives the implied rates in two different ways: (1) starting with the `BF` information in the Records object (as done in the old test), and (2) starting from the information in the `StageIfactors.csv` file. Deriving the implied rates in two ways and testing that the two sets of implied rates are exactly the same, raises confidence in the logic used to compute the implied rates. 

This new test shows that the implied rates in the old test were not exactly correct for two of the three hard-coded rates.  The implied price inflation rates in the new and old test were exactly the same and also exactly the same as those hard-coded in `Policy.__pirates`. But there are differences between the new and old implied rates for the hard-coded `Growth.REAL_GDP_GROWTH_RATES` and for the hard-coded `Policy.__wgrates`.

This pull request does nothing but introduce the new test, but the final comparison between the hard-coded and implied rates has been commented out in two of the three cases.  Uncommenting these final comparisons will require changing the hard-coded rates and dropping the old test.  If no concerns with this pull request arise, those changes will be accomplished in subsequent pull requests: one that changes the hard-coded `Growth.REAL_GDP_GROWTH_RATES` and another that changes the hard-coded `Policy.__wgrates`.

It would be prudent to review this pull request quickly so that we can proceed to the subsequent pull requests.  Unless somebody can point out a problem with the new test (and there may be one or more problems because the logic of deriving the implied rates is fairly complicated), I plan to merge it into the master branch on Tuesday, January 31st.


