### PR TITLE
Allow growdiff_response use when not using internal Tax-Calculaor GrowModel

### DIFF
--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -10,7 +10,7 @@ import tempfile
 import pytest
 import pandas as pd
 # pylint: disable=import-error
-from taxcalc import TaxCalcIO, Growdiff
+from taxcalc import TaxCalcIO, Growdiff, Calculator
 
 
 @pytest.mark.parametrize("input_data, reform, assump", [
@@ -108,6 +108,7 @@ def assumpfile0():
     (2000, 'assumpfile0', Growdiff()),
     (2099, None, None),
     (2020, None, dict()),
+    (2020, 'assumpfile0', 'has_gdiff_response'),
 ])
 def test_init_errors(reformfile0, assumpfile0, year, asm, gdr):
     """
@@ -119,6 +120,11 @@ def test_init_errors(reformfile0, assumpfile0, year, asm, gdr):
         assump = assumpfile0.name
     else:
         assump = asm
+    if gdr == 'has_gdiff_response':
+        gdiff_response = Growdiff()
+        gdiff_response.update_growdiff({2015: {"_ABOOK": [-0.01]}})
+    else:
+        gdiff_response = gdr
     tcio = TaxCalcIO(input_data=recdf,
                      tax_year=year,
                      reform=reformfile0.name,
@@ -128,7 +134,7 @@ def test_init_errors(reformfile0, assumpfile0, year, asm, gdr):
               tax_year=year,
               reform=reformfile0.name,
               assump=assump,
-              growdiff_response=gdr,
+              growdiff_response=gdiff_response,
               aging_input_data=False,
               exact_calculations=False)
     assert len(tcio.errmsg) > 0

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -10,7 +10,7 @@ import tempfile
 import pytest
 import pandas as pd
 # pylint: disable=import-error
-from taxcalc import TaxCalcIO, Growdiff, Calculator
+from taxcalc import TaxCalcIO, Growdiff
 
 
 @pytest.mark.parametrize("input_data, reform, assump", [


### PR DESCRIPTION
This pull request allows the use of non-zero `growdiff_response` parameters as long as no behavioral responses are specified and as long as the internal GrowModel is not being used.  This second condition is easy to satisfy because currently there is no internal GrowModel.

This pull request makes no changes in tax logic and hence there are no changes in any tax results.
