### PR TITLE
Revise taxcalc imports in the simpletaxio.py file

### DIFF
--- a/taxcalc/validation/taxsim/simpletaxio.py
+++ b/taxcalc/validation/taxsim/simpletaxio.py
@@ -13,7 +13,9 @@ import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..', '..'))
 # pylint: disable=wrong-import-position,import-error
-from taxcalc import Policy, Records, Calculator
+from taxcalc.policy import Policy
+from taxcalc.records import Records
+from taxcalc.calculate import Calculator
 
 
 class SimpleTaxIO(object):


### PR DESCRIPTION
This is an experiment to see if the error reported in #1231 will go away with a different import style.

Both the versions --- the prior taxcalc import and the new one in this pull request --- work fine on Python 2.7, but the prior import style might not work correctly under Python 3.x.