### PR TITLE
Add Education Credit HC

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -3041,5 +3041,21 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [0.0]
+    },
+
+    "_CR_Education_hc": {
+        "long_name": "Education Credits",
+        "description": "If greater than zero, this decimal fraction reduces the portion of education credits that can be claimed",
+        "section_1": "Nonrefundable credits",
+        "section_2": "Misc. credit limits",
+        "irs_ref": "",
+        "notes": "Credit claimed will be (1. - Haircut) * Education Credits",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
     }
 }

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1115,6 +1115,7 @@ def SchR(age_head, age_spouse, MARS, c00100,
 def EducationTaxCredit(e87530, MARS, c00100, _num, c05800,
                        e07300, c07180, c07200, c87668,
                        LLC_Expense_c, ETC_pe_Single, ETC_pe_Married,
+                       CR_Education_hc,
                        c07230):
     """
     Education Tax Credit (Form 8863) nonrefundable amount, c07230
@@ -1163,7 +1164,7 @@ def EducationTaxCredit(e87530, MARS, c00100, _num, c05800,
     xline9 = max(0., c05800 - (e07300 + c07180 + c07200 + xline5))
     xline10 = min(c87668, xline9)
     c87680 = xline5 + xline10
-    c07230 = c87680
+    c07230 = c87680 * (1. - CR_Education_hc)
     return c07230
 
 


### PR DESCRIPTION
This PR is a continuation of PR #1247 and adds a haircut for education credits. The reason it was not included in #1247 is at the time I was under the impression that education credits could be zeroed out by simply setting `LLC_Expense` and `ETC_pe_Single/Married` to zero, but that is not the case. 

cc: @MattHJensen @martinholmer 