### PR TITLE
initial implementation of charitable giving elasticity

### DIFF
--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -31,8 +31,8 @@
 
     "_BE_charity_itemizers": {
         "start_year": 2013,
-        "long_name": "Elasticity of charitable contributions for itemizers",
-        "description": "Defined as proportional change in charitable giving divided by proportional change in marginal net-of-tax-rate (1-MTR) on charitable giving caused by the reform. Must be zero or positive.",
+        "long_name": "Elasticity of cash charitable contributions for itemizers",
+        "description": "Defined as proportional change in cash charitable contributions divided by proportional change in marginal net-of-tax-rate (1-MTR) on cash charitable contributions caused by the reform. Must be zero or positive.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0],
@@ -41,8 +41,8 @@
 
     "_BE_charity_non_itemizers": {
         "start_year": 2013,
-        "long_name": "Elasticity of charitable contributions for non-itemizers",
-        "description": "Defined as proportional change in charitable giving divided by proportional change in marginal net-of-tax-rate (1-MTR) on charitable giving caused by the reform. Must be zero or positive.",
+        "long_name": "Elasticity of cash charitable contributions for non-itemizers",
+        "description": "Defined as proportional change in cash charitable contributions divided by proportional change in marginal net-of-tax-rate (1-MTR) on cash charitable contributions caused by the reform. Must be zero or positive.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0],

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -31,8 +31,8 @@
 
     "_BE_charity_itemizers": {
         "start_year": 2013,
-        "long_name": "Elasticity of cash charitable contributions for itemizers",
-        "description": "Defined as proportional change in cash charitable contributions divided by proportional change in the after-tax price of cash charitable contributions caused by the reform. Must be zero or positive.",
+        "long_name": "Elasticity of charitable contributions for itemizers",
+        "description": "Defined as proportional change in cash and non-cash charitable contributions divided by proportional change in the after-tax price of charitable contributions caused by the reform. Must be zero or negative.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0],
@@ -41,8 +41,8 @@
 
     "_BE_charity_non_itemizers": {
         "start_year": 2013,
-        "long_name": "Elasticity of cash charitable contributions for non-itemizers",
-        "description": "Defined as proportional change in cash charitable contributions divided by proportional change in the after-tax price of cash charitable contributions caused by the reform. Must be zero or positive.",
+        "long_name": "Elasticity of charitable contributions for non-itemizers",
+        "description": "Defined as proportional change in cash and non-cash charitable contributions divided by proportional change in the after-tax price of charitable contributions caused by the reform. Must be zero or negative.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0],

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -32,20 +32,20 @@
     "_BE_charity_itemizers": {
         "start_year": 2013,
         "long_name": "Elasticity of cash charitable contributions for itemizers",
-        "description": "Defined as proportional change in cash charitable contributions divided by proportional change in marginal net-of-tax-rate (1-MTR) on cash charitable contributions caused by the reform. Must be zero or positive.",
+        "description": "Defined as proportional change in cash charitable contributions divided by proportional change in the after-tax price of cash charitable contributions caused by the reform. Must be zero or positive.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0],
-        "validations": {"min": 0.0}
+        "validations": {"max": 0.0}
     },
 
     "_BE_charity_non_itemizers": {
         "start_year": 2013,
         "long_name": "Elasticity of cash charitable contributions for non-itemizers",
-        "description": "Defined as proportional change in cash charitable contributions divided by proportional change in marginal net-of-tax-rate (1-MTR) on cash charitable contributions caused by the reform. Must be zero or positive.",
+        "description": "Defined as proportional change in cash charitable contributions divided by proportional change in the after-tax price of cash charitable contributions caused by the reform. Must be zero or positive.",
         "row_label": ["2013"],
         "col_label": "",
         "value": [0.0],
-        "validations": {"min":0.0}
+        "validations": {"max":0.0}
     }
 }

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -27,5 +27,25 @@
         "col_label": "",
         "value": [0.0],
         "validations": {"max": 0.0}
+    },
+
+    "_BE_charity_itemizers": {
+        "start_year": 2013,
+        "long_name": "Elasticity of charitable contributions for itemizers",
+        "description": "Defined as proportional change in charitable giving divided by proportional change in marginal net-of-tax-rate (1-MTR) on charitable giving caused by the reform. Must be zero or positive.",
+        "row_label": ["2013"],
+        "col_label": "",
+        "value": [0.0],
+        "validations": {"min": 0.0}
+    },
+
+    "_BE_charity_non_itemizers": {
+        "start_year": 2013,
+        "long_name": "Elasticity of charitable contributions for non-itemizers",
+        "description": "Defined as proportional change in charitable giving divided by proportional change in marginal net-of-tax-rate (1-MTR) on charitable giving caused by the reform. Must be zero or positive.",
+        "row_label": ["2013"],
+        "col_label": "",
+        "value": [0.0],
+        "validations": {"min":0.0}
     }
 }

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -195,15 +195,15 @@ class Behavior(ParametersBase):
             # cash:
             c_charity_mtr_x, c_charity_mtr_y = Behavior._mtr_xy(
                 calc_x, calc_y, mtr_of='e19800', tax_type='combined')
-            c_charity_mtr_pch = (((1. + c_charity_mtr_y) /
-                                 (1. + c_charity_mtr_x)) -
-                                 1.)
+            c_charity_price_pch = (((1. + c_charity_mtr_y) /
+                                   (1. + c_charity_mtr_x)) -
+                                   1.)
             # non-cash:
             nc_charity_mtr_x, nc_charity_mtr_y = Behavior._mtr_xy(
                 calc_x, calc_y, mtr_of='e20100', tax_type='combined')
-            nc_charity_mtr_pch = (((1. + nc_charity_mtr_y) /
-                                  (1. + nc_charity_mtr_x)) -
-                                  1.)
+            nc_charity_price_pch = (((1. + nc_charity_mtr_y) /
+                                    (1. + nc_charity_mtr_x)) -
+                                    1.)
             # identify itemizers under calc_y
             itemizer = np.where(calc_y.records.c04470 >
                                 calc_y.records._standard,
@@ -213,16 +213,16 @@ class Behavior(ParametersBase):
             c_charity_chg = (
                 np.where(itemizer,
                          (calc_y.behavior.BE_charity_itemizers *
-                          c_charity_mtr_pch * calc_x.records.e19800),
+                          c_charity_price_pch * calc_x.records.e19800),
                          (calc_y.behavior.BE_charity_non_itemizers *
-                          c_charity_mtr_pch * calc_x.records.e19800)))
+                          c_charity_price_pch * calc_x.records.e19800)))
             # calculate change in non-cash contributions
             nc_charity_chg = (
                 np.where(itemizer,
                          (calc_y.behavior.BE_charity_itemizers *
-                          nc_charity_mtr_pch * calc_x.records.e20100),
+                          nc_charity_price_pch * calc_x.records.e20100),
                          (calc_y.behavior.BE_charity_non_itemizers *
-                          nc_charity_mtr_pch * calc_x.records.e20100)))
+                          nc_charity_price_pch * calc_x.records.e20100)))
         # Add behavioral-response changes to income sources
         calc_y_behv = copy.deepcopy(calc_y)
         calc_y_behv = Behavior._update_ordinary_income(taxinc_chg, calc_y_behv)

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -196,8 +196,8 @@ class Behavior(ParametersBase):
                                (1. - charity_mtr_x)) -
                                1.)
             # identify itemizers under calc_y
-            itemizer = np.where(calc_y.records._standard >
-                                calc_y.records.c04470,
+            itemizer = np.where(calc_y.records.c04470 >
+                                calc_y.records._standard,
                                 True,
                                 False)
             charity_chg = (

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -192,8 +192,8 @@ class Behavior(ParametersBase):
             # e19800 is filing units' charity cash contributions
             charity_mtr_x, charity_mtr_y = Behavior._mtr_xy(
                 calc_x, calc_y, mtr_of='e19800', tax_type='combined')
-            charity_mtr_pch = (((1. - charity_mtr_y) /
-                               (1. - charity_mtr_x)) -
+            charity_mtr_pch = (((1. + charity_mtr_y) /
+                               (1. + charity_mtr_x)) -
                                1.)
             # identify itemizers under calc_y
             itemizer = np.where(calc_y.records.c04470 >
@@ -238,10 +238,10 @@ class Behavior(ParametersBase):
                     if val > 0.0:
                         raise ValueError(msg.format(elast, pos, year, val))
                 elif elast == '_BE_charity_itemizers':
-                    if val < 0.0:
+                    if val > 0.0:
                         raise ValueError(msg.format(elast, neg, year, val))
                 elif elast == '_BE_charity_non_itemizers':
-                    if val < 0.0:
+                    if val > 0.0:
                         raise ValueError(msg.format(elast, neg, year, val))
                 else:
                     raise ValueError('illegal elasticity {}'.format(elast))

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -230,7 +230,8 @@ class Calculator(object):
                            'e02000', 'e02400',
                            'p22250', 'p23250',
                            'e18500', 'e19200',
-                           'e26270', 'e19800']
+                           'e26270', 'e19800',
+                           'e20100']
 
     def mtr(self, variable_str='e00200p',
             negative_finite_diff=False,
@@ -296,6 +297,7 @@ class Calculator(object):
         'e19200',  Schedule A total-interest deduction;
         'e26270',  S-corporation/partnership income (also included in e02000);
         'e19800',  Charity cash contributions.
+        'e20100',  Charity non-cash contributions.
         """
         # check validity of variable_str parameter
         if variable_str not in Calculator.MTR_VALID_VARIABLES:

--- a/taxcalc/tests/pufcsv_mtr_expect.txt
+++ b/taxcalc/tests/pufcsv_mtr_expect.txt
@@ -52,3 +52,6 @@ PTAX and ITAX mtr histogram bin counts for e26270:
 PTAX and ITAX mtr histogram bin counts for e19800:
 219814 : 219814      0      0      0      0      0      0      0      0      0
 219814 :  33368  29198  18058   5017 134173      0      0      0      0      0
+PTAX and ITAX mtr histogram bin counts for e20100:
+219814 : 219814      0      0      0      0      0      0      0      0      0
+219814 :  33310  29160  18006   5008 134330      0      0      0      0      0

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -62,8 +62,8 @@ def test_behavioral_response_Calculator(puf_1991, weights_1991):
     behavior4 = {2013: {'_BE_cg': [-0.8]}}
     behavior_y.update_behavior(behavior4)
     calc_y_behavior4 = Behavior.response(calc_x, calc_y)
-    behavior5 = {2013: {'_BE_charity_itemizers': [0.5],
-                        '_BE_charity_non_itemizers': [0.5]}}
+    behavior5 = {2013: {'_BE_charity_itemizers': [-0.5],
+                        '_BE_charity_non_itemizers': [-0.5]}}
     behavior_y.update_behavior(behavior5)
     calc_y_behavior5 = Behavior.response(calc_x, calc_y)
     # check that total income tax liability differs across the
@@ -83,8 +83,8 @@ def test_correct_update_behavior():
     beh = Behavior(start_year=2013)
     beh.update_behavior({2014: {'_BE_sub': [0.5]},
                          2015: {'_BE_cg': [-1.2]},
-                         2016: {'_BE_charity_itemizers': [0.5]},
-                         2017: {'_BE_charity_non_itemizers': [0.5]}})
+                         2016: {'_BE_charity_itemizers': [-0.5]},
+                         2017: {'_BE_charity_non_itemizers': [-0.5]}})
     should_be = np.full((Behavior.DEFAULT_NUM_YEARS,), 0.5)
     should_be[0] = 0.0
     assert np.allclose(beh._BE_sub, should_be, rtol=0.0)
@@ -96,8 +96,8 @@ def test_correct_update_behavior():
     assert beh.BE_sub == 0.5
     assert beh.BE_inc == 0.0
     assert beh.BE_cg == -1.2
-    assert beh.BE_charity_itemizers == .5
-    assert beh.BE_charity_non_itemizers == .5
+    assert beh.BE_charity_itemizers == -0.5
+    assert beh.BE_charity_non_itemizers == -0.5
 
 
 def test_incorrect_update_behavior():
@@ -107,9 +107,9 @@ def test_incorrect_update_behavior():
     with pytest.raises(ValueError):
         behv.update_behavior({2013: {'_BE_sub': [-0.2]}})
     with pytest.raises(ValueError):
-        behv.update_behavior({2013: {'_BE_charity_itemizers': [-0.2]}})
+        behv.update_behavior({2013: {'_BE_charity_itemizers': [0.2]}})
     with pytest.raises(ValueError):
-        behv.update_behavior({2013: {'_BE_charity_non_itemizers': [-0.2]}})
+        behv.update_behavior({2013: {'_BE_charity_non_itemizers': [0.2]}})
     with pytest.raises(ValueError):
         behv.update_behavior({2013: {'_BE_cg': [+0.8]}})
     with pytest.raises(ValueError):

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -40,6 +40,12 @@ def test_behavioral_response_Calculator(puf_1991, weights_1991):
                                 mtr_of='e00200p',
                                 tax_type='nonsense')
     # vary substitution and income effects in calc_y
+    behavior0 = {2013: {'_BE_sub': [0.0],
+                        '_BE_cg': [0.0],
+                        '_BE_charity_itemizers': [0.0],
+                        '_BE_charity_non_itemizers': [0.0]}}
+    behavior_y.update_behavior(behavior0)
+    calc_y_behavior0 = Behavior.response(calc_x, calc_y)
     behavior1 = {2013: {'_BE_sub': [0.3], '_BE_cg': [0.0]}}
     behavior_y.update_behavior(behavior1)
     assert behavior_y.has_response() is True
@@ -56,12 +62,18 @@ def test_behavioral_response_Calculator(puf_1991, weights_1991):
     behavior4 = {2013: {'_BE_cg': [-0.8]}}
     behavior_y.update_behavior(behavior4)
     calc_y_behavior4 = Behavior.response(calc_x, calc_y)
+    behavior5 = {2013: {'_BE_charity_itemizers': [0.5],
+                        '_BE_charity_non_itemizers': [0.5]}}
+    behavior_y.update_behavior(behavior5)
+    calc_y_behavior5 = Behavior.response(calc_x, calc_y)
     # check that total income tax liability differs across the
-    # four sets of behavioral-response elasticities
-    assert (calc_y_behavior1.records._iitax.sum() !=
+    # six sets of behavioral-response elasticities
+    assert (calc_y_behavior0.records._iitax.sum() !=
+            calc_y_behavior1.records._iitax.sum() !=
             calc_y_behavior2.records._iitax.sum() !=
             calc_y_behavior3.records._iitax.sum() !=
-            calc_y_behavior4.records._iitax.sum())
+            calc_y_behavior4.records._iitax.sum() !=
+            calc_y_behavior5.records._iitax.sum())
     # test incorrect _mtr_xy() usage
     with pytest.raises(ValueError):
         Behavior._mtr_xy(calc_x, calc_y, mtr_of='e00200p', tax_type='?')
@@ -70,18 +82,22 @@ def test_behavioral_response_Calculator(puf_1991, weights_1991):
 def test_correct_update_behavior():
     beh = Behavior(start_year=2013)
     beh.update_behavior({2014: {'_BE_sub': [0.5]},
-                         2015: {'_BE_cg': [-1.2]}})
+                         2015: {'_BE_cg': [-1.2]},
+                         2016: {'_BE_charity_itemizers': [0.5]},
+                         2017: {'_BE_charity_non_itemizers': [0.5]}})
     should_be = np.full((Behavior.DEFAULT_NUM_YEARS,), 0.5)
     should_be[0] = 0.0
     assert np.allclose(beh._BE_sub, should_be, rtol=0.0)
     assert np.allclose(beh._BE_inc,
                        np.zeros((Behavior.DEFAULT_NUM_YEARS,)),
                        rtol=0.0)
-    beh.set_year(2015)
-    assert beh.current_year == 2015
+    beh.set_year(2017)
+    assert beh.current_year == 2017
     assert beh.BE_sub == 0.5
     assert beh.BE_inc == 0.0
     assert beh.BE_cg == -1.2
+    assert beh.BE_charity_itemizers == .5
+    assert beh.BE_charity_non_itemizers == .5
 
 
 def test_incorrect_update_behavior():
@@ -90,6 +106,10 @@ def test_incorrect_update_behavior():
         behv.update_behavior({2013: {'_BE_inc': [+0.2]}})
     with pytest.raises(ValueError):
         behv.update_behavior({2013: {'_BE_sub': [-0.2]}})
+    with pytest.raises(ValueError):
+        behv.update_behavior({2013: {'_BE_charity_itemizers': [-0.2]}})
+    with pytest.raises(ValueError):
+        behv.update_behavior({2013: {'_BE_charity_non_itemizers': [-0.2]}})
     with pytest.raises(ValueError):
         behv.update_behavior({2013: {'_BE_cg': [+0.8]}})
     with pytest.raises(ValueError):


### PR DESCRIPTION
This is part 1 of a series of changes that will resolve #1237. 

This PR implements charitable giving elasticities that vary by itemizing status. Sample reforms and usage are below. 

A follow on PR will allow the elasticities to vary by income. 

The elasticity for non-itemizers won't be valuable until @jjbergdo or @gofroggyrun finish their imputations of charitable giving for non-itemizers. 

cc @martinholmer @codykallen @jjbergdo


# Testing charitable contribution behavioral features

### Import taxcalc package and other useful packages


```python
import sys
sys.path.append("../../")
from taxcalc import *
```

### Create Plan X and Plan Y  Policy objects containing current law policy and then implement reforms


```python
# The baseline includes AMT repeal. 
p_xx = Policy()
reform_xx = {
    2016: {
          '_AMT_rt1': [0],
          '_AMT_rt2': [0], 
    }
}
p_xx.implement_reform(reform_xx)

# The reform expands the second tax bracket
# (and repeals AMT to match the baseline)

p_yy = Policy()
reform_yy = {
    2016: {
        '_AMT_rt1': [0],
        '_AMT_rt2': [0], 
        '_ID_Charity_hc': [.5]

    }
}
p_yy.implement_reform(reform_yy)
bhv = Behavior()
```

### Create calculator objects with default tax data and advance the calculator to 2016


```python
c_xx = Calculator(policy=p_xx, records=Records("../../puf.csv"))
c_xx.advance_to_year(2020)
c_yy = Calculator(policy=p_yy, records=Records("../../puf.csv"), behavior = bhv)
c_yy.advance_to_year(2020)
```

    You loaded data for 2009.
    Tax-Calculator startup automatically extrapolated your data to 2013.
    You loaded data for 2009.
    Tax-Calculator startup automatically extrapolated your data to 2013.


### Implement Behavior


```python
# Itemizers
reform_be_item = {2020: {'_BE_charity_itemizers': [.5]}}
bhv.update_behavior(reform_be_item)
c_yy_beh_item = Behavior.response(c_xx, c_yy)

# Non-itemizers
reform_be_no_item = {2020: {'_BE_charity_non_itemizers': [.5]}}
bhv.update_behavior(reform_be_no_item)
c_yy_beh_no_item = Behavior.response(c_xx, c_yy)
```

### Calculate taxes under the baseline and under the reform. 


```python
c_xx.calc_all()
c_yy.calc_all()
c_yy_beh_item.calc_all()
c_yy_beh_no_item.calc_all()
```

### Calculate the change in combined tax revenue

#### No behavior


```python
((c_yy.records._combined - c_xx.records._combined)*c_xx.records.s006).sum()/1000000000
```




    29.780937267036911



#### Itemizer behavior


```python
((c_yy_beh_item.records._combined - c_xx.records._combined)*c_xx.records.s006).sum()/1000000000
```




    31.071111883705189



#### Non-itemizer behavior


```python
((c_yy_beh_no_item.records._combined - c_xx.records._combined)*c_xx.records.s006).sum()/1000000000
```




    29.780937267036911



### Calculate cash charity before and after reform. 

#### No behavior


```python
((c_yy.records.e19800)*c_yy.records.s006).sum()/1000000000
```




    202.17375890856968



#### Itemizer behavior


```python
((c_yy_beh_item.records.e19800)*c_xx.records.s006).sum()/1000000000
```




    193.40411585066309



#### Non-itemizer behavior


```python
((c_yy_beh_no_item.records.e19800)*c_xx.records.s006).sum()/1000000000
```




    201.4100883665042



One might expect that non-itemizer behavior would not affect results since we don't yet have data on charitable contributions for non-itemizers. However, the reason there is a slight change is because we choose which elasticity to apply to taxpayers based on their itemizing status *after* the reform rather than *before* the reform. 

The total difference caused by non-itemizer behavior is:


```python
((c_yy_beh_no_item.records.e19800 - c_yy.records.e19800)*c_xx.records.s006).sum()/1000000000
```




    -0.7636705420654728



The difference for taxpayers who itemized before the reform accounts for the total. 


```python
((c_yy_beh_no_item.records.e19800 - c_yy.records.e19800)*c_xx.records.s006)[c_xx.records.c04470 > c_xx.records._standard].sum()/1000000000
```




    -0.76367054206547258



There is no difference for taxpayers who took the standard deduction before the reform: 


```python
((c_yy_beh_no_item.records.e19800 - c_yy.records.e19800)*c_xx.records.s006)[c_xx.records.c04470 < c_xx.records._standard].sum()/1000000000
```




    0.0




```python

```
