### PR TITLE
UBI Implementation

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -146,6 +146,7 @@ class Calculator(object):
         ALD_InvInc_ec_base(self.policy, self.records)
         CapGains(self.policy, self.records)
         SSBenefits(self.policy, self.records)
+        UBI(self.policy, self.records)
         AGI(self.policy, self.records)
         ItemDed(self.policy, self.records)
         AdditionalMedicareTax(self.policy, self.records)

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -2753,5 +2753,69 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [0.0]
+    },
+
+    "_UBI1": {
+        "long_name": "UBI for those under 18",
+        "description": "Lump sum of money given to people under 18",
+        "section_1": "UBI",
+        "section_2": "Universal Basic Income",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_UBI2": {
+        "long_name": "UBI for those between 18 and 21",
+        "description": "Lump sum of money given to people between 18 and 21",
+        "section_1": "UBI",
+        "section_2": "Universal Basic Income",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_UBI3": {
+        "long_name": "UBI for those 21 and over",
+        "description": "Lump sum of money given to people 21 and over",
+        "section_1": "UBI",
+        "section_2": "Universal Basic Income",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "col_label": "",
+        "value": [0.0]
+    },
+
+    "_UBI_hc": {
+        "long_name": "Portion of UBI taxable",
+        "description": "This portion of UBI is taxable and will be added to AGI",
+        "section_1": "UBI",
+        "section_2": "Universal Basic Income haircut",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [1.0]
     }
 }

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -2816,6 +2816,6 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value": [1.0]
+        "value": [0.0]
     }
 }

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -2803,9 +2803,9 @@
         "value": [0.0]
     },
 
-    "_UBI_hc": {
-        "long_name": "Portion of UBI taxable",
-        "description": "This portion of UBI is taxable and will be added to AGI",
+    "_UBI_ecrt": {
+        "long_name": "Fraction of UBI benefits excluded from AGI",
+        "description": "One minus this fraction of UBI is taxable and will be added to AGI",
         "section_1": "UBI",
         "section_2": "Universal Basic Income haircut",
         "irs_ref": "",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -266,7 +266,7 @@ def SSBenefits(MARS, ymod, e02400, SS_thd50, SS_thd85,
 
 
 @iterate_jit(nopython=True)
-def UBI(nu18, n1821, n21, UBI1, UBI2, UBI3, UBI_hc,
+def UBI(nu18, n1821, n21, UBI1, UBI2, UBI3, UBI_ecrt,
         ubi, taxable_ubi, nontaxable_ubi):
     """
 
@@ -289,7 +289,7 @@ def UBI(nu18, n1821, n21, UBI1, UBI2, UBI3, UBI_hc,
 
     """
     ubi = nu18 * UBI1 + n1821 * UBI2 + n21 * UBI3
-    taxable_ubi = ubi * UBI_hc
+    taxable_ubi = ubi * (1. - UBI_ecrt)
     nontaxable_ubi = ubi - taxable_ubi
     return ubi, taxable_ubi, nontaxable_ubi
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -266,9 +266,38 @@ def SSBenefits(MARS, ymod, e02400, SS_thd50, SS_thd85,
 
 
 @iterate_jit(nopython=True)
+def UBI(nu18, n1821, n21, UBI1, UBI2, UBI3, UBI_hc,
+        ubi, taxable_ubi, nontaxable_ubi):
+    """
+
+    Parameters
+    ----------
+    nu18: Number of people in the tax unit under 18
+    n1821: Number of people in the tax unit between 18 and 21
+    n21: Number of people in the tax unit over 21
+    UBI1: UBI for those under 18
+    UBI2: UBI for those between 18 and 21
+    UBI3: UBI for those over 21
+    UBI_hc: Portion of UBI that is taxable
+
+    Returns
+    -------
+    ubi: total UBI received by the tax unit
+    taxable_ubi: amount of UBI that is taxable. This is added to AGI
+    nontaxable_ubi: amount of UBI that is nontaxable.
+                    This is added to expanded income
+
+    """
+    ubi = nu18 * UBI1 + n1821 * UBI2 + n21 * UBI3
+    taxable_ubi = ubi * UBI_hc
+    nontaxable_ubi = ubi - taxable_ubi
+    return ubi, taxable_ubi, nontaxable_ubi
+
+
+@iterate_jit(nopython=True)
 def AGI(ymod1, c02500, c02900, XTOT, MARS, _sep, DSI, _exact,
         II_em, II_em_ps, II_prt,
-        II_credit, II_credit_ps, II_credit_prt,
+        II_credit, II_credit_ps, II_credit_prt, taxable_ubi,
         c00100, pre_c04600, c04600, personal_credit):
     """
     AGI function: compute Adjusted Gross Income, c00100,
@@ -276,7 +305,7 @@ def AGI(ymod1, c02500, c02900, XTOT, MARS, _sep, DSI, _exact,
                   compute personal_credit amount
     """
     # calculate AGI assuming no foreign earned income exclusion
-    c00100 = ymod1 + c02500 - c02900
+    c00100 = ymod1 + c02500 - c02900 + taxable_ubi
     # calculate personal exemption amount
     pre_c04600 = XTOT * II_em
     if DSI:
@@ -1446,7 +1475,7 @@ def LumpSumTax(DSI, _num, XTOT,
 
 @iterate_jit(nopython=True)
 def ExpandIncome(c00100, ptax_was, e02400, c02500,
-                 c02900_in_ei, e00400, invinc_agi_ec, cmbtp,
+                 c02900_in_ei, e00400, invinc_agi_ec, cmbtp, nontaxable_ubi,
                  _expanded_income):
     """
     ExpandIncome function calculates and returns _expanded_income.
@@ -1462,5 +1491,6 @@ def ExpandIncome(c00100, ptax_was, e02400, c02500,
                         invinc_agi_ec +  # AGI-excluded taxable invest income
                         cmbtp +  # AMT taxable income items from Form 6251
                         non_taxable_ss_benefits +
-                        employer_fica_share)
+                        employer_fica_share +
+                        nontaxable_ubi)  # universal basic income
     return _expanded_income

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -127,7 +127,8 @@ class Records(object):
         'MARS', 'MIDR', 'RECID', 'filer', 'cmbtp',
         'age_head', 'age_spouse', 'blind_head', 'blind_spouse',
         'nu13', 'elderly_dependent',
-        's006', 'nu05', 'agi_bin'])
+        's006', 'nu05', 'agi_bin',
+        'nu18', 'n1821', 'n21'])
 
     # specify set of input variables that MUST be read by Tax-Calculator:
     MUST_READ_VARS = set(['RECID', 'MARS'])
@@ -139,7 +140,8 @@ class Records(object):
         'n24', 'XTOT',
         'MARS', 'MIDR', 'RECID', 'filer',
         'age_head', 'age_spouse', 'blind_head', 'blind_spouse',
-        'nu13', 'elderly_dependent', 'agi_bin'])
+        'nu13', 'elderly_dependent', 'agi_bin',
+        'nu18', 'n1821', 'n21'])
 
     # specify set of Record variables that are calculated by Tax-Calculator:
     CALCULATED_VARS = set([
@@ -171,7 +173,7 @@ class Records(object):
         '_expanded_income', 'c07300', 'c07400',
         'c07600', 'c07240', 'c07260', 'c08000',
         '_surtax', '_combined', 'personal_credit', 'fstax', 'care_deduction',
-        'dep_credit'])
+        'dep_credit', 'ubi', 'taxable_ubi', 'nontaxable_ubi'])
 
     INTEGER_CALCULATED_VARS = set(['_num', '_sep', '_exact'])
 


### PR DESCRIPTION
Second time's the charm. This PR adds a feature to Tax-Calc that calculates the effects of a universal basic income. The UBI function relies on three new PUF variables (`nu18`, `n1821`, and `n21`) that hold the number of people in each age range in each tax unit. These have been discussed in TaxData PR [#83](https://github.com/open-source-economics/taxdata/pull/83).

Four new parameters are added into `current_law_policy.json`. `_UBI1-3` allow the user to specify different levels of UBI for each age group. `_UBI_hc` allows the user to specify what portion of the UBI is taxable (I'm not sure `hc` is the correct tag for this, but it seemed like the best option. If this needs to change let me know).

Using the new variables and parameters, the function calculates three values:
`ubi`: total income from the UBI received by the tax unit.
`taxable_ubi`: the portion of total UBI that is taxable. This is added to AGI.
`nontaxable_ubi`: the portion of total UBI that is not taxable. This is added to expanded income.

Adding only taxable UBI to AGI ensures that if the user specifies that UBI is not taxable, tax liability for the unit does not change. Nontaxable UBI, rather than total UBI is added to expanded income so that the taxable portion of UBI, which was already added to AGI, is not double counted. 

@MattHJensen @Amy-Xu @martinholmer 