### PR TITLE
Add read_egg_json utility function and add limited test of that function

### DIFF
--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -57,8 +57,7 @@ class Growfactors(object):
             if os.path.isfile(growfactors_filename):
                 gfdf = pd.read_csv(growfactors_filename, index_col='YEAR')
             else:
-                gfdf = read_egg_csv('blowup_factors',
-                                    Growfactors.FILENAME, index_col='YEAR')
+                gfdf = read_egg_csv(Growfactors.FILENAME, index_col='YEAR')
         else:
             raise ValueError('growfactors_filename is not a string')
         # check validity of gfdf column names

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -3,9 +3,10 @@ Tax-Calculator abstract base parameters class.
 """
 import os
 import json
-import numpy as np
 from abc import ABCMeta
 from collections import OrderedDict
+import numpy as np
+from taxcalc.utils import read_egg_json
 
 
 class ParametersBase(object):

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -213,7 +213,7 @@ class ParametersBase(object):
             containing complete contents of DEFAULTS_FILENAME file.
         """
         if cls.DEFAULTS_FILENAME is None:
-            msg = 'DEFAULTS_FILENAME must be overrriden by inheriting class'
+            msg = 'DEFAULTS_FILENAME must be overridden by inheriting class'
             raise NotImplementedError(msg)
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                             cls.DEFAULTS_FILENAME)
@@ -221,12 +221,7 @@ class ParametersBase(object):
             with open(path) as pfile:
                 params_dict = json.load(pfile, object_pairs_hook=OrderedDict)
         else:
-            from pkg_resources import resource_stream, Requirement
-            path_in_egg = os.path.join('taxcalc', cls.DEFAULTS_FILENAME)
-            buf = resource_stream(Requirement.parse('taxcalc'), path_in_egg)
-            as_bytes = buf.read()
-            as_string = as_bytes.decode("utf-8")
-            params_dict = json.loads(as_string, object_pairs_hook=OrderedDict)
+            params_dict = read_egg_json(cls.DEFAULTS_FILENAME)
         return params_dict
 
     def _update(self, year_mods):

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -488,7 +488,7 @@ class Records(object):
             if os.path.isfile(adjust_ratios):
                 ADJ = pd.read_csv(adjust_ratios, index_col=0)
             else:
-                ADJ = read_egg_csv(Records.ADJUST_RATIOS_FILENAME)
+                ADJ = read_egg_csv(Records.ADJUST_RATIOS_FILENAME, index_col=0)
             ADJ = ADJ.transpose()
         else:
             msg = ('adjust_ratios is not None or a string'

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -467,7 +467,7 @@ class Records(object):
             if os.path.isfile(weights):
                 WT = pd.read_csv(weights)
             else:
-                WT = read_egg_csv('weights', Records.WEIGHTS_FILENAME)
+                WT = read_egg_csv(Records.WEIGHTS_FILENAME)
         else:
             msg = 'weights is not None or a string or a Pandas DataFrame'
             raise ValueError(msg)
@@ -488,8 +488,7 @@ class Records(object):
             if os.path.isfile(adjust_ratios):
                 ADJ = pd.read_csv(adjust_ratios, index_col=0)
             else:
-                ADJ = Records._read_egg_csv('adjust_ratios',
-                                            Records.ADJUST_RATIOS_FILENAME)
+                ADJ = read_egg_csv(Records.ADJUST_RATIOS_FILENAME)
             ADJ = ADJ.transpose()
         else:
             msg = ('adjust_ratios is not None or a string'

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 import numpy.testing as npt
 from pandas import DataFrame, Series
 from pandas.util.testing import assert_series_equal
-from taxcalc import Policy, Records, Behavior, Calculator
+from taxcalc import Policy, Records, Behavior, Calculator, Growfactors
 from taxcalc.utils import *
 
 data = [[1.0, 2, 'a'],
@@ -794,6 +794,11 @@ def test_ce_aftertax_income(puf_1991, weights_1991):
     with pytest.raises(ValueError):
         ce_aftertax_income(calc1, calc2, require_no_agg_tax_change=True,
                            custom_params=params)
+
+
+def test_read_egg_csv():
+    with pytest.raises(ValueError):
+        vdf = read_egg_csv('bad_filename')
 
 
 def test_create_and_delete_temporary_file():

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -801,6 +801,11 @@ def test_read_egg_csv():
         vdf = read_egg_csv('bad_filename')
 
 
+def test_read_egg_json():
+    with pytest.raises(ValueError):
+        pdict = read_egg_json('bad_filename')
+
+
 def test_create_and_delete_temporary_file():
     # test temporary_filename() and delete_file() functions
     fname = temporary_filename()

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 import numpy.testing as npt
 from pandas import DataFrame, Series
 from pandas.util.testing import assert_series_equal
-from taxcalc import Policy, Records, Behavior, Calculator, Growfactors
+from taxcalc import Policy, Records, Behavior, Calculator
 from taxcalc.utils import *
 
 data = [[1.0, 2, 'a'],

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -13,7 +13,7 @@ import copy
 import json
 import random
 from collections import defaultdict, OrderedDict
-from pkg_resources import resource_stream, Requirement, DistributionNotFound
+from pkg_resources import resource_stream, Requirement
 import six
 import numpy as np
 import pandas as pd
@@ -1358,21 +1358,18 @@ def ce_aftertax_income(calc1, calc2,
     return cedict
 
 
-def read_egg_csv(vname, fpath, **kwargs):
+def read_egg_csv(fname, **kwargs):
     """
-    Read csv file with fpath containing vname data from EGG and
-    return dict of vname data.
+    Read from egg the csv file named fname that contains csv data and
+    return pandas DataFrame containing the data.
     """
     try:
-        # grab vname data from EGG distribution
-        path_in_egg = os.path.join('taxcalc', fpath)
-        vname_fname = resource_stream(
-            Requirement.parse('taxcalc'), path_in_egg)
-        vname_dict = pd.read_csv(vname_fname, **kwargs)
-    except (DistributionNotFound, IOError):
-        msg = 'could not read {} file from EGG'
-        raise ValueError(msg.format(vname))
-    return vname_dict
+        path_in_egg = os.path.join('taxcalc', fname)
+        vdf = pd.read_csv(resource_stream(Requirement.parse('taxcalc'),
+                                          path_in_egg), **kwargs)
+    except:  # pylint: disable=bare-except
+        raise ValueError('could not read {} data from egg'.format(fname))
+    return vdf
 
 
 def temporary_filename(suffix=''):

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1360,7 +1360,7 @@ def ce_aftertax_income(calc1, calc2,
 
 def read_egg_csv(fname, **kwargs):
     """
-    Read from egg the csv file named fname that contains csv data and
+    Read from egg the file named fname that contains CSV data and
     return pandas DataFrame containing the data.
     """
     try:
@@ -1370,6 +1370,21 @@ def read_egg_csv(fname, **kwargs):
     except:  # pylint: disable=bare-except
         raise ValueError('could not read {} data from egg'.format(fname))
     return vdf
+
+
+def read_egg_json(fname):
+    """
+    Read from egg the file named fname that contains JSON data and
+    return dictionary containing the data.
+    """
+    try:
+        path_in_egg = os.path.join('taxcalc', fname)
+        pdict = json.loads(resource_stream(Requirement.parse('taxcalc'),
+                                           path_in_egg).read().decode('utf-8'),
+                           object_pairs_hook=OrderedDict)
+    except:  # pylint: disable=bare-except
+        raise ValueError('could not read {} data from egg'.format(fname))
+    return pdict
 
 
 def temporary_filename(suffix=''):


### PR DESCRIPTION
The purpose of this pull request is to move some untested code in the `ParametersBase._params_dict_from_json_file` function into a new utility function so that it can be tested more easily.  After adding a non-affirmative test of the new `read_egg_json` utility function, the number of untested statements in the taxcalc package has been reduced from 13 to 9.

Of the remaining 9 untested statements, 6 are untested because we have not been able to figure out how to write a test that actually reads a file from an egg.  Two other untested statements are related to uncertainty about whether the `bokeh` graphing package is available.  And the final untested statement is buried deep in the `ParametersBase.expand_2D` function: an else statement is never executed in the py.test unit test suite.  It is not clear if this non-execution is a shortcoming of the test suite or if that statement is unreachable in all cases.