### PR TITLE
Correct Erroneous CTC_new_ps Field

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -2670,10 +2670,10 @@
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
-        "col_var": ["single", "joint", "separate", "head of household", "widow", "separate"],
+        "col_label": ["single", "joint", "separate", "head of household", "widow", "separate"],
         "row_label": ["2013"],
         "cpi_inflated": true,
-        "col_label": "",
+        "col_var": "",
         "value": [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
     },
 


### PR DESCRIPTION
This fixes the issue in https://github.com/OpenSourcePolicyCenter/webapp-public/issues/507

The keys for this field incorrectly defined. `col_var` and `col_label` values had to be swapped in order to get the field to be processed correctly.

cc @MattHJensen @PeterDSteinberg @jdebacker 