### PR TITLE
Make explicit the logic of handling MTRs on spouse earnings

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -250,9 +250,10 @@ class Calculator(object):
         (where the change in total compensation is the sum of the small
         increase in the variable and any increase in the employer share of
         payroll taxes caused by the small increase in the variable).
-          If using 'e00200s' as variable_str, MTR for all records where
-        MARS != 2 will be missing. If you want to perform a function such as
-        np.mean(), you will need to account for this.
+          If using 'e00200s' as variable_str, the marginal tax rate for all
+        records where MARS != 2 will be missing.  If you want to perform a
+        function such as np.mean() on the returned arrays, you will need to
+        account for this.
 
         Parameters
         ----------
@@ -355,7 +356,9 @@ class Calculator(object):
         incometax_diff = incometax_chng - incometax_base
         combined_diff = combined_taxes_chng - combined_taxes_base
         # specify optional adjustment for employer (er) OASDI+HI payroll taxes
-        if wrt_full_compensation and variable_str == 'e00200p':
+        mtr_on_earnings = (variable_str == 'e00200p' or
+                           variable_str == 'e00200s')
+        if wrt_full_compensation and mtr_on_earnings:
             adj = np.where(variable < self.policy.SS_Earnings_c,
                            0.5 * (self.policy.FICA_ss_trt +
                                   self.policy.FICA_mc_trt),

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -285,8 +285,7 @@ class Calculator(object):
         -----
         Valid variable_str values are:
         'e00200p', taxpayer wage/salary earnings (also included in e00200);
-        'e00200s', secondary earner wage/salary earnings (also included in
-                   e00200);
+        'e00200s', spouse wage/salary earnings (also included in e00200);
         'e00900p', taxpayer Schedule C self-employment income (also in e00900);
         'e00300',  taxable interest income;
         'e00400',  federally-tax-exempt interest income;
@@ -304,6 +303,7 @@ class Calculator(object):
         'e19800',  Charity cash contributions.
         'e20100',  Charity non-cash contributions.
         """
+        # pylint: disable=too-many-statements
         # check validity of variable_str parameter
         if variable_str not in Calculator.MTR_VALID_VARIABLES:
             msg = 'mtr variable_str="{}" is not valid'
@@ -366,14 +366,14 @@ class Calculator(object):
         mtr_payrolltax = payrolltax_diff / (finite_diff * (1.0 + adj))
         mtr_incometax = incometax_diff / (finite_diff * (1.0 + adj))
         mtr_combined = combined_diff / (finite_diff * (1.0 + adj))
-        # If using e00200s, set MTR to zero for households with no spouse
+        # if variable_str is e00200s, set MTR to NaN for units without a spouse
         if variable_str == 'e00200s':
-            mtr_payrolltax = np.where(self.records.MARS != 2, np.nan,
-                                      mtr_payrolltax)
-            mtr_incometax = np.where(self.records.MARS != 2, np.nan,
-                                     mtr_incometax)
-            mtr_combined = np.where(self.records.MARS != 2, np.nan,
-                                    mtr_combined)
+            mtr_payrolltax = np.where(self.records.MARS == 2,
+                                      mtr_payrolltax, np.nan)
+            mtr_incometax = np.where(self.records.MARS == 2,
+                                     mtr_incometax, np.nan)
+            mtr_combined = np.where(self.records.MARS == 2,
+                                    mtr_combined, np.nan)
         # return the three marginal tax rate arrays
         return (mtr_payrolltax, mtr_incometax, mtr_combined)
 

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -123,19 +123,18 @@ ITAX_MTR_BIN_EDGES = [-1.0, -0.30, -0.20, -0.10, 0.0,
 #        may want to experiment with alternative boundaries
 
 
-def mtr_bin_counts(mtr_data, bin_edges, recid, var_str):
+def mtr_bin_counts(mtr_data, bin_edges, recid):
     """
     Compute mtr histogram bin counts and return results as a string.
     """
     res = ''
-    (bincount, _) = np.histogram(mtr_data[np.isfinite(mtr_data)].round(4),
-                                 bins=bin_edges)
+    (bincount, _) = np.histogram(mtr_data.round(decimals=4), bins=bin_edges)
     sum_bincount = np.sum(bincount)
     res += '{} :'.format(sum_bincount)
     for idx in range(len(bin_edges) - 1):
         res += ' {:6d}'.format(bincount[idx])
     res += '\n'
-    if sum_bincount < mtr_data.size and var_str != 'e00200s':
+    if sum_bincount < mtr_data.size:
         res += 'WARNING: sum of bin counts is too low\n'
         recinfo = '         mtr={:.2f} for recid={}\n'
         mtr_min = mtr_data.min()
@@ -195,9 +194,13 @@ def test_mtr(tests_path, puf_path):
                                            negative_finite_diff=MTR_NEG_DIFF,
                                            zero_out_calculated_vars=zero_out,
                                            wrt_full_compensation=False)
+        if var_str == 'e00200s':
+            # only MARS==2 filing units have valid MTR values
+            mtr_ptax = mtr_ptax[calc.records.MARS == 2]
+            mtr_itax = mtr_itax[calc.records.MARS == 2]
         res += '{} {}:\n'.format(variable_header, var_str)
-        res += mtr_bin_counts(mtr_ptax, PTAX_MTR_BIN_EDGES, recid, var_str)
-        res += mtr_bin_counts(mtr_itax, ITAX_MTR_BIN_EDGES, recid, var_str)
+        res += mtr_bin_counts(mtr_ptax, PTAX_MTR_BIN_EDGES, recid)
+        res += mtr_bin_counts(mtr_itax, ITAX_MTR_BIN_EDGES, recid)
     # generate differences between actual and expected results
     actual = res.splitlines(True)
     mtrres_path = os.path.join(tests_path, 'pufcsv_mtr_expect.txt')

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -555,6 +555,8 @@ def test_mtr_graph_data(records_2009):
     with pytest.raises(ValueError):
         gdata = mtr_graph_data(calc, calc, mars=list())
     with pytest.raises(ValueError):
+        gdata = mtr_graph_data(calc, calc, mars='ALL', mtr_variable='e00200s')
+    with pytest.raises(ValueError):
         gdata = mtr_graph_data(calc, calc, mtr_measure='badtax')
     with pytest.raises(ValueError):
         gdata = mtr_graph_data(calc, calc, income_measure='badincome')

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -812,6 +812,10 @@ def mtr_graph_data(calc1, calc2,
     else:
         msg = 'mars="{}" is neither a string nor an integer'
         raise ValueError(msg.format(mars))
+    # . . check mars value if mtr_variable is e00200s
+    if mtr_variable == 'e00200s' and mars != 2:
+        msg = 'mtr_variable == "e00200s" but mars != 2'
+        raise ValueError(msg)
     # . . check mtr_measure value
     if mtr_measure == 'itax':
         mtr_str = 'Income-Tax'


### PR DESCRIPTION
This pull request makes no changes that affect Tax-Calculator output or test results.  The code changes clarify how to handle the NaN values of `e00200s` MTR for filing units with `MARS != 2`.

In addition to those clarifications, the Calculator `mtr` method logic has been corrected to handle `e00200s` calculations when its `wrt_full_compensation` parameter is True (which is the default value).

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @GoFroggyRun @codykallen 
