### PR TITLE
add mock as a requirement of Tax-Calc conda recipe and environment.yml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -7,6 +7,7 @@ requirements:
     - pytest
     - setuptools
     - python
+    - mock
     - numpy ==1.10.4
     - pandas <=0.18.0
     - numba
@@ -16,6 +17,7 @@ requirements:
     - pytest
     - setuptools
     - python
+    - mock
     - numpy ==1.10.4
     - pandas <=0.18.0
     - numba

--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,6 @@ dependencies:
 - mock
 - pep8
 - pylint
+- mock
 - pip:
   - pytest-pep8

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
 - six
 - ipython
 - ipython-notebook
-- mock
 - pep8
 - pylint
 - mock


### PR DESCRIPTION
Fixes #1173 (`ImportError` related to `mock` on Windows).  I have encountered that `mock` import error on other projects.  I'm not sure why Windows differs from other OS's in terms of mock being there or not, but this PR will ensure it is always installed when doing `conda install -c ospc taxcalc` or `conda env create` from the source directory.

In the meantime (before the next Tax-Calculator conda packages are built) if you encounter an `ImportError` regarding `mock`, then do the following to install `mock`:

`conda install mock`