### PR TITLE
charitable giving elasticities by income group

### DIFF
--- a/docs/notebooks/Behavioral_example.ipynb
+++ b/docs/notebooks/Behavioral_example.ipynb
@@ -197,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -41,8 +41,8 @@
         "validations": {"max": 0.0}
     },
 
-    "_BE_charity_itemizers": {
-        "long_name": "Elasticity of charitable contributions for itemizers",
+    "_BE_charity": {
+        "long_name": "Elasticity of charitable contributions ",
         "description": "Defined as proportional change in cash and non-cash charitable contributions divided by proportional change in the after-tax price of charitable contributions caused by the reform. Must be zero or negative.",
         "notes": "",
         "row_var": "FLPDYR",
@@ -53,20 +53,5 @@
         "col_label": "AGI < 50k, 50k <= AGI < 100k, 100k <= AGI",
         "value": [[0.0, 0.0, 0.0]],
         "validations": {"max": 0.0}
-    },
-
-    "_BE_charity_non_itemizers": {
-        "long_name": "Elasticity of charitable contributions for non-itemizers",
-        "description": "Defined as proportional change in cash and non-cash charitable contributions divided by proportional change in the after-tax price of charitable contributions caused by the reform. Must be zero or negative.",
-        "notes": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "start_year": 2013,
-        "cpi_inflated": false,
-        "col_var": "",
-        "col_label": "c00100",
-        "col_label": "AGI < 50k, 50k <= AGI < 100k, 100k <= AGI",
-        "value": [[0.0, 0.0, 0.0]],
-        "validations": {"max":0.0}
     }
 }

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -50,7 +50,7 @@
         "start_year": 2013,
         "cpi_inflated": false,
         "col_var": "c00100",
-        "col_label": "AGI < 50k, 50k <= AGI < 100k, 100k <= AGI",
+        "col_label": ["AGI < 50k", "50k <= AGI < 100k", "100k <= AGI"],
         "value": [[0.0, 0.0, 0.0]],
         "validations": {"max": 0.0}
     }

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -49,9 +49,9 @@
         "row_label": ["2013"],
         "start_year": 2013,
         "cpi_inflated": false,
-        "col_var": "",
-        "col_label": "",
-        "value": [0.0],
+        "col_var": "c00100",
+        "col_label": "AGI < 50k, 50k <= AGI < 100k, 100k <= AGI",
+        "value": [[0.0, 0.0, 0.0]],
         "validations": {"max": 0.0}
     },
 
@@ -64,8 +64,9 @@
         "start_year": 2013,
         "cpi_inflated": false,
         "col_var": "",
-        "col_label": "",
-        "value": [0.0],
-        "validations": {"max": 0.0}
+        "col_label": "c00100",
+        "col_label": "AGI < 50k, 50k <= AGI < 100k, 100k <= AGI",
+        "value": [[0.0, 0.0, 0.0]],
+        "validations": {"max":0.0}
     }
 }

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -84,11 +84,19 @@ class Behavior(ParametersBase):
         the current_year; returns false if all elasticities are zero.
         """
         # pylint: disable=no-member
+
+        if (self.BE_sub == 0.0 and self.BE_inc == 0.0 and self.BE_cg == 0.0 and
+           self.BE_charity_itemizers.tolist() == [0.0, 0.0, 0.0] and
+           self.BE_charity_non_itemizers.tolist() == [0.0, 0.0, 0.0]):
+            return False
+        else:
+            return True
+
         all_zero = (self.BE_sub == 0.0 and
                     self.BE_inc == 0.0 and
                     self.BE_cg == 0.0 and
-                    self.BE_charity_itemizers == 0.0 and
-                    self.BE_charity_non_itemizers == 0.0)
+                    self.BE_charity_itemizers == [0.0, 0.0, 0.0] and
+                    self.BE_charity_non_itemizers == [0.0, 0.0, 0.0])
         return not all_zero
 
     def has_any_response(self):
@@ -184,8 +192,11 @@ class Behavior(ParametersBase):
             new_ltcg = calc_x.records.p23250 * exp_term
             ltcg_chg = new_ltcg - calc_x.records.p23250
         # calculate charitable giving effect
-        no_charity_response = (calc_y.behavior.BE_charity_itemizers == 0.0 and
-                               calc_y.behavior.BE_charity_non_itemizers == 0.0)
+        no_charity_response = \
+            calc_y.behavior.BE_charity_itemizers.tolist() == \
+            [0.0, 0.0, 0.0] and \
+            calc_y.behavior.BE_charity_non_itemizers.tolist() == \
+            [0.0, 0.0, 0.0]
         if no_charity_response:
             c_charity_chg = np.zeros(calc_x.records.dim)
             nc_charity_chg = np.zeros(calc_x.records.dim)
@@ -211,16 +222,16 @@ class Behavior(ParametersBase):
             # calculate change in cash contributions
             c_charity_chg = (
                 np.where(itemizer,
-                         (calc_y.behavior.BE_charity_itemizers *
+                         (calc_y.behavior.BE_charity_itemizers[0] *
                           c_charity_price_pch * calc_x.records.e19800),
-                         (calc_y.behavior.BE_charity_non_itemizers *
+                         (calc_y.behavior.BE_charity_non_itemizers[0] *
                           c_charity_price_pch * calc_x.records.e19800)))
             # calculate change in non-cash contributions
             nc_charity_chg = (
                 np.where(itemizer,
-                         (calc_y.behavior.BE_charity_itemizers *
+                         (calc_y.behavior.BE_charity_itemizers[0] *
                           nc_charity_price_pch * calc_x.records.e20100),
-                         (calc_y.behavior.BE_charity_non_itemizers *
+                         (calc_y.behavior.BE_charity_non_itemizers[0] *
                           nc_charity_price_pch * calc_x.records.e20100)))
         # Add behavioral-response changes to income sources
         calc_y_behv = copy.deepcopy(calc_y)

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -210,14 +210,51 @@ class Behavior(ParametersBase):
                 calc_x, calc_y, mtr_of='e20100', tax_type='combined')
             nc_charity_price_pch = (((1. + nc_charity_mtr_y) /
                                      (1. + nc_charity_mtr_x)) - 1.)
+            # identify income bin based on baseline income
+            low_income = (calc_x.records.c00100 < 50000)
+            mid_income = ((calc_x.records.c00100 >= 50000) &
+                          (calc_x.records.c00100 < 100000))
+            high_income = (calc_x.records.c00100 >= 100000)
             # calculate change in cash contributions
-            c_charity_chg = (calc_y.behavior.BE_charity[0] *
-                             c_charity_price_pch *
-                             calc_x.records.e19800)
+            c_charity_chg = np.zeros(calc_x.records.dim)
+            # AGI < 50000
+            c_charity_chg = np.where(low_income,
+                                     (calc_y.behavior.BE_charity[0] *
+                                      c_charity_price_pch *
+                                      calc_x.records.e19800),
+                                     c_charity_chg)
+            # 50000 <= AGI < 1000000
+            c_charity_chg = np.where(mid_income,
+                                     (calc_y.behavior.BE_charity[1] *
+                                      c_charity_price_pch *
+                                      calc_x.records.e19800),
+                                     c_charity_chg)
+            # 1000000 < AGI
+            c_charity_chg = np.where(high_income,
+                                     (calc_y.behavior.BE_charity[2] *
+                                      c_charity_price_pch *
+                                      calc_x.records.e19800),
+                                     c_charity_chg)
             # calculate change in non-cash contributions
-            nc_charity_chg = (calc_y.behavior.BE_charity[0] *
-                              nc_charity_price_pch *
-                              calc_x.records.e20100)
+            nc_charity_chg = np.zeros(calc_x.records.dim)
+            # AGI < 50000
+            nc_charity_chg = np.where(low_income,
+                                      (calc_y.behavior.BE_charity[0] *
+                                       c_charity_price_pch *
+                                       calc_x.records.e20100),
+                                      nc_charity_chg)
+            # 50000 <= AGI < 1000000
+            nc_charity_chg = np.where(mid_income,
+                                      (calc_y.behavior.BE_charity[1] *
+                                       c_charity_price_pch *
+                                       calc_x.records.e20100),
+                                      nc_charity_chg)
+            # 1000000 < AGI
+            nc_charity_chg = np.where(high_income,
+                                      (calc_y.behavior.BE_charity[2] *
+                                       c_charity_price_pch *
+                                       calc_x.records.e20100),
+                                      nc_charity_chg)
         # Add behavioral-response changes to income sources
         calc_y_behv = copy.deepcopy(calc_y)
         calc_y_behv = Behavior._update_ordinary_income(taxinc_chg, calc_y_behv)

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -86,8 +86,7 @@ class Behavior(ParametersBase):
         # pylint: disable=no-member
 
         if (self.BE_sub == 0.0 and self.BE_inc == 0.0 and self.BE_cg == 0.0 and
-           self.BE_charity_itemizers.tolist() == [0.0, 0.0, 0.0] and
-           self.BE_charity_non_itemizers.tolist() == [0.0, 0.0, 0.0]):
+           self.BE_charity.tolist() == [0.0, 0.0, 0.0]):
             return False
         else:
             return True
@@ -95,8 +94,7 @@ class Behavior(ParametersBase):
         all_zero = (self.BE_sub == 0.0 and
                     self.BE_inc == 0.0 and
                     self.BE_cg == 0.0 and
-                    self.BE_charity_itemizers == [0.0, 0.0, 0.0] and
-                    self.BE_charity_non_itemizers == [0.0, 0.0, 0.0])
+                    self.BE_charity.tolist() == [0.0, 0.0, 0.0])
         return not all_zero
 
     def has_any_response(self):
@@ -193,9 +191,7 @@ class Behavior(ParametersBase):
             ltcg_chg = new_ltcg - calc_x.records.p23250
         # calculate charitable giving effect
         no_charity_response = \
-            calc_y.behavior.BE_charity_itemizers.tolist() == \
-            [0.0, 0.0, 0.0] and \
-            calc_y.behavior.BE_charity_non_itemizers.tolist() == \
+            calc_y.behavior.BE_charity.tolist() == \
             [0.0, 0.0, 0.0]
         if no_charity_response:
             c_charity_chg = np.zeros(calc_x.records.dim)
@@ -214,25 +210,14 @@ class Behavior(ParametersBase):
                 calc_x, calc_y, mtr_of='e20100', tax_type='combined')
             nc_charity_price_pch = (((1. + nc_charity_mtr_y) /
                                      (1. + nc_charity_mtr_x)) - 1.)
-            # identify itemizers under calc_y
-            itemizer = np.where(calc_y.records.c04470 >
-                                calc_y.records._standard,
-                                True,
-                                False)
             # calculate change in cash contributions
-            c_charity_chg = (
-                np.where(itemizer,
-                         (calc_y.behavior.BE_charity_itemizers[0] *
-                          c_charity_price_pch * calc_x.records.e19800),
-                         (calc_y.behavior.BE_charity_non_itemizers[0] *
-                          c_charity_price_pch * calc_x.records.e19800)))
+            c_charity_chg = (calc_y.behavior.BE_charity[0] *
+                             c_charity_price_pch *
+                             calc_x.records.e19800)
             # calculate change in non-cash contributions
-            nc_charity_chg = (
-                np.where(itemizer,
-                         (calc_y.behavior.BE_charity_itemizers[0] *
-                          nc_charity_price_pch * calc_x.records.e20100),
-                         (calc_y.behavior.BE_charity_non_itemizers[0] *
-                          nc_charity_price_pch * calc_x.records.e20100)))
+            nc_charity_chg = (calc_y.behavior.BE_charity[0] *
+                              nc_charity_price_pch *
+                              calc_x.records.e20100)
         # Add behavioral-response changes to income sources
         calc_y_behv = copy.deepcopy(calc_y)
         calc_y_behv = Behavior._update_ordinary_income(taxinc_chg, calc_y_behv)
@@ -266,10 +251,7 @@ class Behavior(ParametersBase):
                 elif elast == '_BE_cg':
                     if val > 0.0:
                         raise ValueError(msg.format(elast, pos, year, val))
-                elif elast == '_BE_charity_itemizers':
-                    if val > 0.0:
-                        raise ValueError(msg.format(elast, neg, year, val))
-                elif elast == '_BE_charity_non_itemizers':
+                elif elast == '_BE_charity':
                     if val > 0.0:
                         raise ValueError(msg.format(elast, neg, year, val))
                 else:

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -42,8 +42,7 @@ def test_behavioral_response_Calculator(puf_1991, weights_1991):
     # vary substitution and income effects in calc_y
     behavior0 = {2013: {'_BE_sub': [0.0],
                         '_BE_cg': [0.0],
-                        '_BE_charity_itemizers': [0.0],
-                        '_BE_charity_non_itemizers': [0.0]}}
+                        '_BE_charity': [[0.0, 0.0, 0.0]]}}
     behavior_y.update_behavior(behavior0)
     calc_y_behavior0 = Behavior.response(calc_x, calc_y)
     behavior1 = {2013: {'_BE_sub': [0.3], '_BE_cg': [0.0]}}
@@ -62,8 +61,7 @@ def test_behavioral_response_Calculator(puf_1991, weights_1991):
     behavior4 = {2013: {'_BE_cg': [-0.8]}}
     behavior_y.update_behavior(behavior4)
     calc_y_behavior4 = Behavior.response(calc_x, calc_y)
-    behavior5 = {2013: {'_BE_charity_itemizers': [-0.5],
-                        '_BE_charity_non_itemizers': [-0.5]}}
+    behavior5 = {2013: {'_BE_charity': [[-0.5, -0.5, -0.5]]}}
     behavior_y.update_behavior(behavior5)
     calc_y_behavior5 = Behavior.response(calc_x, calc_y)
     # check that total income tax liability differs across the
@@ -83,8 +81,8 @@ def test_correct_update_behavior():
     beh = Behavior(start_year=2013)
     beh.update_behavior({2014: {'_BE_sub': [0.5]},
                          2015: {'_BE_cg': [-1.2]},
-                         2016: {'_BE_charity_itemizers': [-0.5]},
-                         2017: {'_BE_charity_non_itemizers': [-0.5]}})
+                         2016: {'_BE_charity':
+                         [[-0.5, -0.5, -0.5]]}})
     should_be = np.full((Behavior.DEFAULT_NUM_YEARS,), 0.5)
     should_be[0] = 0.0
     assert np.allclose(beh._BE_sub, should_be, rtol=0.0)
@@ -96,8 +94,7 @@ def test_correct_update_behavior():
     assert beh.BE_sub == 0.5
     assert beh.BE_inc == 0.0
     assert beh.BE_cg == -1.2
-    assert beh.BE_charity_itemizers == -0.5
-    assert beh.BE_charity_non_itemizers == -0.5
+    assert beh.BE_charity.tolist() == [-0.5, -0.5, -0.5]
 
 
 def test_incorrect_update_behavior():
@@ -107,9 +104,9 @@ def test_incorrect_update_behavior():
     with pytest.raises(ValueError):
         behv.update_behavior({2013: {'_BE_sub': [-0.2]}})
     with pytest.raises(ValueError):
-        behv.update_behavior({2013: {'_BE_charity_itemizers': [0.2]}})
-    with pytest.raises(ValueError):
-        behv.update_behavior({2013: {'_BE_charity_non_itemizers': [0.2]}})
+        behv.update_behavior({2013:
+                             {'_BE_charity':
+                              [[0.2, -0.2, 0.2]]}})
     with pytest.raises(ValueError):
         behv.update_behavior({2013: {'_BE_cg': [+0.8]}})
     with pytest.raises(ValueError):

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -110,6 +110,8 @@ def test_json_file_contents(tests_path, fname):
                 assert len(clab) == 4
             elif cvar == 'idedtype':
                 assert len(clab) == 7
+            elif cvar == 'c00100':
+                pass
             else:
                 assert cvar == 'UNKNOWN col_var VALUE'
             # check length of each value row


### PR DESCRIPTION
This PR makes two changes:

1. Add ability to specify different elasticities for charitable contributions by income group
2. Remove the ability to specify different elasticities for charitable contributions by itemizing status (no longer wanted by user). 

@codykallen, would you mind reviewing? 