### PR TITLE
charity ded for non itemizers

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -570,6 +570,20 @@
         "validations": {"min": "default"}
     },
 
+    "_STD_allow_charity_ded_nonitemizers": {
+        "long_name": "Allow standard deduction filers to take the charitable contributions deduction",
+        "description": "Extends the charitable contributions deduction to taxpayers who take the standard deduction. The same ceilings, floor, and haircuts applied to itemized deduction for charitable contributions also apply here.",
+        "irs_ref": "",
+        "notes": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "start_year": 2013,
+        "cpi_inflated": false,
+        "col_var": "",
+        "col_label": "",
+        "value": [false]
+    },
+
     "_II_credit": {
         "long_name": "Personal refundable credit maximum amount",
         "description": "This credit amount is fully refundable and phased out based on AGI. It is available to tax units who would otherwise not file.",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -502,7 +502,8 @@ def AdditionalMedicareTax(e00200, MARS,
 
 @iterate_jit(nopython=True)
 def StdDed(DSI, _earned, STD, age_head, age_spouse, STD_Aged, STD_Dep,
-           MARS, MIDR, blind_head, blind_spouse, _standard):
+           MARS, MIDR, blind_head, blind_spouse, _standard, c19700,
+           STD_allow_charity_ded_nonitemizers):
     """
     StdDed function:
 
@@ -561,6 +562,8 @@ def StdDed(DSI, _earned, STD, age_head, age_spouse, STD_Aged, STD_Dep,
     _standard = basic_stded + extra_stded
     if MARS == 3 and MIDR == 1:
         _standard = 0.
+    if STD_allow_charity_ded_nonitemizers:
+        _standard += c19700
     return _standard
 
 


### PR DESCRIPTION
Closes #1236 (request of IUPUI researcher @jjbergdo)

Adds a switch parameter `_STD_allow_charity_ded_nonitemizers` that, when `true`, allows standard deduction filers to additionally take a deduction for charitable contributions. 

This is implemented by adding the allowable itemized deduction for charitable contributions, `c019700`, to `_standard`.

Under current law, `_STD_allow_charity_ded_nonitemizers` is `false`. 

The key documentation is excerpted below.  

```
"_STD_allow_charity_ded_nonitemizers": {
    "long_name": "Allow standard deduction filers to take the charitable contributions deduction",
    "description": "Extends the charitable contributions deduction to taxpayers who take the standard deduction. The same ceilings, floor, and haircuts applied to itemized deduction for charitable contributions also apply here.",
```

Note that this will only affect results when we have data on the charitable contributions of non-itemizers.

cc @martinholmer @codykallen @feenberg @jjbergdo 