### PR TITLE
Add experimental framework for dynamic tax analysis

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -193,19 +193,20 @@ class Records(object):
         self._read_data(data, exact_calculations)
         # check that three sets of split-earnings variables have valid values
         msg = 'expression "{0} == {0}p + {0}s" is not true for every record'
+        tol = 0.010001  # handles "%.2f" rounding error
         if not np.allclose(self.e00200, (self.e00200p + self.e00200s),
-                           rtol=0.0, atol=0.001):
+                           rtol=0.0, atol=tol):
             raise ValueError(msg.format('e00200'))
         if not np.allclose(self.e00900, (self.e00900p + self.e00900s),
-                           rtol=0.0, atol=0.001):
+                           rtol=0.0, atol=tol):
             raise ValueError(msg.format('e00900'))
         if not np.allclose(self.e02100, (self.e02100p + self.e02100s),
-                           rtol=0.0, atol=0.001):
+                           rtol=0.0, atol=tol):
             raise ValueError(msg.format('e02100'))
         # check that ordinary dividends are no less than qualified dividends
         other_dividends = np.maximum(0., self.e00600 - self.e00650)
         if not np.allclose(self.e00600, self.e00650 + other_dividends,
-                           rtol=0.0, atol=0.001):
+                           rtol=0.0, atol=tol):
             msg = 'expression "e00600 >= e00650" is not true for every record'
             raise ValueError(msg)
         # handle grow factors

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -62,15 +62,15 @@ def test_correct_Records_instantiation_sample(puf_1991, weights_1991):
 @pytest.mark.parametrize("csv", [
     (
         u'RECID,MARS,e00200,e00200p,e00200s\n'
-        u'1,    2,   200000, 200000,   0.01\n'
+        u'1,    2,   200000, 200000,   0.02\n'
     ),
     (
         u'RECID,MARS,e00900,e00900p,e00900s\n'
-        u'1,    2,   200000, 200000,   0.01\n'
+        u'1,    2,   200000, 200000,   0.02\n'
     ),
     (
         u'RECID,MARS,e02100,e02100p,e02100s\n'
-        u'1,    2,   200000, 200000,   0.01\n'
+        u'1,    2,   200000, 200000,   0.02\n'
     ),
     (
         u'RxCID,MARS\n'

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -23,15 +23,6 @@ RAWINPUTFILE_CONTENTS = (
 )
 
 
-EXPECTED_TO_STRING_OUTPUT = (  # from using RAWINPUTFILE_CONTENTS as input
-    'RECID  YEAR  WEIGHT  INCTAX  LSTAX  PAYTAX\n'
-    '    1  2021     0.0     0.0    0.0     0.0\n'
-    '    2  2021     0.0     0.0    0.0     0.0\n'
-    '    3  2021     0.0     0.0    0.0     0.0\n'
-    '    4  2021     0.0     0.0    0.0     0.0'  # no trailing EOL character
-)
-
-
 @pytest.yield_fixture
 def rawinputfile():
     """
@@ -56,7 +47,7 @@ def rawinputfile():
 ])
 def test_incorrect_creation_1(input_data, exact):
     """
-    Ensure a ValueError is raised when created with invalid data pointers
+    Ensure a ValueError is raised when created with invalid data pointers.
     """
     with pytest.raises(ValueError):
         TaxCalcIO(input_data=input_data,
@@ -71,7 +62,7 @@ def test_incorrect_creation_1(input_data, exact):
 @pytest.yield_fixture
 def reformfile0():
     """
-    specify JSON text for reform
+    Specify JSON reform file.
     """
     txt = """
     {
@@ -108,7 +99,7 @@ def reformfile0():
 ])
 def test_incorrect_creation_2(rawinputfile, reformfile0, year, ref, asm, gdr):
     """
-    Ensure a ValueError is raised when created with invalid parameters
+    Ensure a ValueError is raised when created with invalid parameters.
     """
     # pylint: disable=too-many-arguments
     if ref == 'reformfile0':
@@ -128,7 +119,7 @@ def test_incorrect_creation_2(rawinputfile, reformfile0, year, ref, asm, gdr):
 
 def test_creation_with_aging(rawinputfile, reformfile0):
     """
-    Test TaxCalcIO instantiation with no policy reform and with aging.
+    Test TaxCalcIO instantiation with/without no policy reform and with aging.
     """
     taxyear = 2021
     tcio = TaxCalcIO(input_data=rawinputfile.name,
@@ -150,23 +141,7 @@ def test_creation_with_aging(rawinputfile, reformfile0):
     assert tcio.tax_year() == taxyear
 
 
-def test_2(rawinputfile, reformfile0):
-    """
-    Test TaxCalcIO calculate method with no output writing and no aging.
-    """
-    taxyear = 2021
-    tcio = TaxCalcIO(input_data=rawinputfile.name,
-                     tax_year=taxyear,
-                     reform=reformfile0.name,
-                     assump=None,
-                     growdiff_response=None,
-                     aging_input_data=False,
-                     exact_calculations=False)
-    output = tcio.static_analysis()
-    assert output == EXPECTED_TO_STRING_OUTPUT
-
-
-REFORM_CONTENTS = """
+REFORM1_CONTENTS = """
 // Example of a reform file suitable for the read_json_param_files() function.
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
@@ -213,24 +188,7 @@ def reformfile1():
     Temporary reform file with .json extension.
     """
     rfile = tempfile.NamedTemporaryFile(suffix='.json', mode='a', delete=False)
-    rfile.write(REFORM_CONTENTS)
-    rfile.close()
-    # must close and then yield for Windows platform
-    yield rfile
-    if os.path.isfile(rfile.name):
-        try:
-            os.remove(rfile.name)
-        except OSError:
-            pass  # sometimes we can't remove a generated temporary file
-
-
-@pytest.yield_fixture
-def reformfile2():
-    """
-    Temporary reform file without .json extension.
-    """
-    rfile = tempfile.NamedTemporaryFile(suffix='.json', mode='a', delete=False)
-    rfile.write(REFORM_CONTENTS)
+    rfile.write(REFORM1_CONTENTS)
     rfile.close()
     # must close and then yield for Windows platform
     yield rfile
@@ -279,10 +237,9 @@ def assumpfile1():
             pass  # sometimes we can't remove a generated temporary file
 
 
-def test_3(rawinputfile, reformfile1, assumpfile1):
+def test_output_otions(rawinputfile, reformfile1, assumpfile1):
     """
-    Test TaxCalcIO calculate method with output writing but no aging,
-    using file name for TaxCalcIO constructor input_data.
+    Test TaxCalcIO output_ceeu & output_dump options when writing_output_file.
     """
     taxyear = 2021
     tcio = TaxCalcIO(input_data=rawinputfile.name,
@@ -295,8 +252,7 @@ def test_3(rawinputfile, reformfile1, assumpfile1):
     outfilepath = tcio.output_filepath()
     # --ceeu output and standard output
     try:
-        output = tcio.static_analysis(writing_output_file=True,
-                                      output_ceeu=True)
+        tcio.static_analysis(writing_output_file=True, output_ceeu=True)
     except:  # pylint: disable=bare-except
         if os.path.isfile(outfilepath):
             try:
@@ -306,8 +262,7 @@ def test_3(rawinputfile, reformfile1, assumpfile1):
         assert 'TaxCalcIO.calculate(ceeu)_ok' == 'no'
     # --dump output
     try:
-        output = tcio.static_analysis(writing_output_file=True,
-                                      output_dump=True)
+        tcio.static_analysis(writing_output_file=True, output_dump=True)
     except:  # pylint: disable=bare-except
         if os.path.isfile(outfilepath):
             try:
@@ -315,39 +270,18 @@ def test_3(rawinputfile, reformfile1, assumpfile1):
             except OSError:
                 pass  # sometimes we can't remove a generated temporary file
         assert 'TaxCalcIO.calculate(dump)_ok' == 'no'
-    # if tries were successful, try to remove the output files
+    # if tries were successful, try to remove the output file
     if os.path.isfile(outfilepath):
         try:
             os.remove(outfilepath)
         except OSError:
             pass  # sometimes we can't remove a generated temporary file
-    # check that output is empty string (because output was written to file)
-    assert output == ''
 
 
-def test_4(reformfile2, assumpfile1):
-    """
-    Test TaxCalcIO calculate method with no output writing and no aging,
-    using DataFrame for TaxCalcIO constructor input_data.
-    """
-    input_stream = StringIO(RAWINPUTFILE_CONTENTS)
-    input_dataframe = pd.read_csv(input_stream)
-    taxyear = 2021
-    tcio = TaxCalcIO(input_data=input_dataframe,
-                     tax_year=taxyear,
-                     reform=reformfile2.name,
-                     assump=assumpfile1.name,
-                     growdiff_response=None,
-                     aging_input_data=False,
-                     exact_calculations=False)
-    output = tcio.static_analysis()
-    assert output == EXPECTED_TO_STRING_OUTPUT
-
-
-# skip test_5 until have a more realistic sample to replace puf_1991
-# def test_5(puf_1991, reformfile1):
+# skip test_graph until have a more realistic sample to replace puf_1991
+# def test_graph(puf_1991, reformfile1):
 #     #
-#     Test TaxCalcIO calculate method with output writing but no aging,
+#     Test TaxCalcIO with output_graph
 #     using file name for TaxCalcIO constructor input_data and writing
 #     --graph output.
 #     #
@@ -358,37 +292,9 @@ def test_4(reformfile2, assumpfile1):
 #                      growdiff_response=None,
 #                      aging_input_data=False,
 #                      exact_calculations=False)
-#     output = tcio.static_analysis(writing_output_file=False,
-#                                   output_graph=True)
+#     tcio.static_analysis(writing_output_file=False,
+#                          output_graph=True)
 #     # cleanup html files
-#     assert output != ''
-
-
-def test_6(rawinputfile):
-    """
-    Test TaxCalcIO calculate method with no output writing and no aging and
-    no reform, using the --dump option.
-    """
-    taxyear = 2021
-    tcio = TaxCalcIO(input_data=rawinputfile.name,
-                     tax_year=taxyear,
-                     reform=None,
-                     assump=None,
-                     growdiff_response=None,
-                     aging_input_data=False,
-                     exact_calculations=False)
-    output = tcio.static_analysis(writing_output_file=False, output_dump=True)
-    assert len(output) > 5000
-    assert tcio.tax_year() == taxyear
-
-
-LUMPSUM_REFORM_CONTENTS = """
-{
-  "policy": {
-    "_LST": {"2013": [200]}
-  }
-}
-"""
 
 
 @pytest.yield_fixture
@@ -397,7 +303,12 @@ def lumpsumreformfile():
     Temporary reform file without .json extension.
     """
     rfile = tempfile.NamedTemporaryFile(suffix='.json', mode='a', delete=False)
-    rfile.write(LUMPSUM_REFORM_CONTENTS)
+    lumpsum_reform_contents = """
+    {
+    "policy": {"_LST": {"2013": [200]}}
+    }
+    """
+    rfile.write(lumpsum_reform_contents)
     rfile.close()
     # must close and then yield for Windows platform
     yield rfile
@@ -408,25 +319,13 @@ def lumpsumreformfile():
             pass  # sometimes we can't remove a generated temporary file
 
 
-def test_7(reformfile1, lumpsumreformfile):
+def test_ceeu_output(lumpsumreformfile):
     """
     Test TaxCalcIO calculate method with no output writing using ceeu option.
     """
     taxyear = 2020
     recdict = {'RECID': 1, 'MARS': 1, 'e00300': 100000, 's006': 1e8}
     recdf = pd.DataFrame(data=recdict, index=[0])
-
-    tcio = TaxCalcIO(input_data=recdf,
-                     tax_year=taxyear,
-                     reform=reformfile1.name,
-                     assump=None,
-                     growdiff_response=None,
-                     aging_input_data=False,
-                     exact_calculations=False)
-    output = tcio.static_analysis(writing_output_file=False, output_ceeu=True)
-    assert tcio.tax_year() == taxyear
-    assert len(output) > 0
-
     tcio = TaxCalcIO(input_data=recdf,
                      tax_year=taxyear,
                      reform=lumpsumreformfile.name,
@@ -434,39 +333,8 @@ def test_7(reformfile1, lumpsumreformfile):
                      growdiff_response=None,
                      aging_input_data=False,
                      exact_calculations=False)
-    output = tcio.static_analysis(writing_output_file=False, output_ceeu=True)
+    tcio.static_analysis(writing_output_file=False, output_ceeu=True)
     assert tcio.tax_year() == taxyear
-    assert len(output) > 0
-
-
-BAD1_ASSUMP_CONTENTS = """
-{
-  "consumption": {
-  },
-  "behavior": {
-      "_BE_sub": {"2020": [0.05]}
-  },
-  "growdiff_baseline": {
-  },
-  "growdiff_response": {
-  }
-}
-"""
-
-
-BAD2_ASSUMP_CONTENTS = """
-{
-  "consumption": {
-  },
-  "behavior": {
-  },
-  "growdiff_baseline": {
-  },
-  "growdiff_response": {
-      "_ABOOK": {"2015": [-0.01]}
-  }
-}
-"""
 
 
 @pytest.yield_fixture
@@ -475,7 +343,15 @@ def assumpfile_bad1():
     Temporary assumption file with .json extension.
     """
     afile = tempfile.NamedTemporaryFile(suffix='.json', mode='a', delete=False)
-    afile.write(BAD1_ASSUMP_CONTENTS)
+    bad1_assump_contents = """
+    {
+    "consumption": {},
+    "behavior": {"_BE_sub": {"2020": [0.05]}},
+    "growdiff_baseline": {},
+    "growdiff_response": {}
+    }
+    """
+    afile.write(bad1_assump_contents)
     afile.close()
     # must close and then yield for Windows platform
     yield afile
@@ -492,7 +368,15 @@ def assumpfile_bad2():
     Temporary assumption file with .json extension.
     """
     afile = tempfile.NamedTemporaryFile(suffix='.json', mode='a', delete=False)
-    afile.write(BAD2_ASSUMP_CONTENTS)
+    bad2_assump_contents = """
+    {
+    "consumption": {},
+    "behavior": {},
+    "growdiff_baseline": {},
+    "growdiff_response": {"_ABOOK": {"2015": [-0.01]}}
+    }
+    """
+    afile.write(bad2_assump_contents)
     afile.close()
     # must close and then yield for Windows platform
     yield afile
@@ -503,7 +387,7 @@ def assumpfile_bad2():
             pass  # sometimes we can't remove a generated temporary file
 
 
-def test_9(reformfile2, assumpfile_bad1, assumpfile_bad2):
+def test_bad_assumption_file(reformfile1, assumpfile_bad1, assumpfile_bad2):
     """
     Test TaxCalcIO constructor with illegal assumptions.
     """
@@ -513,7 +397,7 @@ def test_9(reformfile2, assumpfile_bad1, assumpfile_bad2):
     with pytest.raises(ValueError):
         TaxCalcIO(input_data=input_dataframe,
                   tax_year=taxyear,
-                  reform=reformfile2.name,
+                  reform=reformfile1.name,
                   assump=assumpfile_bad1.name,
                   growdiff_response=None,
                   aging_input_data=False,
@@ -521,8 +405,26 @@ def test_9(reformfile2, assumpfile_bad1, assumpfile_bad2):
     with pytest.raises(ValueError):
         TaxCalcIO(input_data=input_dataframe,
                   tax_year=taxyear,
-                  reform=reformfile2.name,
+                  reform=reformfile1.name,
                   assump=assumpfile_bad2.name,
                   growdiff_response=None,
                   aging_input_data=False,
                   exact_calculations=False)
+
+
+def test_dynamic_analysis(reformfile1, assumpfile1):
+    """
+    Test TaxCalcIO.dynamic_analysis method with no output.
+    """
+    taxyear = 2015
+    recdict = {'RECID': 1, 'MARS': 1, 'e00300': 100000, 's006': 1e8}
+    recdf = pd.DataFrame(data=recdict, index=[0])
+    try:
+        TaxCalcIO.dynamic_analysis(input_data=recdf,
+                                   tax_year=taxyear,
+                                   reform=reformfile1.name,
+                                   assump=assumpfile1.name,
+                                   aging_input_data=False,
+                                   exact_calculations=False)
+    except:  # pylint: disable=bare-except
+        assert 'TaxCalcIO.dynamic_analysis_ok' == 'no'

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -110,6 +110,7 @@ def test_incorrect_creation_2(rawinputfile, reformfile0, year, ref, asm, gdr):
     """
     Ensure a ValueError is raised when created with invalid parameters
     """
+    # pylint: disable=too-many-arguments
     if ref == 'reformfile0':
         reform = reformfile0.name
     else:

--- a/tcdyn.py
+++ b/tcdyn.py
@@ -104,7 +104,7 @@ def main():
         sys.stderr.write('ERROR: cannot specify both --exact and --graph\n')
         sys.stderr.write('USAGE: python tcdyn.py --help\n')
         return 1
-    # do DYNANIC tax analysis
+    # do DYNAMIC tax analysis
     aging = args.INPUT.endswith('puf.csv') or args.INPUT.endswith('cps.csv')
     TaxCalcIO.dynamic_analysis(input_data=args.INPUT,
                                tax_year=args.TAXYEAR,

--- a/tcdyn.py
+++ b/tcdyn.py
@@ -1,0 +1,126 @@
+"""
+Command-line interface to Tax-Calculator for DYNAMIC tax analysis.
+"""
+# CODING-STYLE CHECKS:
+# pep8 --ignore=E402 tcdyn.py
+# pylint --disable=locally-disabled tcdyn.py
+
+import argparse
+import sys
+from taxcalc import TaxCalcIO
+
+
+def main():
+    """
+    Contains DYNAMIC command-line interface to Tax-Calculator TaxCalcIO class.
+    """
+    # pylint: disable=too-many-return-statements
+    # parse command-line arguments:
+    parser = argparse.ArgumentParser(
+        prog='python tcdyn.py',
+        description=('Writes to a file the federal income and payroll tax '
+                     'OUTPUT for each filing unit specified in the INPUT '
+                     'file, with the OUTPUT computed from the INPUT for the '
+                     'TAXYEAR using Tax-Calculator operating under DYNAMIC '
+                     'analysis assumptions. The OUTPUT file is a '
+                     'CSV-formatted file that contains tax information for '
+                     'each INPUT filing unit.'))
+    parser.add_argument('INPUT', nargs='?',
+                        help=('INPUT is name of CSV-formatted file that '
+                              'contains for each filing unit variables used '
+                              'to compute taxes for TAXYEAR.'),
+                        default='')
+    parser.add_argument('TAXYEAR', nargs='?',
+                        help=('TAXYEAR is calendar year for which taxes '
+                              'are computed.'),
+                        type=int,
+                        default=0)
+    parser.add_argument('--reform',
+                        help=('REFORM is name of optional JSON reform file. '
+                              'No --reform implies use of current-law '
+                              'policy.'),
+                        default=None)
+    parser.add_argument('--assump',
+                        help=('ASSUMP is name of optional JSON economic '
+                              'assumption file.  No --assump implies use of '
+                              'static analysis assumptions.'),
+                        default=None)
+    parser.add_argument('--exact',
+                        help=('optional flag that suppresses the smoothing of '
+                              '"stair-step" provisions in the tax law that '
+                              'complicate marginal-tax-rate calculations.'),
+                        default=False,
+                        action="store_true")
+    parser.add_argument('--graph',
+                        help=('optional flag that causes graphs to be written '
+                              'to HTML files for viewing in browser.'),
+                        default=False,
+                        action="store_true")
+    parser.add_argument('--ceeu',
+                        help=('optional flag that causes normative welfare '
+                              'statistics, including certainty-equivalent '
+                              'expected-utility (ceeu) of after-tax income '
+                              'values for different '
+                              'constant-relative-risk-aversion parameter '
+                              'values, to be written to screen.'),
+                        default=False,
+                        action="store_true")
+    parser.add_argument('--dump',
+                        help=('optional flag that causes OUTPUT to contain '
+                              'all INPUT variables (possibly aged to TAXYEAR) '
+                              'and all calculated tax variables, where all '
+                              'the variables are named using their internal '
+                              'Tax-Calculator names.'),
+                        default=False,
+                        action="store_true")
+    args = parser.parse_args()
+    # check INPUT file name
+    if args.INPUT == '':
+        sys.stderr.write('ERROR: must specify INPUT file name;\n')
+        sys.stderr.write('USAGE: python tcdyn.py --help\n')
+        return 1
+    # check TAXYEAR value
+    if args.TAXYEAR == 0:
+        sys.stderr.write('ERROR: must specify TAXYEAR >= 2013;\n')
+        sys.stderr.write('USAGE: python tcdyn.py --help\n')
+        return 1
+    # check that --reform option used
+    if not args.reform:
+        sys.stderr.write('ERROR: must use --reform\n')
+        sys.stderr.write('USAGE: python tcdyn.py --help\n')
+        return 1
+    # check consistency of --reform and --graph options
+    if args.graph and not args.reform:
+        sys.stderr.write('ERROR: cannot specify --graph without --reform\n')
+        sys.stderr.write('USAGE: python tcdyn.py --help\n')
+        return 1
+    # check consistency of --reform and --ceeu options
+    if args.ceeu and not args.reform:
+        sys.stderr.write('ERROR: cannot specify --ceeu without --reform\n')
+        sys.stderr.write('USAGE: python tcdyn.py --help\n')
+        return 1
+    # check consistency of --exact and --graph options
+    if args.exact and args.graph:
+        sys.stderr.write('ERROR: cannot specify both --exact and --graph\n')
+        sys.stderr.write('USAGE: python tcdyn.py --help\n')
+        return 1
+    # do DYNANIC tax analysis
+    aging = args.INPUT.endswith('puf.csv') or args.INPUT.endswith('cps.csv')
+    TaxCalcIO.dynamic_analysis(input_data=args.INPUT,
+                               tax_year=args.TAXYEAR,
+                               reform=args.reform,
+                               assump=args.assump,
+                               aging_input_data=aging,
+                               exact_calculations=args.exact,
+                               # extra parameters go here
+                               writing_output_file=True,
+                               output_graph=args.graph,
+                               output_ceeu=args.ceeu,
+                               output_dump=args.dump)
+    # return no-error exit code
+    return 0
+# end of main function code
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This pull request adds to the TaxCalcIO class an initial version of a dynamic_analysis() static method and also adds the `tcdyn.py` script, a command-line interface to the TaxCalcIO.dynamic_analysis() method, which is analogous to the `tc.py` script that does static tax analysis.

This is the first of many experimental enhancements that have the goal of adding to Tax-Calculator a simple, self-contained, macroeconomic growth model that can be used to conduct dynamic tax analysis.  The goal of this experiment is be able to support dynamic tax analysis that is roughly similar to that used by CBO as described in Appendix A of [this
document](https://www.cbo.gov/sites/default/files/114th-congress-2015-2016/reports/51625-EconomicAPB.pdf).  The goal is to go beyond current CBO practice and have the growth model results feedback to the individuals in the Tax-Calculator.  As best as I can tell, none of the tax models in Washington have this sort of feedback.

The goal of these enhancements is not to replace the OG-USA model, which is far more complex.  Rather the goal is to provide a much simpler dynamic analysis capability while OG-USA development continues.  Note that the feedback capability described above is also a goal of the OG-USA project as can be seen in [this short note](https://github.com/open-source-economics/OG-USA/blob/master/Model%20Writeup/Integrating_Micro_Macro.pdf).

The current pull request provides the framework within which the experimental development will proceed.  The main focus of future work will be to add a GrowModel class and two-way linkages between the microsimulation model and the aggregate growth model.  The GrowModel class will be able to accept aggregated TaxCalcIO results and will be able to provide reform Growdiff feedback to the reform Calculator object in the TaxCalcIO object.

In this pull request the absence of a GrowModel object means that the recursive dynamic analysis currently produces exactly the same results as does static analysis (because the growdiff_response parameters for each year are all zero).

@MattHJensen @rickecon @jdebacker @feenberg @Amy-Xu @andersonfrailey
@codykallen @zrisher  @GoFroggyRun 

