### PR TITLE
fix numpy version also in run section of meta.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - setuptools
     - python
     - mock
-    - numpy ==1.10.4
+    - numpy ==1.11.2
     - pandas <=0.18.0
     - numba
     - toolz


### PR DESCRIPTION
I forgot the numpy version was specified in two places of the `yaml` file.

Addresses @martinholmer 's comment [here](https://github.com/open-source-economics/Tax-Calculator/pull/1223#issuecomment-284910626)