### PR TITLE
Remove all logic and tests related to param_code capability

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -143,10 +143,7 @@ class Calculator(object):
         EI_PayrollTax(self.policy, self.records)
         DependentCare(self.policy, self.records)
         Adj(self.policy, self.records)
-        if self.policy.ALD_InvInc_ec_base_code_active:
-            ALD_InvInc_ec_base_code(self)
-        else:
-            ALD_InvInc_ec_base_nocode(self.policy, self.records)
+        ALD_InvInc_ec_base(self.policy, self.records)
         CapGains(self.policy, self.records)
         SSBenefits(self.policy, self.records)
         AGI(self.policy, self.records)
@@ -188,10 +185,7 @@ class Calculator(object):
         NonrefundableCredits(self.policy, self.records)
         AdditionalCTC(self.policy, self.records)
         C1040(self.policy, self.records)
-        if self.policy.CTC_new_code_active:
-            CTC_new_code(self)
-        else:
-            CTC_new_nocode(self.policy, self.records)
+        CTC_new(self.policy, self.records)
         IITAX(self.policy, self.records)
 
     def calc_all(self, zero_out_calc_vars=False):
@@ -440,15 +434,8 @@ class Calculator(object):
         The returned dictionary is suitable as the argument to
            the Policy implement_reform(rpol_dict) method.
         """
-        # define function used by re.sub to process parameter code
-        def repl_func(mat):
-            code = mat.group(2).replace('\r', '\\r').replace('\n', '\\n')
-            return '"' + code + '"'
         # strip out //-comments without changing line numbers
-        json_without_comments = re.sub('//.*', ' ', text_string)
-        # convert multi-line string between pairs of || into a simple string
-        json_str = re.sub('(\|\|)(.*?)(\|\|)',  # pylint: disable=W1401
-                          repl_func, json_without_comments, flags=re.DOTALL)
+        json_str = re.sub('//.*', ' ', text_string)
         # convert JSON text into a Python dictionary
         try:
             raw_dict = json.loads(json_str)
@@ -476,14 +463,6 @@ class Calculator(object):
             if rkey in Calculator.REQUIRED_ASSUMP_KEYS:
                 msg = 'key "{}" should be in economic assumption file'
                 raise ValueError(msg.format(rkey))
-        # handle special param_code key in raw_dict policy component dictionary
-        paramcode = raw_dict['policy'].pop('param_code', None)
-        if paramcode:
-            if Policy.PROHIBIT_PARAM_CODE:
-                msg = 'JSON reform file containing "param_code" is not allowed'
-                raise ValueError(msg)
-            for param, code in paramcode.items():
-                raw_dict['policy'][param] = {'0': code}
         # convert the policy dictionary in raw_dict
         rpol_dict = Calculator.convert_parameter_dict(raw_dict['policy'])
         return rpol_dict

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -185,37 +185,17 @@ def Adj(e03150, e03210, c03260,
 
 
 @iterate_jit(nopython=True)
-def ALD_InvInc_ec_base_nocode(p22250, p23250, _sep,
-                              e00300, e00600, e01100, e01200,
-                              invinc_ec_base):
+def ALD_InvInc_ec_base(p22250, p23250, _sep,
+                       e00300, e00600, e01100, e01200,
+                       invinc_ec_base):
     """
-    Compute invinc_ec_base without code
+    Compute invinc_ec_base
     """
     # limitation on net short-term and long-term capital losses
     cgain = max((-3000. / _sep), p22250 + p23250)
     # compute exclusion of investment income from AGI
     invinc_ec_base = e00300 + e00600 + cgain + e01100 + e01200
     return invinc_ec_base
-
-
-def ALD_InvInc_ec_base_code(calc):
-    """
-    Compute invinc_ec_base from code
-    """
-    code = calc.policy.param_code['ALD_InvInc_ec_base_code']
-    # pylint: disable=no-member
-    # (above pylint comment eliminates several bogus np warnings)
-    visible = {'min': np.minimum, 'max': np.maximum,
-               'where': np.where, 'equal': np.equal}
-    variables = ['e00300', 'e00600', 'e00650', 'e01100', 'e01200',
-                 'p22250', 'p23250', '_sep']
-    for var in variables:
-        visible[var] = getattr(calc.records, var)
-    visible['cpi'] = calc.policy.cpi_for_param_code('ALD_InvInc_ec_base_code')
-    visible['returned_value'] = calc.records.invinc_ec_base
-    # pylint: disable=exec-used
-    exec(compile(code, '<str>', 'exec'), {'__builtins__': {}}, visible)
-    calc.records.invinc_ec_base = visible['returned_value']
 
 
 @iterate_jit(nopython=True)
@@ -1244,11 +1224,11 @@ def C1040(c05800, c07180, c07200, c07220, c07230, c07240, c07260, c07300,
 
 
 @iterate_jit(nopython=True)
-def CTC_new_nocode(CTC_new_c, CTC_new_rt, CTC_new_c_under5_bonus,
-                   CTC_new_ps, CTC_new_prt,
-                   CTC_new_refund_limited, CTC_new_refund_limit_payroll_rt,
-                   n24, nu05, c00100, MARS, ptax_oasdi, c09200,
-                   ctc_new):
+def CTC_new(CTC_new_c, CTC_new_rt, CTC_new_c_under5_bonus,
+            CTC_new_ps, CTC_new_prt,
+            CTC_new_refund_limited, CTC_new_refund_limit_payroll_rt,
+            n24, nu05, c00100, MARS, ptax_oasdi, c09200,
+            ctc_new):
     """
     Compute new refundable child tax credit with numeric parameters
     """
@@ -1269,25 +1249,6 @@ def CTC_new_nocode(CTC_new_c, CTC_new_rt, CTC_new_c_under5_bonus,
     else:
         ctc_new = 0.
     return ctc_new
-
-
-def CTC_new_code(calc):
-    """
-    Compute new refundable child tax credit using parameter code
-    """
-    code = calc.policy.param_code['CTC_new_code']
-    # pylint: disable=no-member
-    # (above pylint comment eliminates several bogus np warnings)
-    visible = {'min': np.minimum, 'max': np.maximum,
-               'where': np.where, 'equal': np.equal}
-    variables = ['n24', 'c00100', 'nu05', 'MARS', 'ptax_oasdi', 'c09200']
-    for var in variables:
-        visible[var] = getattr(calc.records, var)
-    visible['cpi'] = calc.policy.cpi_for_param_code('CTC_new_code')
-    visible['returned_value'] = calc.records.ctc_new
-    # pylint: disable=exec-used
-    exec(compile(code, '<str>', 'exec'), {'__builtins__': {}}, visible)
-    calc.records.ctc_new = visible['returned_value']
 
 
 @iterate_jit(nopython=True)

--- a/taxcalc/taxbrain/a1.json
+++ b/taxcalc/taxbrain/a1.json
@@ -1,12 +1,12 @@
-// 2022 RESULTS from taxcalc-inctax (3/4/17) and taxbrain-upload version 0.7.7
-// INCOME TAX ($B)   1822.21                     1822.2
-// PAYROLL TAX ($B)  1464.16                     1464.2
+// 2022 RESULTS from taxcalc-inctax (3/7/17) and taxbrain-upload version 0.7.7
+// INCOME TAX ($B)   1797.12                     1797.3  <--- small difference
+// PAYROLL TAX ($B)  1464.21                     1464.1  <--- small difference
 // taxcalc-inctax results are generated as follows:
-//   python ../../inctax.py puf.csv 2022 --aging --reform r0.json --assump a1.json
+//   python ../../inctax.py puf.csv 2022 --reform r0.json --assump a1.json
 //   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-r0-a1
 //   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-r0-a1
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/10230/
+//   http://www.ospc.org/taxbrain/10295/
 {
     "consumption": {
         "_MPC_e18400": {"2018": [0.05]}

--- a/taxcalc/taxbrain/r0.json
+++ b/taxcalc/taxbrain/r0.json
@@ -1,12 +1,12 @@
-// 2022 RESULTS from taxcalc-inctax (3/4/17) and taxbrain-upload version 0.7.7
-// INCOME TAX ($B)   1842.92                     1842.9
+// 2022 RESULTS from taxcalc-inctax (3/7/17) and taxbrain-upload version 0.7.7
+// INCOME TAX ($B)   1817.32                     1817.5  <--- small difference
 // PAYROLL TAX ($B)  1474.76                     1474.8
 // taxcalc-inctax results generated as follows:
-//   python ../../inctax.py puf.csv 2022 --aging --reform r0.json
+//   python ../../inctax.py puf.csv 2022 --reform r0.json
 //   awk '{r+=$4*$29}END{print r*1e-9}' puf-22.out-inctax-r0
 //   awk '{r+=$6*$29}END{print r*1e-9}' puf-22.out-inctax-r0
 // taxbrain-upload results from:
-//   http://www.ospc.org/taxbrain/10227/
+//   http://www.ospc.org/taxbrain/10293/
 {
     "policy": {
         "_SS_Earnings_c": // social security (OASDI) maximum taxable earnings
@@ -23,16 +23,6 @@
         },
         "_ALD_InvInc_ec_rt": // investment income AGI exclusion rate
         {"2019": [0.20]
-        },
-        // investment income AGI exclusion base is not all investment income
-        // but rather the sum of taxable interest, qualified dividends, and
-        // long-term capital gains
-        "_ALD_InvInc_ec_base_code_active":
-        {"2019": [true]
-        },
-        "param_code":
-        {"ALD_InvInc_ec_base_code":
-         "returned_value = e00300 + e00650 + p23250"
         }
     }
 }

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -247,15 +247,7 @@ def test_Calculator_create_difference_table(puf_1991, weights_1991):
     calc1.calc_all()
     # create policy-reform Policy object and use to create Calculator calc2
     policy2 = Policy()
-    reform = {
-        2013: {'_II_rt7': [0.45]},
-        2013: {'_ALD_InvInc_ec_base_code_active': [True]},
-        2013: {'_CTC_new_code_active': [True]},
-        0: {'ALD_InvInc_ec_base_code':
-            'returned_value = e00300 + e00650 + p23250',
-            'CTC_new_code':
-            'returned_value = where(n24>0, 100, 0)'}
-    }
+    reform = {2013: {'_II_rt7': [0.45]}}
     policy2.implement_reform(reform)
     puf2 = Records(data=puf_1991, weights=weights_1991, start_year=2009)
     calc2 = Calculator(policy=policy2, records=puf2)
@@ -373,15 +365,6 @@ REFORM_CONTENTS = """
   "author": "",
   "date": "",
   "policy": {
-    "param_code": { // all the parameter code must go in one place
-"ALD_InvInc_ec_base_code":
-||
-// base is sum of taxable interest, qualified dividends and long-term cap gains
-returned_value = e00300 + e00650 + p23250
-||},
-    "_ALD_InvInc_ec_base_code_active":
-    {"2016": [true]
-    },
     "_AMT_brk1": // top of first AMT tax bracket
     {"2015": [200000],
      "2017": [300000]
@@ -667,7 +650,7 @@ def test_convert_parameter_dict():
         rdict = Calculator.convert_parameter_dict({'_II_em': 40000})
 
 
-def test_param_code_calc_all(reform_file, rawinputfile):
+def test_calc_all(reform_file, rawinputfile):
     cyr = 2016
     policy = Policy()
     param_dict = Calculator.read_json_param_files(reform_file.name, None)

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -20,18 +20,7 @@ REFORM_CONTENTS = """
   "date": "",
   "policy": {
     // specify fraction of investment income that can be excluded from AGI
-    "_ALD_InvInc_ec_rt": {"2016": [0.50]},
-
-    // specify "investment income" base to mean the sum of three things:
-    // taxable interest (e00300), qualified dividends (e00650), and
-    // long-term capital gains (p23250) [see functions.py for other
-    // types of investment income that can be included in the base]
-    "param_code": {"ALD_InvInc_ec_base_code":
-                   ||returned_value = e00300 + e00650 + p23250||},
-
-    "_ALD_InvInc_ec_base_code_active": {"2016": [true]}
-    // the dollar exclusion is the product of the base defined by code
-    // and the fraction defined above
+    "_ALD_InvInc_ec_rt": {"2016": [0.50]}
   }
 }
 """

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -107,8 +107,7 @@ def test_calc_and_used_vars(tests_path):
             msg1 += 'VAR NOT CALCULATED: {}\n'.format(var)
     # Test (2):
     faux_functions = ['EITCamount', 'ComputeBenefit',
-                      'BenefitSurtax', 'BenefitLimitation',
-                      'ALD_InvInc_ec_base_code', 'CTC_new_code']
+                      'BenefitSurtax', 'BenefitLimitation']
     found_error2 = False
     msg2 = 'calculated & returned variables are not function arguments\n'
     for fname in fnames:

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -486,15 +486,6 @@ REFORM_CONTENTS = """
 // pipe characters (||).
 {
 "policy": {
-    "param_code": {
-"ALD_InvInc_ec_base_code":
-||
-returned_value = e00300 + e00650 + p23250
-||
-},
-    "_ALD_InvInc_ec_base_code_active": {
-        "2016": [true]
-    },
     "_AMT_brk1": // top of first AMT tax bracket
     {"2015": [200000],
      "2017": [300000]
@@ -541,13 +532,6 @@ def reform_file():
             os.remove(rfile.name)
         except OSError:
             pass  # sometimes we can't remove a generated temporary file
-
-
-def test_prohibit_param_code(reform_file):
-    Policy.PROHIBIT_PARAM_CODE = True
-    with pytest.raises(ValueError):
-        Calculator.read_json_param_files(reform_file.name, None)
-    Policy.PROHIBIT_PARAM_CODE = False
 
 
 @pytest.mark.parametrize("set_year", [False, True])
@@ -677,38 +661,3 @@ def test_current_law_version():
     assert clp_mte_2015 == ref_mte_2015 == clv_mte_2015
     assert clp_mte_2016 != ref_mte_2016
     assert clp_mte_2016 == clv_mte_2016
-
-
-def test_scan_param_code():
-    """
-    Test scan_param_code function.
-    """
-    with pytest.raises(ValueError):
-        Policy.scan_param_code('__builtins__')
-    with pytest.raises(ValueError):
-        Policy.scan_param_code('lambda x: x**2')
-    with pytest.raises(ValueError):
-        Policy.scan_param_code('[x*x for x in range(9)]')
-    with pytest.raises(ValueError):
-        Policy.scan_param_code('9999**99999999')
-
-
-def test_cpi_for_param_code():
-    """
-    Test cpi_for_param_code function.
-    """
-    reform2020 = {
-        0: {"ALD_InvInc_ec_base_code":
-            "returned_value = e00300 + e00650 + p23250"},
-        2020: {"_ALD_InvInc_ec_base_code_active": [True]}
-    }
-    pol = Policy()
-    pol.implement_reform(reform2020)
-    assert pol.current_year == 2013
-    with pytest.raises(ValueError):
-        cpi = pol.cpi_for_param_code('badname')
-    with pytest.raises(ValueError):
-        cpi = pol.cpi_for_param_code('ALD_InvInc_ec_base_code')
-    pol.set_year(2020)
-    cpi = pol.cpi_for_param_code('ALD_InvInc_ec_base_code')
-    assert cpi == 1.0

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -39,8 +39,6 @@ def test_reforms(reforms_path):  # pylint: disable=redefined-outer-name
         policy.implement_reform(policy_dict)
         # identify "policy" parameters included in jrf
         for year in policy_dict.keys():
-            if year == 0:
-                continue  # skip param_code info which is marked with year zero
             policy_year_dict = policy_dict[year]
             for param in policy_year_dict.keys():
                 if param.endswith('_cpi'):


### PR DESCRIPTION
The `param_code` capability, which was merged on January 13, 2017, into the master branch with pull request #1107, was an experimental attempt to resolve issue #429.  This experimental attempt to resolve #429 revealed that the approach adopted in #1107 had benefits, but its costs were larger than the benefits.  The #1107 approach raised security questions because of the use of the Python exec() function.  It was awkward to write multiple-line code in a JSON reform file.  And the #1107 approach required the use of the numpy `where` function, which was not as easy to read as the if-then-else statements used in the `functions.py` file.

Given this experience, my conclusion is that, if one wanted to eliminate the problems with the #1107 approach, it may require writing a simple parser that would translate more user-freindly parameter code into Python code.  But there may be different approaches that are effective at eliminating the problems with the #1107 approach.

In any case, this pull request removes the experimental `param_code` logic implemented in #1107.
And it also serves as an historical record of a failed experiment in resolving #429.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @GoFroggyRun @codykallen @zrisher 
@PeterDSteinberg 
