### PR TITLE
Add test of graphing with TaxCalcIO class

### DIFF
--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -292,17 +292,17 @@ class TaxCalcIO(object):
             outdf.to_csv(self._output_filename, index=False,
                          float_format='%.2f')
         # optionally write --graph output to HTML files
-        atr_fname = self._output_filename.replace('.csv', '-atr.html')
-        atr_title = 'ATR by Income Percentile'
-        mtr_fname = self._output_filename.replace('.csv', '-mtr.html')
-        mtr_title = 'MTR by Income Percentile'
         if output_graph:
             atr_data = atr_graph_data(self._calc_clp, self._calc)
             atr_plot = xtr_graph_plot(atr_data)
+            atr_fname = self._output_filename.replace('.csv', '-atr.html')
+            atr_title = 'ATR by Income Percentile'
             write_graph_file(atr_plot, atr_fname, atr_title)
             mtr_data = mtr_graph_data(self._calc_clp, self._calc,
                                       alt_e00200p_text='Taxpayer Earnings')
             mtr_plot = xtr_graph_plot(mtr_data)
+            mtr_fname = self._output_filename.replace('.csv', '-mtr.html')
+            mtr_title = 'MTR by Income Percentile'
             write_graph_file(mtr_plot, mtr_fname, mtr_title)
         # optionally write --ceeu output to stdout
         if ceeu_results:

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -301,14 +301,14 @@ def test_graph(reformfile1):
                      exact_calculations=False)
     tcio.static_analysis(writing_output_file=False,
                          output_graph=True)
-    # confirm existence of graph files and then delete
+    # delete graph files
     output_filename = tcio.output_filepath()
-    atr_fname = output_filename.replace('.csv', '-atr.html')
-    mtr_fname = output_filename.replace('.csv', '-mtr.html')
-    assert os.path.isfile(atr_fname)
-    assert os.path.isfile(mtr_fname)
-    os.remove(atr_fname)
-    os.remove(mtr_fname)
+    fname = output_filename.replace('.csv', '-atr.html')
+    if os.path.isfile(fname):
+        os.remove(fname)
+    fname = output_filename.replace('.csv', '-mtr.html')
+    if os.path.isfile(fname):
+        os.remove(fname)
 
 
 @pytest.yield_fixture

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -278,23 +278,37 @@ def test_output_otions(rawinputfile, reformfile1, assumpfile1):
             pass  # sometimes we can't remove a generated temporary file
 
 
-# skip test_graph until have a more realistic sample to replace puf_1991
-# def test_graph(puf_1991, reformfile1):
-#     #
-#     Test TaxCalcIO with output_graph
-#     using file name for TaxCalcIO constructor input_data and writing
-#     --graph output.
-#     #
-#     tcio = TaxCalcIO(input_data=puf_1991,
-#                      tax_year=2016,
-#                      reform=reformfile1.name,
-#                      assump=None,
-#                      growdiff_response=None,
-#                      aging_input_data=False,
-#                      exact_calculations=False)
-#     tcio.static_analysis(writing_output_file=False,
-#                          output_graph=True)
-#     # cleanup html files
+def test_graph(reformfile1):
+    """
+    Test TaxCalcIO with output_graph=True.
+    """
+    # create graphable input
+    nobs = 100
+    idict = dict()
+    idict['RECID'] = [i for i in range(1, nobs + 1)]
+    idict['MARS'] = [2 for i in range(1, nobs + 1)]
+    idict['s006'] = [10.0 for i in range(1, nobs + 1)]
+    idict['e00300'] = [10000 * i for i in range(1, nobs + 1)]
+    idict['_expanded_income'] = idict['e00300']
+    idf = pd.DataFrame(idict, columns=list(idict))
+    # create TaxCalcIO graph files
+    tcio = TaxCalcIO(input_data=idf,
+                     tax_year=2020,
+                     reform=reformfile1.name,
+                     assump=None,
+                     growdiff_response=None,
+                     aging_input_data=False,
+                     exact_calculations=False)
+    tcio.static_analysis(writing_output_file=False,
+                         output_graph=True)
+    # confirm existence of graph files and then delete
+    output_filename = tcio.output_filepath()
+    atr_fname = output_filename.replace('.csv', '-atr.html')
+    mtr_fname = output_filename.replace('.csv', '-mtr.html')
+    assert os.path.isfile(atr_fname)
+    assert os.path.isfile(mtr_fname)
+    os.remove(atr_fname)
+    os.remove(mtr_fname)
 
 
 @pytest.yield_fixture


### PR DESCRIPTION
This pull request activates a test in the `test_taxcalcio.py` file that checks the generation of average and marginal tax rate graphs in HTML files.  Activating this test reduces the number of untested statements in the taxcalc package from 26 to 20.  Most of the remaining untested statements are related to reading data from an egg.

This pull request makes no changes in tax logic, and hence, test results are unchanged.
