### PR TITLE
Remove unused policy parameters revealed by new test

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -341,20 +341,6 @@
         "value": [0.0]
     },
 
-    "_ALD_InvInc_ec_base_code_active": {
-        "long_name": "Use parameter code to compute investment income exclusion base",
-        "description": "False implies base includes all investment income; otherwise code defines base.",
-        "irs_ref": "",
-        "notes": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "start_year": 2013,
-        "cpi_inflated": false,
-        "col_var": "",
-        "col_label": "",
-        "value": [false]
-    },
-
     "_ALD_InvInc_ec_base_RyanBrady": {
         "long_name": "Investment income exclusion base for Ryan-Brady tax blueprint",
         "description": "Exclusion is applied to long-term gains before loss limitation, taxable interest and qualified dividends. Interpretation of the sparsely-detailed Ryan-Brady provision.",
@@ -2669,20 +2655,6 @@
         "col_var": "",
         "col_label": "",
         "value": [3]
-    },
-
-    "_CTC_new_code_active": {
-        "long_name": "Use parameter code to compute new refundable child tax credit",
-        "description": "False implies additional refundable child tax credit computed using numeric parameters; otherwise code defines credit.",
-        "irs_ref": "",
-        "notes": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "start_year": 2013,
-        "cpi_inflated": false,
-        "col_var": "",
-        "col_label": "",
-        "value": [false]
     },
 
     "_CTC_new_c": {

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -124,3 +124,23 @@ def test_json_file_contents(tests_path, fname):
                 assert len(rowlabel) == num_known_years - 1
             else:
                 assert len(rowlabel) == num_known_years
+
+
+def test_policy_parameter_usage(tests_path):
+    """
+    Make sure each policy parameter is mentioned in functions.py text.
+    """
+    # read policy parameter file into a dictionary
+    path = os.path.join(tests_path, '..', 'current_law_policy.json')
+    pfile = open(path, 'r')
+    allparams = json.load(pfile)
+    pfile.close()
+    assert isinstance(allparams, dict)
+    # read functions.py text
+    path = os.path.join(tests_path, '..', 'functions.py')
+    ffile = open(path, 'r')
+    functions_text = ffile.read()
+    ffile.close()
+    # check that each param (without leading _) is mentioned in functions.py
+    for pname in allparams:
+        assert pname[1:] in functions_text


### PR DESCRIPTION
This pull request removes two policy parameters that have been unused since pull request #1221 and adds a test that will identify a policy parameter in `current_law_policy.json` that is not mentioned in the `functions.py` file.