### PR TITLE
Add --graph logic to tc.py script

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -122,7 +122,7 @@ class Calculator(object):
             while self.records.current_year < self.policy.current_year:
                 self.records.increment_year()
             if verbose:
-                print('Calculator instantiation automatically ' +
+                print('Tax-Calculator startup automatically ' +
                       'extrapolated your data to ' +
                       str(self.records.current_year) + '.')
         assert self.policy.current_year == self.records.current_year

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -275,7 +275,8 @@ class TaxCalcIO(object):
             atr_data = atr_graph_data(self._calc_clp, self._calc)
             atr_plot = xtr_graph_plot(atr_data)
             write_graph_file(atr_plot, atr_fname, atr_title)
-            mtr_data = mtr_graph_data(self._calc_clp, self._calc)
+            mtr_data = mtr_graph_data(self._calc_clp, self._calc,
+                                      alt_e00200p_text='Taxpayer Earnings')
             mtr_plot = xtr_graph_plot(mtr_data)
             write_graph_file(mtr_plot, mtr_fname, mtr_title)
         # optionally write --ceeu output to stdout

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -16,6 +16,7 @@ from taxcalc.behavior import Behavior
 from taxcalc.growdiff import Growdiff
 from taxcalc.growfactors import Growfactors
 from taxcalc.calculate import Calculator
+from taxcalc.utils import delete_file
 from taxcalc.utils import ce_aftertax_income
 from taxcalc.utils import atr_graph_data, mtr_graph_data
 from taxcalc.utils import xtr_graph_plot, write_graph_file
@@ -135,8 +136,7 @@ class TaxCalcIO(object):
             msg = 'TaxCalcIO.ctor assump is neither None nor str'
             raise ValueError(msg)
         self._output_filename = '{}{}{}.csv'.format(inp, ref, asm)
-        if os.path.isfile(self._output_filename):
-            os.remove(self._output_filename)
+        delete_file(self._output_filename)
         # get parameter dictionaries
         param_dict = Calculator.read_json_param_files(reform, assump)
         # make sure no behavioral response is specified
@@ -336,7 +336,7 @@ class TaxCalcIO(object):
             text = ('      because "alltax difference" is '
                     '{:.3f} which is not zero\n')
             txt += text.format(alltaxdiff)
-            txt += ('FIX: adjust _LST or another policy parameter '
+            txt += ('FIX: adjust _LST or another reform policy parameter '
                     'to bracket\n')
             txt += ('     "alltax difference" equals zero and '
                     'then interpolate')

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -61,7 +61,8 @@ def test_make_Calculator(records_2009):
     consump = Consumption()
     consump.update_consumption({2014: {'_MPC_e20400': [0.05]}})
     assert consump.current_year == 2013
-    calc = Calculator(policy=parm, records=recs, consumption=consump)
+    calc = Calculator(policy=parm, records=recs, consumption=consump,
+                      behavior=Behavior())
     assert calc.current_year == 2014
     # test incorrect Calculator instantiation:
     with pytest.raises(ValueError):

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -147,7 +147,7 @@ def test_2(rawinputfile, reformfile0):
                      assump=None,
                      aging_input_data=False,
                      exact_calculations=False)
-    output = tcio.calculate()
+    output = tcio.static_analysis()
     assert output == EXPECTED_TO_STRING_OUTPUT
 
 
@@ -279,8 +279,8 @@ def test_3(rawinputfile, reformfile1, assumpfile1):
     outfilepath = tcio.output_filepath()
     # --ceeu output and standard output
     try:
-        output = tcio.calculate(writing_output_file=True,
-                                output_ceeu=True)
+        output = tcio.static_analysis(writing_output_file=True,
+                                      output_ceeu=True)
     except:  # pylint: disable=bare-except
         if os.path.isfile(outfilepath):
             try:
@@ -290,8 +290,8 @@ def test_3(rawinputfile, reformfile1, assumpfile1):
         assert 'TaxCalcIO.calculate(ceeu)_ok' == 'no'
     # --dump output
     try:
-        output = tcio.calculate(writing_output_file=True,
-                                output_dump=True)
+        output = tcio.static_analysis(writing_output_file=True,
+                                      output_dump=True)
     except:  # pylint: disable=bare-except
         if os.path.isfile(outfilepath):
             try:
@@ -323,7 +323,7 @@ def test_4(reformfile2, assumpfile1):
                      assump=assumpfile1.name,
                      aging_input_data=False,
                      exact_calculations=False)
-    output = tcio.calculate()
+    output = tcio.static_analysis()
     assert output == EXPECTED_TO_STRING_OUTPUT
 
 
@@ -340,7 +340,8 @@ def test_4(reformfile2, assumpfile1):
 #                      assump=None,
 #                      aging_input_data=False,
 #                      exact_calculations=False)
-#     output = tcio.calculate(writing_output_file=False, output_graph=True)
+#     output = tcio.static_analysis(writing_output_file=False,
+#                                   output_graph=True)
 #     # cleanup html files
 #     assert output != ''
 
@@ -357,7 +358,7 @@ def test_6(rawinputfile):
                      assump=None,
                      aging_input_data=False,
                      exact_calculations=False)
-    output = tcio.calculate(writing_output_file=False, output_dump=True)
+    output = tcio.static_analysis(writing_output_file=False, output_dump=True)
     assert len(output) > 5000
     assert tcio.tax_year() == taxyear
 
@@ -402,7 +403,7 @@ def test_7(reformfile1, lumpsumreformfile):
                      assump=None,
                      aging_input_data=False,
                      exact_calculations=False)
-    output = tcio.calculate(writing_output_file=False, output_ceeu=True)
+    output = tcio.static_analysis(writing_output_file=False, output_ceeu=True)
     assert tcio.tax_year() == taxyear
     assert len(output) > 0
 
@@ -412,7 +413,7 @@ def test_7(reformfile1, lumpsumreformfile):
                      assump=None,
                      aging_input_data=False,
                      exact_calculations=False)
-    output = tcio.calculate(writing_output_file=False, output_ceeu=True)
+    output = tcio.static_analysis(writing_output_file=False, output_ceeu=True)
     assert tcio.tax_year() == taxyear
     assert len(output) > 0
 

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -418,12 +418,26 @@ def test_7(reformfile1, lumpsumreformfile):
     assert len(output) > 0
 
 
-BAD_ASSUMP_CONTENTS = """
+BAD1_ASSUMP_CONTENTS = """
 {
   "consumption": {
   },
   "behavior": {
       "_BE_sub": {"2020": [0.05]}
+  },
+  "growdiff_baseline": {
+  },
+  "growdiff_response": {
+  }
+}
+"""
+
+
+BAD2_ASSUMP_CONTENTS = """
+{
+  "consumption": {
+  },
+  "behavior": {
   },
   "growdiff_baseline": {
   },
@@ -435,12 +449,12 @@ BAD_ASSUMP_CONTENTS = """
 
 
 @pytest.yield_fixture
-def assumpfile3():
+def assumpfile_bad1():
     """
     Temporary assumption file with .json extension.
     """
     afile = tempfile.NamedTemporaryFile(suffix='.json', mode='a', delete=False)
-    afile.write(BAD_ASSUMP_CONTENTS)
+    afile.write(BAD1_ASSUMP_CONTENTS)
     afile.close()
     # must close and then yield for Windows platform
     yield afile
@@ -451,7 +465,24 @@ def assumpfile3():
             pass  # sometimes we can't remove a generated temporary file
 
 
-def test_9(reformfile2, assumpfile3):
+@pytest.yield_fixture
+def assumpfile_bad2():
+    """
+    Temporary assumption file with .json extension.
+    """
+    afile = tempfile.NamedTemporaryFile(suffix='.json', mode='a', delete=False)
+    afile.write(BAD2_ASSUMP_CONTENTS)
+    afile.close()
+    # must close and then yield for Windows platform
+    yield afile
+    if os.path.isfile(afile.name):
+        try:
+            os.remove(afile.name)
+        except OSError:
+            pass  # sometimes we can't remove a generated temporary file
+
+
+def test_9(reformfile2, assumpfile_bad1, assumpfile_bad2):
     """
     Test TaxCalcIO constructor with illegal assumptions.
     """
@@ -462,6 +493,13 @@ def test_9(reformfile2, assumpfile3):
         TaxCalcIO(input_data=input_dataframe,
                   tax_year=taxyear,
                   reform=reformfile2.name,
-                  assump=assumpfile3.name,
+                  assump=assumpfile_bad1.name,
+                  aging_input_data=False,
+                  exact_calculations=False)
+    with pytest.raises(ValueError):
+        TaxCalcIO(input_data=input_dataframe,
+                  tax_year=taxyear,
+                  reform=reformfile2.name,
+                  assump=assumpfile_bad2.name,
                   aging_input_data=False,
                   exact_calculations=False)

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -334,16 +334,15 @@ def test_4(reformfile2, assumpfile1):
 #     using file name for TaxCalcIO constructor input_data and writing
 #     --graph output.
 #     #
-#     taxyear = 2021
 #     tcio = TaxCalcIO(input_data=puf_1991,
-#                      tax_year=taxyear,
+#                      tax_year=2016,
 #                      reform=reformfile1.name,
 #                      assump=None,
 #                      aging_input_data=False,
 #                      exact_calculations=False)
-#     output = tcio.calculate(writing_output_file=True, output_graph=True)
-#     # cleanup output and html files
-#     assert output == ''
+#     output = tcio.calculate(writing_output_file=False, output_graph=True)
+#     # cleanup html files
+#     assert output != ''
 
 
 def test_6(rawinputfile):

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -277,26 +277,29 @@ def test_3(rawinputfile, reformfile1, assumpfile1):
                      aging_input_data=False,
                      exact_calculations=False)
     outfilepath = tcio.output_filepath()
-    # try output file writing
+    # --ceeu output and standard output
     try:
-        output = tcio.calculate(writing_output_file=True, output_ceeu=True)
+        output = tcio.calculate(writing_output_file=True,
+                                output_ceeu=True)
     except:  # pylint: disable=bare-except
         if os.path.isfile(outfilepath):
             try:
                 os.remove(outfilepath)
             except OSError:
                 pass  # sometimes we can't remove a generated temporary file
-        assert 'TaxCalcIO.calculate()_ok(1)' == 'no'
+        assert 'TaxCalcIO.calculate(ceeu)_ok' == 'no'
+    # --dump output
     try:
-        output = tcio.calculate(writing_output_file=True, output_dump=True)
+        output = tcio.calculate(writing_output_file=True,
+                                output_dump=True)
     except:  # pylint: disable=bare-except
         if os.path.isfile(outfilepath):
             try:
                 os.remove(outfilepath)
             except OSError:
                 pass  # sometimes we can't remove a generated temporary file
-        assert 'TaxCalcIO.calculate()_ok(2)' == 'no'
-    # if tries were successful, try to remove the output file
+        assert 'TaxCalcIO.calculate(dump)_ok' == 'no'
+    # if tries were successful, try to remove the output files
     if os.path.isfile(outfilepath):
         try:
             os.remove(outfilepath)
@@ -324,7 +327,23 @@ def test_4(reformfile2, assumpfile1):
     assert output == EXPECTED_TO_STRING_OUTPUT
 
 
-# remove test_5 because there is no longer a TaxCalcIO.output_records() method
+# skip test_5 until have a more realistic sample to replace puf_1991
+# def test_5(puf_1991, reformfile1):
+#     #
+#     Test TaxCalcIO calculate method with output writing but no aging,
+#     using file name for TaxCalcIO constructor input_data and writing
+#     --graph output.
+#     #
+#     taxyear = 2021
+#     tcio = TaxCalcIO(input_data=puf_1991,
+#                      tax_year=taxyear,
+#                      reform=reformfile1.name,
+#                      assump=None,
+#                      aging_input_data=False,
+#                      exact_calculations=False)
+#     output = tcio.calculate(writing_output_file=True, output_graph=True)
+#     # cleanup output and html files
+#     assert output == ''
 
 
 def test_6(rawinputfile):

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -627,9 +627,7 @@ def test_write_graph_file(records_2009):
     assert gplot
     # generate random filename
     import random
-    hex = "%064x" % random.randrange(10**20)
-    htmlfname = '{}.html'.format(hex[:16])
-    print(htmlfname)  # TODO: temporary code
+    htmlfname = '{}.html'.format(random.randint(1000000000, 9999999999))
     try:
         write_graph_file(gplot, htmlfname, 'title')
     except:  # pylint: disable=bare-except

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -616,7 +616,7 @@ def test_xtr_graph_plot_no_bokeh(records_2009):
         gplot = xtr_graph_plot(gdata)
     taxcalc.utils.BOKEH_AVAILABLE = True
 
-
+@pytest.mark.one
 def test_write_graph_file(records_2009):
     calc = Calculator(policy=Policy(), records=records_2009)
     gdata = mtr_graph_data(calc, calc, mtr_measure='ptax',
@@ -625,7 +625,8 @@ def test_write_graph_file(records_2009):
                            dollar_weighting=False)
     gplot = xtr_graph_plot(gdata)
     assert gplot
-    htmlfile = tempfile.NamedTemporaryFile(mode='w', suffix='.html')
+    htmlfile = tempfile.NamedTemporaryFile(mode='w', suffix='.html',
+                                           delete=False)
     write_graph_file(gplot, htmlfile.name, 'title')
 
 

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -629,7 +629,7 @@ def test_write_graph_file(records_2009):
     import random
     hex = "%064x" % random.randrange(10**20)
     htmlfname = '{}.html'.format(hex[:16])
-    print htmlfname
+    print(htmlfname)  # TODO: temporary code
     try:
         write_graph_file(gplot, htmlfname, 'title')
     except:  # pylint: disable=bare-except

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -599,6 +599,7 @@ def test_xtr_graph_plot(records_2009):
     gplot = xtr_graph_plot(gdata)
     assert gplot
     gdata = mtr_graph_data(calc, calc, mtr_measure='itax',
+                           alt_e00200p_text='Taxpayer Earnings',
                            income_measure='expanded_income',
                            dollar_weighting=False)
     assert type(gdata) == dict
@@ -614,6 +615,18 @@ def test_xtr_graph_plot_no_bokeh(records_2009):
     with pytest.raises(RuntimeError):
         gplot = xtr_graph_plot(gdata)
     taxcalc.utils.BOKEH_AVAILABLE = True
+
+
+def test_write_graph_file(records_2009):
+    calc = Calculator(policy=Policy(), records=records_2009)
+    gdata = mtr_graph_data(calc, calc, mtr_measure='ptax',
+                           alt_e00200p_text='Taxpayer Earnings',
+                           income_measure='agi',
+                           dollar_weighting=False)
+    gplot = xtr_graph_plot(gdata)
+    assert gplot
+    htmlfile = tempfile.NamedTemporaryFile(mode='w', suffix='.html')
+    write_graph_file(gplot, htmlfile.name, 'title')
 
 
 def test_multiyear_diagnostic_table(records_2009):

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -625,9 +625,7 @@ def test_write_graph_file(records_2009):
                            dollar_weighting=False)
     gplot = xtr_graph_plot(gdata)
     assert gplot
-    # generate random filename
-    import random
-    htmlfname = '{}.html'.format(random.randint(1000000000, 9999999999))
+    htmlfname = temporary_filename(suffix='.html')
     try:
         write_graph_file(gplot, htmlfname, 'title')
     except:  # pylint: disable=bare-except
@@ -796,3 +794,13 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     with pytest.raises(ValueError):
         ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True,
                            custom_params=params)
+
+
+def test_create_and_delete_temporary_file():
+    # test temporary_filename() and delete_file() functions
+    fname = temporary_filename()
+    with open(fname, 'w') as tmpfile:
+        tmpfile.write('any content will do')
+    assert os.path.isfile(fname) is True
+    delete_file(fname)
+    assert os.path.isfile(fname) is False

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -625,9 +625,26 @@ def test_write_graph_file(records_2009):
                            dollar_weighting=False)
     gplot = xtr_graph_plot(gdata)
     assert gplot
-    htmlfile = tempfile.NamedTemporaryFile(mode='w', suffix='.html',
-                                           delete=False)
-    write_graph_file(gplot, htmlfile.name, 'title')
+    # generate random filename
+    import random
+    hex = "%064x" % random.randrange(10**20)
+    htmlfname = '{}.html'.format(hex[:16])
+    print htmlfname
+    try:
+        write_graph_file(gplot, htmlfname, 'title')
+    except:  # pylint: disable=bare-except
+        if os.path.isfile(htmlfname):
+            try:
+                os.remove(htmlfname)
+            except OSError:
+                pass  # sometimes we can't remove a generated temporary file
+        assert 'write_graph_file()_ok' == 'no'
+    # if try was successful, try to remove the file
+    if os.path.isfile(htmlfname):
+        try:
+            os.remove(htmlfname)
+        except OSError:
+            pass  # sometimes we can't remove a generated temporary file
 
 
 def test_multiyear_diagnostic_table(records_2009):

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -616,7 +616,7 @@ def test_xtr_graph_plot_no_bokeh(records_2009):
         gplot = xtr_graph_plot(gdata)
     taxcalc.utils.BOKEH_AVAILABLE = True
 
-@pytest.mark.one
+
 def test_write_graph_file(records_2009):
     calc = Calculator(policy=Policy(), records=records_2009)
     gdata = mtr_graph_data(calc, calc, mtr_measure='ptax',

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -11,6 +11,7 @@ import os
 import math
 import copy
 import json
+import random
 from collections import defaultdict, OrderedDict
 from pkg_resources import resource_stream, Requirement, DistributionNotFound
 import six
@@ -1144,8 +1145,7 @@ def write_graph_file(figure, filename, title):
     -------
     Nothing
     """
-    if os.path.isfile(filename):
-        os.remove(filename)  # work around annoying 'already exists' bokeh msg
+    delete_file(filename)    # work around annoying 'already exists' bokeh msg
     bio.output_file(filename=filename, title=title)
     bio.save(figure)
 
@@ -1373,3 +1373,18 @@ def read_egg_csv(vname, fpath, **kwargs):
         msg = 'could not read {} file from EGG'
         raise ValueError(msg.format(vname))
     return vname_dict
+
+
+def temporary_filename(suffix=''):
+    """
+    Return string containing filename.
+    """
+    return 'tmp{}{}'.format(random.randint(10000000, 99999999), suffix)
+
+
+def delete_file(filename):
+    """
+    Remove specified file if it exists.
+    """
+    if os.path.isfile(filename):
+        os.remove(filename)

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -18,6 +18,7 @@ import numpy as np
 import pandas as pd
 try:
     BOKEH_AVAILABLE = True
+    import bokeh.io as bio
     import bokeh.plotting as bp
 except ImportError:
     BOKEH_AVAILABLE = False
@@ -1070,9 +1071,9 @@ def xtr_graph_plot(data,
     THEN  # when working interactively in a Python notebook
       bp.show(gplot)
     OR    # when executing script using Python command-line interpreter
-      bp.output_file('anyname.html')  # file to write to when invoking bp.show
-      bp.show(gplot, title='MTR by Income Percentile')
-    WILL VISUALIZE GRAPH IN BROWSER
+      bio.output_file('graph-name.html', title='?TR by Income Percentile')
+      bio.show(gplot)
+    WILL VISUALIZE GRAPH IN BROWSER AND WRITE GRAPH TO SPECIFIED HTML FILE
 
     To convert the visualized graph into a PNG-formatted file, click on
     the "Save" icon on the Toolbar (located in the top-right corner of
@@ -1114,6 +1115,30 @@ def xtr_graph_plot(data,
     fig.legend.spacing = 5
     fig.legend.padding = 5
     return fig
+
+
+@requires_bokeh
+def write_graph_file(figure, filename, title):
+    """
+    Write HTML file named filename containing figure.
+    The title is the text displayed in the browser tab.
+
+    Parameters
+    ----------
+    figure : bokeh.plotting figure object
+
+    filename : string
+        name of HTML file to which figure is written; should end in .html
+
+    title : string
+        text displayed in browser tab when HTML file is displayed in browser
+
+    Returns
+    -------
+    Nothing
+    """
+    bio.output_file(filename=filename, title=title)
+    bio.save(figure)
 
 
 def read_json_from_file(path):

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -698,6 +698,7 @@ def mtr_graph_data(calc1, calc2,
                    mars='ALL',
                    mtr_measure='combined',
                    mtr_variable='e00200p',
+                   alt_e00200p_text='',
                    mtr_wrt_full_compen=False,
                    income_measure='expanded_income',
                    dollar_weighting=False):
@@ -729,6 +730,10 @@ def mtr_graph_data(calc1, calc2,
     mtr_variable : string
         any string in the Calculator.VALID_MTR_VARS set
         specifies variable to change in order to compute marginal tax rates
+
+    alt_e00200p_text : string
+        text to use in place of mtr_variable when mtr_variable is 'e00200p';
+        if empty string then use 'e00200p'
 
     mtr_wrt_full_compen : boolean
         see documentation of Calculator.mtr() argument wrt_full_compensation
@@ -862,6 +867,8 @@ def mtr_graph_data(calc1, calc2,
         xlabel_str = '{} for MARS={}'.format(xlabel_str, mars)
     data['xlabel'] = xlabel_str
     var_str = '{}'.format(mtr_variable)
+    if mtr_variable == 'e00200p' and alt_e00200p_text != '':
+        var_str = '{}'.format(alt_e00200p_text)
     if mtr_variable == 'e00200p' and mtr_wrt_full_compen:
         var_str = '{} wrt full compensation'.format(var_str)
     title_str = 'Mean Marginal Tax Rate for {} by Income Percentile'
@@ -1072,7 +1079,7 @@ def xtr_graph_plot(data,
       bp.show(gplot)
     OR    # when executing script using Python command-line interpreter
       bio.output_file('graph-name.html', title='?TR by Income Percentile')
-      bio.show(gplot)
+      bio.show(gplot)  [OR bio.save(gplot) WILL JUST WRITE FILE TO DISK]
     WILL VISUALIZE GRAPH IN BROWSER AND WRITE GRAPH TO SPECIFIED HTML FILE
 
     To convert the visualized graph into a PNG-formatted file, click on
@@ -1137,6 +1144,8 @@ def write_graph_file(figure, filename, title):
     -------
     Nothing
     """
+    if os.path.isfile(filename):
+        os.remove(filename)  # work around annoying 'already exists' bokeh msg
     bio.output_file(filename=filename, title=title)
     bio.save(figure)
 

--- a/taxcalc/validation/taxsim/simpletaxio.py
+++ b/taxcalc/validation/taxsim/simpletaxio.py
@@ -13,9 +13,7 @@ import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..', '..'))
 # pylint: disable=wrong-import-position,import-error
-from taxcalc.policy import Policy
-from taxcalc.records import Records
-from taxcalc.calculate import Calculator
+from taxcalc import Policy, Records, Calculator
 
 
 class SimpleTaxIO(object):

--- a/tc.py
+++ b/tc.py
@@ -1,5 +1,5 @@
 """
-Command-line interface to Tax-Calculator.
+Command-line interface to Tax-Calculator for STATIC tax analysis.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 tc.py
@@ -12,7 +12,7 @@ from taxcalc import TaxCalcIO
 
 def main():
     """
-    Contains command-line interface to the Tax-Calculator TaxCalcIO class.
+    Contains STATIC command-line interface to Tax-Calculator TaxCalcIO class.
     """
     # parse command-line arguments:
     parser = argparse.ArgumentParser(
@@ -20,17 +20,20 @@ def main():
         description=('Writes to a file the federal income and payroll tax '
                      'OUTPUT for each filing unit specified in the INPUT '
                      'file, with the OUTPUT computed from the INPUT for the '
-                     'TAXYEAR using Tax-Calculator. The OUTPUT file is a '
+                     'TAXYEAR using Tax-Calculator operating under STATIC '
+                     'analysis assumptions. The OUTPUT file is a '
                      'CSV-formatted file that contains tax information for '
                      'each INPUT filing unit.'))
-    parser.add_argument('INPUT', nargs='?', default='',
+    parser.add_argument('INPUT', nargs='?',
                         help=('INPUT is name of CSV-formatted file that '
                               'contains for each filing unit variables used '
-                              'to compute taxes for TAXYEAR.'))
-    parser.add_argument('TAXYEAR', nargs='?', default=0,
+                              'to compute taxes for TAXYEAR.'),
+                        default='')
+    parser.add_argument('TAXYEAR', nargs='?',
                         help=('TAXYEAR is calendar year for which taxes '
                               'are computed.'),
-                        type=int)
+                        type=int,
+                        default=0)
     parser.add_argument('--reform',
                         help=('REFORM is name of optional JSON reform file. '
                               'No --reform implies use of current-law '
@@ -55,16 +58,17 @@ def main():
     parser.add_argument('--ceeu',
                         help=('optional flag that causes normative welfare '
                               'statistics, including certainty-equivalent '
-                              'expected-utility of after-tax income values '
-                              'for different constant-relative-risk-aversion '
-                              'parameter values, to be written to screen.'),
+                              'expected-utility (ceeu) of after-tax income '
+                              'values for different '
+                              'constant-relative-risk-aversion parameter '
+                              'values, to be written to screen.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--dump',
                         help=('optional flag that causes OUTPUT to contain '
                               'all INPUT variables (possibly aged to TAXYEAR) '
-                              'and all calculated tax variables, where the '
-                              'variables are named using their internal '
+                              'and all calculated tax variables, where all '
+                              'the variables are named using their internal '
                               'Tax-Calculator names.'),
                         default=False,
                         action="store_true")
@@ -94,7 +98,12 @@ def main():
         sys.stderr.write('ERROR: cannot specify --ceeu without --reform\n')
         sys.stderr.write('USAGE: python tc.py --help\n')
         return 1
-    # instantiate TaxCalcIO object and do federal tax calculations
+    # check consistency of --exact and --graph options
+    if args.exact and args.graph:
+        sys.stderr.write('ERROR: cannot specify both --exact and --graph\n')
+        sys.stderr.write('USAGE: python tc.py --help\n')
+        return 1
+    # instantiate TaxCalcIO object and do STATIC tax analysis
     if args.INPUT.endswith('puf.csv') or args.INPUT.endswith('cps.csv'):
         aging_input = True
     else:
@@ -105,10 +114,10 @@ def main():
                      assump=args.assump,
                      aging_input_data=aging_input,
                      exact_calculations=args.exact)
-    tcio.calculate(writing_output_file=True,
-                   output_graph=args.graph,
-                   output_ceeu=args.ceeu,
-                   output_dump=args.dump)
+    tcio.static_analysis(writing_output_file=True,
+                         output_graph=args.graph,
+                         output_ceeu=args.ceeu,
+                         output_dump=args.dump)
     # return no-error exit code
     return 0
 # end of main function code

--- a/tc.py
+++ b/tc.py
@@ -48,8 +48,8 @@ def main():
                         default=False,
                         action="store_true")
     parser.add_argument('--graph',
-                        help=('optional flag that causes HTML graphs to be '
-                              'generated.'),
+                        help=('optional flag that causes graphs to be written '
+                              'to HTML files for viewing in browser.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--ceeu',
@@ -94,12 +94,6 @@ def main():
         sys.stderr.write('ERROR: cannot specify --ceeu without --reform\n')
         sys.stderr.write('USAGE: python tc.py --help\n')
         return 1
-
-    if args.graph:
-        sys.stderr.write('ERROR: --graph option not yet implemented\n')
-        sys.stderr.write('USAGE: python tc.py --help\n')
-        return 1
-
     # instantiate TaxCalcIO object and do federal tax calculations
     if args.INPUT.endswith('puf.csv') or args.INPUT.endswith('cps.csv'):
         aging_input = True
@@ -112,6 +106,7 @@ def main():
                      aging_input_data=aging_input,
                      exact_calculations=args.exact)
     tcio.calculate(writing_output_file=True,
+                   output_graph=args.graph,
                    output_ceeu=args.ceeu,
                    output_dump=args.dump)
     # return no-error exit code

--- a/tc.py
+++ b/tc.py
@@ -14,6 +14,7 @@ def main():
     """
     Contains STATIC command-line interface to Tax-Calculator TaxCalcIO class.
     """
+    # pylint: disable=too-many-return-statements
     # parse command-line arguments:
     parser = argparse.ArgumentParser(
         prog='python tc.py',
@@ -104,15 +105,13 @@ def main():
         sys.stderr.write('USAGE: python tc.py --help\n')
         return 1
     # instantiate TaxCalcIO object and do STATIC tax analysis
-    if args.INPUT.endswith('puf.csv') or args.INPUT.endswith('cps.csv'):
-        aging_input = True
-    else:
-        aging_input = False
+    aging = args.INPUT.endswith('puf.csv') or args.INPUT.endswith('cps.csv')
     tcio = TaxCalcIO(input_data=args.INPUT,
                      tax_year=args.TAXYEAR,
                      reform=args.reform,
                      assump=args.assump,
-                     aging_input_data=aging_input,
+                     growdiff_response=None,
+                     aging_input_data=aging,
                      exact_calculations=args.exact)
     tcio.static_analysis(writing_output_file=True,
                          output_graph=args.graph,


### PR DESCRIPTION
This pull request completes a series of enhancements to the `tc.py` command-line interface to Tax-Calculator operating under static tax analysis assumptions.  The focus of these enhancements has been to focus `tc.py` on static tax analysis (rather than on validation, which was its original purpose).  The earlier pull requests in this series include #1225 and #1228 and #1232 and #1234.

The drop in code coverage is caused by the fact that the 1991 alt data are so rough that they cannot be used in a test of the new `tc.py` `--graph` logic.  There is a commented-out test in `test_taxcalcio.py` that will be activated when we have more reasonable small-sample data for testing.  Presumably this will happen when the `cps.csv` (and its three associated data files) become available.  When that happens, the commented-out test will be activated and the six uncovered statements in `taxcalcio.py` will then be covered by the unit tests.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @GoFroggyRun @codykallen @zrisher 