### PR TITLE
Simplify inctax.py command-line options

### DIFF
--- a/inctax.py
+++ b/inctax.py
@@ -18,33 +18,33 @@ def main():
     # parse command-line arguments:
     parser = argparse.ArgumentParser(
         prog='python inctax.py',
-        description=('Writes to a file the federal income tax OUTPUT for the '
-                     'tax filing units specified in the INPUT file with the '
-                     'OUTPUT computed from the INPUT for the TAXYEAR using '
-                     'the Tax-Calculator. '
+        description=('Writes to a file the federal income and payroll tax '
+                     'OUTPUT for each filing unit specified in the INPUT '
+                     'file, with the OUTPUT computed from the INPUT for '
+                     'the TAXYEAR using the Tax-Calculator. '
                      'The INPUT file is a CSV-formatted file that contains '
                      'variable names that include the Records.MUST_READ_VARS '
                      'set plus other variables.  The OUTPUT file is in '
-                     'Internet-TAXSIM format.  The OUTPUT filename is the '
-                     'INPUT filename (excluding the .csv suffix or '
-                     '.gz suffix, or both) followed by '
-                     'a string equal to "-YY" (where the YY is the last two '
-                     'digits in the TAXYEAR) and all that is followed by a '
-                     'trailing string.  The trailing string is ".out-inctax" '
-                     'if no --reform option is specified; otherwise the '
-                     'trailing string is ".out-inctax-REFORM" (excluding any '
-                     '".json" ending to the REFORM filename) if no --assump '
-                     'option is specified or ".out-inctax-REFORM-ASSUMP" '
-                     '(excluding any .json ending to the ASSUMP filename) '
-                     'if an --assump option is specified.  The OUTPUT '
-                     'file contains the first 28 Internet-TAXSIM output '
+                     'Internet-TAXSIM format.  The OUTPUT file name is the '
+                     'INPUT file name (excluding directory path prefix and '
+                     '.csv suffix) followed by a string equal to "-YY" '
+                     '(where the YY is the last two digits in the TAXYEAR) '
+                     'and all that is followed by a trailing string.  The '
+                     'trailing string is ".out-inctax" if no --reform '
+                     'option is specified; otherwise the trailing string is '
+                     '".out-inctax-REFORM" (excluding any ".json" ending to '
+                     'the REFORM file name) if no --assump option is '
+                     'specified or ".out-inctax-REFORM-ASSUMP" (excluding '
+                     'any .json ending to the ASSUMP file name) if an '
+                     '--assump option is specified.  The OUTPUT file '
+                     'contains the first 28 Internet-TAXSIM output '
                      'variables.  Use --iohelp flag for more information. '
                      'For details on the Internet-TAXSIM version 9.3 '
                      'OUTPUT format, go to '
-                     'http://users.nber.org/~taxsim/taxsim-calc9/'))
+                     '<http://users.nber.org/~taxsim/taxsim-calc9/>.'))
     parser.add_argument('--iohelp',
                         help=('optional flag to show INPUT and OUTPUT '
-                              'variable definitions and exit'),
+                              'variable definitions and exit.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--reform',
@@ -56,16 +56,32 @@ def main():
                         default=None)
     parser.add_argument('--assump',
                         help=('ASSUMP is name of optional file that contains '
-                              'economic assumption parameters ("behavior", '
-                              '"consumption" and "growth" parameters); the '
-                              'ASSUMP file is specified using JSON that may '
-                              'include //-comments. No --assump implies use '
+                              'economic assumption parameters ("consumption" '
+                              'and "behavior" and "growdiff_baseline" and '
+                              '"growdiff_response"); the ASSUMP file is '
+                              'specified using JSON that may include '
+                              '//-comments. No --assump implies use '
                               'of static analysis assumptions.  Note that '
                               'use of the --assump option requires use of '
                               'the --reform option (although the specified '
                               'reform could be empty, meaning it could be '
                               'current-law policy).'),
                         default=None)
+    parser.add_argument('--aging',
+                        help=('optional flag that triggers three things: '
+                              'the default extrapolation (or blowup) logic, '
+                              'the default income ajustment logic, and the '
+                              'default reweighting logic that will age the '
+                              'INPUT data from Records.PUF_YEAR to '
+                              'TAXYEAR.  The --aging flag also adds the '
+                              'sampling weight for each unit as OUTPUT '
+                              'variable 29.  It makes sense to use this flag '
+                              'only if the restricted "puf.csv" file is used '
+                              'as INPUT.  No --aging flag implies INPUT data '
+                              'are considered raw data that are not aged in '
+                              'any way.'),
+                        default=False,
+                        action="store_true")
     parser.add_argument('--exact',
                         help=('optional flag to suppress smoothing in income '
                               'tax calculations that eliminate marginal-tax-'
@@ -75,39 +91,15 @@ def main():
                               'law.'),
                         default=False,
                         action="store_true")
-    parser.add_argument('--blowup',
-                        help=('optional flag that triggers the default '
-                              'blowup (or aging) logic built '
-                              'into the Tax-Calculator that will age the '
-                              'INPUT data from Records.PUF_YEAR to TAXYEAR. '
-                              'No --blowup option implies INPUT data are '
-                              'considered raw data that are not aged or '
-                              'adjusted in any way.'),
-                        default=False,
-                        action="store_true")
-    parser.add_argument('--adjust',
-                        help=('optional flag that triggers the default '
-                              'adjustment logic built into the Tax-Calculator '
-                              'that will adjust the distribution of income.'),
-                        default=False,
-                        action="store_true")
-
-    parser.add_argument('--weights',
-                        help=('optional flag that causes OUTPUT to have an '
-                              'additional variable [29] containing the s006 '
-                              'sample weight, which will be aged if the '
-                              '--blowup option is used'),
-                        default=False,
-                        action="store_true")
     parser.add_argument('--fullcomp',
                         help=('optional flag that causes OUTPUT to have '
                               'marginal tax rates (MTRs) calculated with '
                               'respect to full compensation (but any '
                               'behavioral-response calculations always use '
                               'MTRs that are calculated with respect to full '
-                              'compensation).  No --fullcomp option implies '
+                              'compensation).  No --fullcomp flag implies '
                               'MTRs reported in OUTPUT are not calculated '
-                              'with respect to full compensation'),
+                              'with respect to full compensation.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--ceeu',
@@ -116,35 +108,37 @@ def main():
                               'expected-utility of after-tax income values '
                               'for different constant-relative-risk-aversion '
                               'parameter values, to be written to stdout.  '
-                              'No --ceeu option implies nothing is written '
-                              'to stdout.  Note that --reform  option must '
+                              'No --ceeu flag implies nothing is written '
+                              'to stdout.  Note that --reform option must '
                               'be specified and aggregate combined taxes '
                               'under that reform must be same as under '
-                              'current-law policy for this option to work'),
+                              'current-law policy for this option to work.'),
                         default=False,
                         action="store_true")
     output = parser.add_mutually_exclusive_group(required=False)
     output.add_argument('--records',
-                        help=('optional flag that causes the output file to '
+                        help=('optional flag that causes the OUTPUT file to '
                               'be a CSV-formatted file containing for each '
                               'INPUT filing unit the TAXYEAR values of each '
                               'variable in the Records.USABLE_READ_VARS set. '
                               'If the --records option is specified, the '
-                              'output file name will be the same as if the '
+                              'OUTPUT file name will be the same as if the '
                               'option was not specified, except that the '
-                              '".out-inctax" part is replaced by ".records"'),
+                              '".out-inctax" part is replaced by '
+                              '".records".'),
                         default=False,
                         action="store_true")
     output.add_argument('--csvdump',
-                        help=('optional flag that causes the output file to '
+                        help=('optional flag that causes the OUTPUT file to '
                               'be a CSV-formatted file containing for each '
                               'INPUT filing unit the TAXYEAR values of each '
                               'variable in the Records.USABLE_READ_VARS set '
                               'and in the Records.CALCULATED_VARS set. '
                               'If the --csvdump option is specified, the '
-                              'output file name will be the same as if the '
+                              'OUTPUT file name will be the same as if the '
                               'option was not specified, except that the '
-                              '".out-inctax" part is replaced by ".csvdump"'),
+                              '".out-inctax" part is replaced by '
+                              '".csvdump".'),
                         default=False,
                         action="store_true")
     parser.add_argument('INPUT', nargs='?', default='',
@@ -161,7 +155,7 @@ def main():
     if args.iohelp:
         IncomeTaxIO.show_iovar_definitions()
         return 0
-    # check INPUT filename
+    # check INPUT file name
     if args.INPUT == '':
         sys.stderr.write('ERROR: must specify INPUT file name;\n')
         sys.stderr.write('USAGE: python inctax.py --help\n')
@@ -173,18 +167,16 @@ def main():
         return 1
     # check consistency of REFORM and ASSUMP options
     if args.assump and not args.reform:
-        sys.stderr.write('ERROR: cannot specify ASSUMP without a REFORM\n')
+        sys.stderr.write('ERROR: cannot specify ASSUMP without REFORM\n')
         sys.stderr.write('USAGE: python inctax.py --help\n')
         return 1
-    # instantiate IncometaxIO object and do federal income tax calculations
+    # instantiate IncometaxIO object and do federal inc/pay tax calculations
     inctax = IncomeTaxIO(input_data=args.INPUT,
                          tax_year=args.TAXYEAR,
                          reform=args.reform,
                          assump=args.assump,
+                         aging_input_data=args.aging,
                          exact_calculations=args.exact,
-                         blowup_input_data=args.blowup,
-                         adjust_input_data=args.adjust,
-                         output_weights=args.weights,
                          output_records=args.records,
                          csv_dump=args.csvdump)
     if args.records:
@@ -192,14 +184,14 @@ def main():
     elif args.csvdump:
         inctax.calculate(writing_output_file=False,
                          exact_output=args.exact,
-                         output_weights=args.weights,
+                         output_weights=args.aging,
                          output_mtr_wrt_fullcomp=args.fullcomp,
                          output_ceeu=args.ceeu)
         inctax.csv_dump(writing_output_file=True)
     else:
         inctax.calculate(writing_output_file=True,
                          exact_output=args.exact,
-                         output_weights=args.weights,
+                         output_weights=args.aging,
                          output_mtr_wrt_fullcomp=args.fullcomp,
                          output_ceeu=args.ceeu)
     # return no-error exit code

--- a/taxcalc/incometaxio.py
+++ b/taxcalc/incometaxio.py
@@ -51,15 +51,12 @@ class IncomeTaxIO(object):
         a static analysis of reform is conducted, or
         string is name of optional ASSUMP file.
 
+    aging_input_data: boolean
+        whether or not to age record data from data year to tax_year.
+
     exact_calculations: boolean
         specifies whether or not exact tax calculations are done without
         any smoothing of "stair-step" provisions in income tax law.
-
-    blowup_input_data: boolean
-        whether or not to age record data from data year to tax_year.
-
-    output_weights: boolean
-        whether or will be including sample weights in output.
 
     output_records: boolean
         whether or not to write CSV-formatted file containing the values
@@ -86,8 +83,7 @@ class IncomeTaxIO(object):
     """
 
     def __init__(self, input_data, tax_year, reform, assump,
-                 exact_calculations,
-                 blowup_input_data, adjust_input_data, output_weights,
+                 aging_input_data, exact_calculations,
                  output_records, csv_dump):
         """
         IncomeTaxIO class constructor.
@@ -98,9 +94,11 @@ class IncomeTaxIO(object):
         # pylint: disable=too-many-locals
         if isinstance(input_data, six.string_types):
             self._using_input_file = True
-            # check that input_data string ends with ".csv"
-            if input_data.endswith('.csv'):
-                inp = '{}-{}'.format(input_data[:-4], str(tax_year)[2:])
+            # remove any leading directory path from INPUT filename
+            fname = os.path.basename(input_data)
+            # check if fname ends with ".csv"
+            if fname.endswith('.csv'):
+                inp = '{}-{}'.format(fname[:-4], str(tax_year)[2:])
             else:
                 msg = 'INPUT file named {} does not end in .csv'
                 raise ValueError(msg.format(input_data))
@@ -111,27 +109,33 @@ class IncomeTaxIO(object):
             msg = 'INPUT is neither string nor Pandas DataFrame'
             raise ValueError(msg)
         # construct output_filename and delete old output file if it exists
-        if assump is None:
-            asm = ''
-        elif isinstance(assump, six.string_types):
-            if assump.endswith('.json'):
-                asm = '-{}'.format(assump[:-5])
-            else:
-                asm = '-{}'.format(assump)
-        else:
-            msg = 'IncomeTaxIO.ctor assump is neither None nor str'
-            raise ValueError(msg)
         if reform is None:
             self._reform = False
             ref = ''
         elif isinstance(reform, six.string_types):
             self._reform = True
-            if reform.endswith('.json'):
-                ref = '-{}'.format(reform[:-5])
+            # remove any leading directory path from REFORM filename
+            fname = os.path.basename(reform)
+            # check if fname ends with ".json"
+            if fname.endswith('.json'):
+                ref = '-{}'.format(fname[:-5])
             else:
-                ref = '-{}'.format(reform)
+                ref = '-{}'.format(fname)
         else:
             msg = 'IncomeTaxIO.ctor reform is neither None nor str'
+            raise ValueError(msg)
+        if assump is None:
+            asm = ''
+        elif isinstance(assump, six.string_types):
+            # remove any leading directory path from ASSUMP filename
+            fname = os.path.basename(assump)
+            # check if fname ends with ".json"
+            if fname.endswith('.json'):
+                asm = '-{}'.format(fname[:-5])
+            else:
+                asm = '-{}'.format(fname)
+        else:
+            msg = 'IncomeTaxIO.ctor assump is neither None nor str'
             raise ValueError(msg)
         if output_records:
             self._output_filename = '{}.records{}{}'.format(inp, ref, asm)
@@ -162,52 +166,16 @@ class IncomeTaxIO(object):
         # set tax policy parameters to specified tax_year
         pol.set_year(tax_year)
         # read input file contents into Records object
-        if blowup_input_data:
-            if output_weights:
-                if adjust_input_data:
-                    recs = Records(data=input_data,
-                                   exact_calculations=exact_calculations)
-                else:
-                    recs = Records(data=input_data,
-                                   exact_calculations=exact_calculations,
-                                   adjust_ratios=None)
-            else:
-                if adjust_input_data:
-                    recs = Records(data=input_data,
-                                   exact_calculations=exact_calculations,
-                                   weights=None)
-                else:
-                    recs = Records(data=input_data,
-                                   exact_calculations=exact_calculations,
-                                   adjust_ratios=None,
-                                   weights=None)
-        else:
-            if output_weights:
-                if adjust_input_data:
-                    recs = Records(data=input_data,
-                                   exact_calculations=exact_calculations,
-                                   blowup_factors=None,
-                                   start_year=tax_year)
-                else:
-                    recs = Records(data=input_data,
-                                   exact_calculations=exact_calculations,
-                                   blowup_factors=None,
-                                   adjust_ratios=None,
-                                   start_year=tax_year)
-            else:
-                if adjust_input_data:
-                    recs = Records(data=input_data,
-                                   exact_calculations=exact_calculations,
-                                   blowup_factors=None,
-                                   weights=None,
-                                   start_year=tax_year)
-                else:
-                    recs = Records(data=input_data,
-                                   exact_calculations=exact_calculations,
-                                   blowup_factors=None,
-                                   adjust_ratios=None,
-                                   weights=None,
-                                   start_year=tax_year)
+        if aging_input_data:
+            recs = Records(data=input_data,
+                           exact_calculations=exact_calculations)
+        else:  # input_data are raw data
+            recs = Records(data=input_data,
+                           exact_calculations=exact_calculations,
+                           blowup_factors=None,
+                           adjust_ratios=None,
+                           weights=None,
+                           start_year=tax_year)
         # create Calculator object
         con = Consumption()
         con.update_consumption(con_d)
@@ -221,7 +189,7 @@ class IncomeTaxIO(object):
                                         verbose=False,
                                         consumption=con,
                                         growth=gro,
-                                        sync_years=blowup_input_data)
+                                        sync_years=aging_input_data)
             beh = Behavior()
             beh.update_behavior(beh_d)
             self._calc = Calculator(policy=pol, records=recs,
@@ -229,13 +197,13 @@ class IncomeTaxIO(object):
                                     behavior=beh,
                                     consumption=con,
                                     growth=gro,
-                                    sync_years=blowup_input_data)
+                                    sync_years=aging_input_data)
         else:
             self._calc = Calculator(policy=pol, records=recs,
                                     verbose=True,
                                     consumption=con,
                                     growth=gro,
-                                    sync_years=blowup_input_data)
+                                    sync_years=aging_input_data)
 
     def tax_year(self):
         """

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -224,10 +224,8 @@ def test_1(reformfile1):
                          tax_year=2015,
                          reform=reformfile1.name,
                          assump=None,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=False,
                          output_records=False,
                          csv_dump=False)
     output = inctax.calculate()
@@ -287,10 +285,8 @@ def test_2(reformfile2):
                          tax_year=2015,
                          reform=reformfile2.name,
                          assump=None,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=False,
                          output_records=False,
                          csv_dump=False)
     output = inctax.calculate()

--- a/taxcalc/tests/test_incometaxio.py
+++ b/taxcalc/tests/test_incometaxio.py
@@ -52,7 +52,7 @@ def rawinputfile():
         except OSError:
             pass  # sometimes we can't remove a generated temporary file
 
-
+@pytest.mark.one
 @pytest.mark.parametrize("input_data, exact", [
     ('no-dot-csv-filename', True),
     (list(), False),
@@ -68,10 +68,8 @@ def test_incorrect_creation_1(input_data, exact):
             tax_year=2013,
             reform=None,
             assump=None,
+            aging_input_data=False,
             exact_calculations=exact,
-            blowup_input_data=True,
-            adjust_input_data=False,
-            output_weights=False,
             output_records=False,
             csv_dump=False
         )
@@ -79,7 +77,7 @@ def test_incorrect_creation_1(input_data, exact):
 
 # for fixture args, pylint: disable=redefined-outer-name
 
-
+@pytest.mark.one
 @pytest.mark.parametrize("year, reform, assump", [
     (2013, list(), None),
     (2013, None, list()),
@@ -96,29 +94,16 @@ def test_incorrect_creation_2(rawinputfile, year, reform, assump):
             tax_year=year,
             reform=reform,
             assump=assump,
+            aging_input_data=False,
             exact_calculations=False,
-            blowup_input_data=True,
-            adjust_input_data=False,
-            output_weights=False,
             output_records=False,
             csv_dump=False
         )
 
-
-@pytest.mark.parametrize("blowup, weights_out, adjust", [
-    (True, False, True),
-    (True, True, True),
-    (False, True, True),
-    (True, True, False),
-    (True, False, False),
-    (False, True, False),
-    (False, False, True),
-    (False, False, False)
-])
-def test_creation_with_blowup(rawinputfile, blowup,
-                              weights_out, adjust):
+@pytest.mark.one
+def test_creation_with_aging(rawinputfile):
     """
-    Test IncomeTaxIO instantiation with no policy reform and with blowup.
+    Test IncomeTaxIO instantiation with no policy reform and with aging.
     """
     IncomeTaxIO.show_iovar_definitions()
     taxyear = 2021
@@ -126,10 +111,8 @@ def test_creation_with_blowup(rawinputfile, blowup,
                          tax_year=taxyear,
                          reform=None,
                          assump=None,
+                         aging_input_data=True,
                          exact_calculations=False,
-                         blowup_input_data=blowup,
-                         adjust_input_data=adjust,
-                         output_weights=weights_out,
                          output_records=False,
                          csv_dump=False)
     assert inctax.tax_year() == taxyear
@@ -156,20 +139,18 @@ def reformfile0():
     yield rfile
     os.remove(rfile.name)
 
-
+@pytest.mark.one
 def test_2(rawinputfile, reformfile0):
     """
-    Test IncomeTaxIO calculate method with no output writing and no blowup.
+    Test IncomeTaxIO calculate method with no output writing and no aging.
     """
     taxyear = 2021
     inctax = IncomeTaxIO(input_data=rawinputfile.name,
                          tax_year=taxyear,
                          reform=reformfile0.name,
                          assump=None,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=False,
                          output_records=False,
                          csv_dump=False)
     output = inctax.calculate()
@@ -213,7 +194,7 @@ REFORM_CONTENTS = """
      "2020": true   // values in future years indexed with this year as base
     },
     "_LST": // Lump-Sum Tax
-    {"2013": [500]
+    {"2013": [400]  // was [500]
     }
   }
 }
@@ -306,10 +287,10 @@ def assumpfile2():
         except OSError:
             pass  # sometimes we can't remove a generated temporary file
 
-
+@pytest.mark.one
 def test_3(rawinputfile, reformfile1, assumpfile1):
     """
-    Test IncomeTaxIO calculate method with no output writing and no blowup,
+    Test IncomeTaxIO calculate method with no output writing and no aging,
     using file name for IncomeTaxIO constructor input_data.
     """
     taxyear = 2021
@@ -317,19 +298,17 @@ def test_3(rawinputfile, reformfile1, assumpfile1):
                          tax_year=taxyear,
                          reform=reformfile1.name,
                          assump=assumpfile1.name,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=False,
                          output_records=False,
                          csv_dump=False)
     output = inctax.calculate()
     assert output == EXPECTED_OUTPUT
 
-
+@pytest.mark.one
 def test_4(reformfile2, assumpfile2):
     """
-    Test IncomeTaxIO calculate method with no output writing and no blowup,
+    Test IncomeTaxIO calculate method with no output writing and no aging,
     using DataFrame for IncomeTaxIO constructor input_data.
     """
     input_stream = StringIO(RAWINPUTFILE_CONTENTS)
@@ -339,19 +318,17 @@ def test_4(reformfile2, assumpfile2):
                          tax_year=taxyear,
                          reform=reformfile2.name,
                          assump=assumpfile2.name,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=False,
                          output_records=False,
                          csv_dump=False)
     output = inctax.calculate()
     assert output == EXPECTED_OUTPUT
 
-
+@pytest.mark.one
 def test_5(rawinputfile):
     """
-    Test IncomeTaxIO calculate method with no output writing and no blowup and
+    Test IncomeTaxIO calculate method with no output writing and no aging and
     no reform, using the output_records option.
     """
     taxyear = 2021
@@ -359,19 +336,17 @@ def test_5(rawinputfile):
                          tax_year=taxyear,
                          reform=None,
                          assump=None,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=False,
                          output_records=True,
                          csv_dump=False)
     inctax.output_records(writing_output_file=False)
     assert inctax.tax_year() == taxyear
 
-
+@pytest.mark.one
 def test_6(rawinputfile):
     """
-    Test IncomeTaxIO calculate method with no output writing and no blowup and
+    Test IncomeTaxIO calculate method with no output writing and no aging and
     no reform, using the csv_dump option.
     """
     taxyear = 2021
@@ -379,16 +354,14 @@ def test_6(rawinputfile):
                          tax_year=taxyear,
                          reform=None,
                          assump=None,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=False,
                          output_records=False,
                          csv_dump=True)
     inctax.csv_dump(writing_output_file=False)
     assert inctax.tax_year() == taxyear
 
-
+@pytest.mark.one
 def test_7(rawinputfile, reformfile1):
     """
     Test IncomeTaxIO calculate method with no output writing using ceeu option.
@@ -398,16 +371,14 @@ def test_7(rawinputfile, reformfile1):
                          tax_year=taxyear,
                          reform=reformfile1.name,
                          assump=None,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=False,
                          output_records=False,
                          csv_dump=False)
     inctax.calculate(writing_output_file=False, output_ceeu=True)
     assert inctax.tax_year() == taxyear
 
-
+@pytest.mark.one
 def test_8(reformfile1):
     """
     Test IncomeTaxIO calculate method with no output writing using ceeu option.
@@ -420,10 +391,8 @@ def test_8(reformfile1):
                          tax_year=taxyear,
                          reform=reformfile1.name,
                          assump=None,
+                         aging_input_data=False,
                          exact_calculations=False,
-                         blowup_input_data=False,
-                         adjust_input_data=False,
-                         output_weights=True,
                          output_records=False,
                          csv_dump=False)
     output = inctax.calculate(writing_output_file=False, output_ceeu=True)


### PR DESCRIPTION
This pull request replaces three old flags (`--blowup` and `--adjust` and `--weights`) with a single new `--aging` flag.  It also allows the INPUT and REFORM and ASSUMP file names to have a directory path, which is removed when constructing the OUTPUT file name.  So, for example, if  the restricted `puf.csv` file is in the `~/tax-calculator/taxcalc/` directory and you want to analyze a REFORM described in the `~/tax-analysis/reform1.json` file, then you can do this:
```
$ cd ~/tax-analysis
$ python ~/tax-calculator/inctax.py ~/tax-calculator/taxcalc/puf.csv 2017 --reform reforn1.json --aging
$ ls puf-17*
puf-17.out-inctax-reform1
```
For more details enter `python inctax.py --help` at the OS command line.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @GoFroggyRun @codykallen @zrisher