### PR TITLE
remove instruction for extraneous git command

### DIFF
--- a/docs/source/contributor_guide.rst
+++ b/docs/source/contributor_guide.rst
@@ -204,21 +204,31 @@ situations, in which case other contributors are here to help.
       tax-calculator$ git add [filename]
       tax-calculator$ git commit -m "[description-of-your-commit]"
 
-6. When you're ready for other team members to review your code, make
-   your final commit and push your local branch to your remote repo
-   (this repo is also called the origin).
+6. Periodically, make sure that the branch you created in step 2
+   is in sync with the changes other contributors are making to 
+   the central master branch by fetching upstream and merging
+   upstream/master into your branch. 
+
+   .. code-block:: python
+
+       tax-calculator$ git fetch upstream
+       tax-calculator$ git merge upstream/master
+
+    You may need to resolve conflicts that arise when another
+    contributor changed the same section of code that you are 
+    changing. Feel free to ask other contributors for guidance 
+    if this happens to you. If you do need to fix a merge
+    conflict, re-run the test suite afterwards (step 4.)
+
+6. When you are ready for other team members to review your code, make
+   your final commit and push your local branch to your remote repo.
 
    .. code-block:: python
 
       tax-calculator$ git push origin [new-branch-name]
 
-7. Ask other team members to review your changes by directing them to:
-   **github.com/[github-username]/Tax-Calculator/[new-branch-name]**.
-
-8. If this is your first time, wait for feedback and instructions on
-   how to proceed. Most likely, the other contributors will ask you to
-   `fetch`_ and merge new changes from `upstream`_/master and then
-   open a `pull request`_.
+7. From the GitHub.com user interface, select "open pull request." 
+   
 
 Simple Usage
 ------------

--- a/docs/source/contributor_guide.rst
+++ b/docs/source/contributor_guide.rst
@@ -85,6 +85,10 @@ Setup Git
     .. code-block:: python
    
        tax-calculator$ activate taxcalc-dev
+
+    Note: never conda install the taxcalc package in the taxcalc-dev
+    environment because the taxcalc source code and the installed package
+    will conflict. 
    
 11. To check that everything is working properly, run the following at
     the command line from the tax-calculator directory, but skip the

--- a/docs/source/contributor_guide.rst
+++ b/docs/source/contributor_guide.rst
@@ -133,7 +133,7 @@ situations, in which case other contributors are here to help.
 
 1. Before you edit the calculator on your machine, make sure you have
    the latest version of the central Tax-Calculator by executing the
-   following **four** Git commands:
+   following **three** Git commands:
 
    a. Download all of the content from the central Tax-Calculator repo.
       Navigate to your local tax-calculator directory and enter the
@@ -156,13 +156,6 @@ situations, in which case other contributors are here to help.
       .. code-block:: python
 
          tax-calculator$ git merge upstream/master
-
-   d. Push the updated master branch in your local repo to your GitHub
-      repo.
-
-      .. code-block:: python
-
-         tax-calculator$ git push
 
 2. Create a new `branch`_ on your local machine. Think of your
    branches as a way to organize your projects. If you want to work on

--- a/docs/source/contributor_guide.rst
+++ b/docs/source/contributor_guide.rst
@@ -227,8 +227,8 @@ situations, in which case other contributors are here to help.
 
       tax-calculator$ git push origin [new-branch-name]
 
-7. From the GitHub.com user interface, select "open pull request." 
-   
+7. From the GitHub.com user interface, `open a pull request`_.  
+
 
 Simple Usage
 ------------
@@ -316,3 +316,6 @@ sample notebook: `10 Minutes To Tax-Calculator`_.
 
 .. _`pull request`:
    https://help.github.com/articles/github-glossary/#pull-request
+
+.. _`open a pull request`:
+   https://help.github.com/articles/creating-a-pull-request/#creating-the-pull-request

--- a/docs/source/contributor_guide.rst
+++ b/docs/source/contributor_guide.rst
@@ -224,14 +224,14 @@ situations, in which case other contributors are here to help.
     if this happens to you. If you do need to fix a merge
     conflict, re-run the test suite afterwards (step 4.)
 
-6. When you are ready for other team members to review your code, make
+7. When you are ready for other team members to review your code, make
    your final commit and push your local branch to your remote repo.
 
    .. code-block:: python
 
       tax-calculator$ git push origin [new-branch-name]
 
-7. From the GitHub.com user interface, `open a pull request`_.  
+8. From the GitHub.com user interface, `open a pull request`_.  
 
 
 Simple Usage


### PR DESCRIPTION
`contributor_guide.rst` contained an extraneous git command in the workflow. There is no need to keep the master branch of your 'origin' remote repository in sync with the master branch of the 'upstream' repository (open-source-economics/tax-calculator). 