### PR TITLE
Streamline read_egg_csv utility, test it and standardize its use

### DIFF
--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -57,8 +57,7 @@ class Growfactors(object):
             if os.path.isfile(growfactors_filename):
                 gfdf = pd.read_csv(growfactors_filename, index_col='YEAR')
             else:
-                gfdf = read_egg_csv('blowup_factors',
-                                    Growfactors.FILENAME, index_col='YEAR')
+                gfdf = read_egg_csv(Growfactors.FILENAME, index_col='YEAR')
         else:
             raise ValueError('growfactors_filename is not a string')
         # check validity of gfdf column names

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -488,7 +488,7 @@ class Records(object):
             if os.path.isfile(adjust_ratios):
                 ADJ = pd.read_csv(adjust_ratios, index_col=0)
             else:
-                ADJ = read_egg_csv(Records.ADJUST_RATIOS_FILENAME)
+                ADJ = read_egg_csv(Records.ADJUST_RATIOS_FILENAME, index_col=0)
             ADJ = ADJ.transpose()
         else:
             msg = ('adjust_ratios is not None or a string'

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -467,7 +467,7 @@ class Records(object):
             if os.path.isfile(weights):
                 WT = pd.read_csv(weights)
             else:
-                WT = read_egg_csv('weights', Records.WEIGHTS_FILENAME)
+                WT = read_egg_csv(Records.WEIGHTS_FILENAME)
         else:
             msg = 'weights is not None or a string or a Pandas DataFrame'
             raise ValueError(msg)
@@ -488,8 +488,7 @@ class Records(object):
             if os.path.isfile(adjust_ratios):
                 ADJ = pd.read_csv(adjust_ratios, index_col=0)
             else:
-                ADJ = Records._read_egg_csv('adjust_ratios',
-                                            Records.ADJUST_RATIOS_FILENAME)
+                ADJ = read_egg_csv(Records.ADJUST_RATIOS_FILENAME)
             ADJ = ADJ.transpose()
         else:
             msg = ('adjust_ratios is not None or a string'

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 import numpy.testing as npt
 from pandas import DataFrame, Series
 from pandas.util.testing import assert_series_equal
-from taxcalc import Policy, Records, Behavior, Calculator
+from taxcalc import Policy, Records, Behavior, Calculator, Growfactors
 from taxcalc.utils import *
 
 data = [[1.0, 2, 'a'],
@@ -794,6 +794,11 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     with pytest.raises(ValueError):
         ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True,
                            custom_params=params)
+
+
+def test_read_egg_csv():
+    with pytest.raises(ValueError):
+        vdf = read_egg_csv('bad_filename')
 
 
 def test_create_and_delete_temporary_file():

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 import numpy.testing as npt
 from pandas import DataFrame, Series
 from pandas.util.testing import assert_series_equal
-from taxcalc import Policy, Records, Behavior, Calculator, Growfactors
+from taxcalc import Policy, Records, Behavior, Calculator
 from taxcalc.utils import *
 
 data = [[1.0, 2, 'a'],

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -13,7 +13,7 @@ import copy
 import json
 import random
 from collections import defaultdict, OrderedDict
-from pkg_resources import resource_stream, Requirement, DistributionNotFound
+from pkg_resources import resource_stream, Requirement
 import six
 import numpy as np
 import pandas as pd
@@ -1358,21 +1358,18 @@ def ce_aftertax_income(calc1, calc2,
     return cedict
 
 
-def read_egg_csv(vname, fpath, **kwargs):
+def read_egg_csv(fname, **kwargs):
     """
-    Read csv file with fpath containing vname data from EGG and
-    return dict of vname data.
+    Read from egg the csv file named fname that contains csv data and
+    return pandas DataFrame containing the data.
     """
     try:
-        # grab vname data from EGG distribution
-        path_in_egg = os.path.join('taxcalc', fpath)
-        vname_fname = resource_stream(
-            Requirement.parse('taxcalc'), path_in_egg)
-        vname_dict = pd.read_csv(vname_fname, **kwargs)
-    except (DistributionNotFound, IOError):
-        msg = 'could not read {} file from EGG'
-        raise ValueError(msg.format(vname))
-    return vname_dict
+        path_in_egg = os.path.join('taxcalc', fname)
+        vdf = pd.read_csv(resource_stream(Requirement.parse('taxcalc'),
+                                          path_in_egg), **kwargs)
+    except:  # pylint: disable=bare-except
+        raise ValueError('could not read {} data from egg'.format(fname))
+    return vdf
 
 
 def temporary_filename(suffix=''):


### PR DESCRIPTION
The intention of this pull request was to make non-substantive changes in the `read_egg_csv` utility function and to add a test that would increase code coverage.  I have done all that and now the number of untested statements has been reduced from 20 to 13.

However, while doing this work I discovered a substantive problem in the `records.py` file.  This problem, which will affect only TaxBrain, has gone undetected because we don't have any affirmative tests of egg-reading logic.  Before this pull request, the following statement was in the `records.py` file:
```
            if os.path.isfile(adjust_ratios):
                ADJ = pd.read_csv(adjust_ratios, index_col=0)
            else:
                ADJ = Records._read_egg_csv('adjust_ratios',
                                            Records.ADJUST_RATIOS_FILENAME)
```
The problem is that there is no `_read_egg_csv` function in the Records class.  This if-then-else statement has been change to call the `read_egg_csv` utility function:
```
             if os.path.isfile(adjust_ratios):
                 ADJ = pd.read_csv(adjust_ratios, index_col=0)
             else:
                 ADJ = read_egg_csv(Records.ADJUST_RATIOS_FILENAME, index_col=0)
```
