### PR TITLE
Add text to tc CLI section of user documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,14 +181,65 @@ installation and file preparation work may be worth it to you.</p>
 <p><a href="#cli-spec-output">Specify Output Options</a></p>
 <p><a href="#cli-init-analysis">Initiate Reform Analysis</a></p>
 <p><a href="#cli-tab-results">Tabulate Reform Results</a></p>
+<p><a href="#cli-taxbrain-upload">Upload Files to TaxBrain</a></p>
 
 
 <h3 id="cli-install-test">Install/Test tc CLI</h3>
 
-<p>Text goes here.</p>
+<p>Installation of tc CLI involves steps:</p>
 
-<p>More text goes here.</p>
+<p><b>Install the free Anaconda Python distribution</b> by going to
+the <a href="https://www.continuum.io/downloads">Continuum Analytics
+download page</a> and selecting a version of Python suitable for your
+computer.  You should install Python 2.7, which is the older and more
+stable version.  You must do this installation even if you already
+have Python installed on your computer because the Anaconda
+distribution contains all the additional Python packages that
+Tax-Calculator uses to conduct tax calculations (many of which are not
+included in other Python installations). You can install the Anaconda
+distribution without having administrative privileges on your computer
+and the Anaconda distribution will not interfere with any Python
+installation that came as part of your computer’s operating
+system.</p>
 
+<p><b>Check your Anaconda Python installation </b> by entering the
+following two commands at the operating system command prompt (which
+is shown as <kbd>$</kbd> here, but would be <kbd>></kbd> on Windows)
+in any directory:
+<pre>$ conda --version</pre>
+Expected output is something like <kbd>conda 4.3.17</kbd>
+<pre>$ python --version</pre>
+Expected output should contain the <kbd>Python 2.7.</kbd> and
+<kbd>Anaconda</kbd> phrases, the presence of which confirm that the
+installation went smoothly.  The full output could look something
+like this <kbd>Python 2.7.12 :: Anaconda 2.3.0 (x86_64)</kbd>.</p>
+
+<p><b>Install the free taxcalc package</b> by entering the following:
+<pre>$ conda install -c ospc taxcalc</pre>
+Expected output should contain information about all the additional
+packages that Tax-Calculator needs.  After all that information has
+been shown on the screen, press the <kbd>y</kbd> key to proceed with
+the package installations.</p>
+
+<p><b>Check your installation of tc</b> (the CLI to Tax-Calculator) by
+entering the following:
+<pre>$ tc --test</pre>
+Expected output (after about twenty seconds) should be <kbd>PASSED
+TEST</kbd>.  If you get <kbd>FAILED TEST</kbd>, something when wrong
+in the installation process.  If the installation test fails, please
+report your experience on
+the <a href="http://list.ospc.org/mailman/listinfo/users_list.ospc.org">Tax-Calculator
+users mailing list</a> or in an email to one of the core maintainers
+of Tax-Calculator listed at the bottom of the <i>What is TaxBrain?</i>
+page at <a href="http://www.ospc.org/taxbrain/">this website</a>.
+
+<p>If your installation passes the test, you are ready to begin using
+tc to analyze your tax reforms.  Continue reading this section for
+information about how to do that.  But if you want a quick hint about
+the range of tc capabilities, enter the following:
+<pre>$ tc --help</pre>
+</p>
+ 
 <p><a href="#cli">Back to Section Contents</a></p>
 
 
@@ -229,6 +280,13 @@ installation and file preparation work may be worth it to you.</p>
 
 
 <h3 id="cli-tab-results">Tabulate Reform Results</h3>
+
+<p>Text goes here.</p>
+
+<p>More text goes here.</p>
+
+
+<h3 id="cli-taxbrain-upload">Upload Files to TaxBrain</h3>
 
 <p>Text goes here.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -178,6 +178,7 @@ installation and file preparation work may be worth it to you.</p>
 <p><a href="#cli-install-test">Install/Test tc CLI</a></p>
 <p><a href="#cli-spec-reform">Specify Tax Reform</a></p>
 <p><a href="#cli-spec-assump">Specify Analysis Assumptions</a></p>
+<p><a href="#cli-spec-funits">Specify Filing Units</a></p>
 <p><a href="#cli-spec-output">Specify Output Options</a></p>
 <p><a href="#cli-init-analysis">Initiate Reform Analysis</a></p>
 <p><a href="#cli-tab-results">Tabulate Reform Results</a></p>
@@ -186,7 +187,7 @@ installation and file preparation work may be worth it to you.</p>
 
 <h3 id="cli-install-test">Install/Test tc CLI</h3>
 
-<p>Installation of tc CLI involves steps:</p>
+<p>Installation of tc CLI involves several steps:</p>
 
 <p><b>Install the free Anaconda Python distribution</b> by going to
 the <a href="https://www.continuum.io/downloads">Continuum Analytics
@@ -202,7 +203,7 @@ and the Anaconda distribution will not interfere with any Python
 installation that came as part of your computer’s operating
 system.</p>
 
-<p><b>Check your Anaconda Python installation </b> by entering the
+<p><b>Check your Anaconda Python installation</b> by entering the
 following two commands at the operating system command prompt (which
 is shown as <kbd>$</kbd> here, but would be <kbd>></kbd> on Windows)
 in any directory:
@@ -224,8 +225,8 @@ the package installations.</p>
 <p><b>Check your installation of tc</b> (the CLI to Tax-Calculator) by
 entering the following:
 <pre>$ tc --test</pre>
-Expected output (after about twenty seconds) should be <kbd>PASSED
-TEST</kbd>.  If you get <kbd>FAILED TEST</kbd>, something when wrong
+Expected output (after about twenty seconds) is <kbd>PASSED
+TEST</kbd>.  If you get <kbd>FAILED TEST</kbd>, something went wrong
 in the installation process.  If the installation test fails, please
 report your experience on
 the <a href="http://list.ospc.org/mailman/listinfo/users_list.ospc.org">Tax-Calculator
@@ -239,20 +240,58 @@ information about how to do that.  But if you want a quick hint about
 the range of tc capabilities, enter the following:
 <pre>$ tc --help</pre>
 </p>
- 
+
+<p>The basic idea of tc tax analysis is that each tax reform is
+specified in a text file using a simple method to describe the details
+of the reform.  If your plan is to use tc to analyze tax reforms on
+your local computer, it is best to read the remaining parts of this
+section in order.  If your plan is to upload reform files to TaxBrain
+and view results there (and/or download those results to your computer
+for further analysis), you can read the next section on how of specify
+a tax reform file and then skip to the last part of this section on
+how to upload a reform file to TaxBrain.</p>
+
 <p><a href="#cli">Back to Section Contents</a></p>
 
 
 <h3 id="cli-spec-reform">Specify Tax Reform</h3>
 
-<p>Text goes here.</p>
+<p>The details of a tax reform are contained in a text file that you
+write with a text editor.  The reform is expressed by specifying which
+tax policy parameters are changed from their current-law values by the
+reform.  The timing and magnitude of these policy parameter changes
+are written in JSON, a simple and widely-used data-specification
+language.</p>
 
-<p>More text goes here.</p>
+<p>For several examples of reform files and the general rules for
+writing JSON reform files, go
+to <a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/reforms/REFORMS.md">this
+page</a>.</p>
+
+<p>If you want to upload reform files to TaxBrain for static analysis
+(rather than use the tc CLI on your computer for analysis), go to this
+section's last part, which discusses reform file uploading.  If you
+want to assume any responses to your tax reform (that is, if you want
+to conduct non-static analysis), read the next part before going to
+the last part.</p>
 
 <p><a href="#cli">Back to Section Contents</a></p>
 
 
 <h3 id="cli-spec-assump">Specify Analysis Assumptions</h3>
+
+<p>Text goes here.</p>
+
+<p>If you want to upload policy reform and response assumption files
+to TaxBrain, you can go directly to this section's last part, which
+discusses TaxBrain file uploading.  If you want to analyze your
+tax reforms on your local computer, go to the next part on how to
+specify tax filing units used in the analysis.</p>
+
+<p><a href="#cli">Back to Section Contents</a></p>
+
+
+<h3 id="cli-spec-funits">Specify Filing Units</h3>
 
 <p>Text goes here.</p>
 

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -91,7 +91,8 @@ def main():
                         action="store_true")
     parser.add_argument('--sqldb',
                         help=('optional flag that writes SQLite database with '
-                              'dump table containing same output as --dump.'),
+                              'dump table containing same output as '
+                              'produced by --dump option.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--test',

--- a/taxcalc/docs/index.htmx
+++ b/taxcalc/docs/index.htmx
@@ -181,14 +181,65 @@ installation and file preparation work may be worth it to you.</p>
 <p><a href="#cli-spec-output">Specify Output Options</a></p>
 <p><a href="#cli-init-analysis">Initiate Reform Analysis</a></p>
 <p><a href="#cli-tab-results">Tabulate Reform Results</a></p>
+<p><a href="#cli-taxbrain-upload">Upload Files to TaxBrain</a></p>
 
 
 <h3 id="cli-install-test">Install/Test tc CLI</h3>
 
-<p>Text goes here.</p>
+<p>Installation of tc CLI involves steps:</p>
 
-<p>More text goes here.</p>
+<p><b>Install the free Anaconda Python distribution</b> by going to
+the <a href="https://www.continuum.io/downloads">Continuum Analytics
+download page</a> and selecting a version of Python suitable for your
+computer.  You should install Python 2.7, which is the older and more
+stable version.  You must do this installation even if you already
+have Python installed on your computer because the Anaconda
+distribution contains all the additional Python packages that
+Tax-Calculator uses to conduct tax calculations (many of which are not
+included in other Python installations). You can install the Anaconda
+distribution without having administrative privileges on your computer
+and the Anaconda distribution will not interfere with any Python
+installation that came as part of your computer’s operating
+system.</p>
 
+<p><b>Check your Anaconda Python installation </b> by entering the
+following two commands at the operating system command prompt (which
+is shown as <kbd>$</kbd> here, but would be <kbd>></kbd> on Windows)
+in any directory:
+<pre>$ conda --version</pre>
+Expected output is something like <kbd>conda 4.3.17</kbd>
+<pre>$ python --version</pre>
+Expected output should contain the <kbd>Python 2.7.</kbd> and
+<kbd>Anaconda</kbd> phrases, the presence of which confirm that the
+installation went smoothly.  The full output could look something
+like this <kbd>Python 2.7.12 :: Anaconda 2.3.0 (x86_64)</kbd>.</p>
+
+<p><b>Install the free taxcalc package</b> by entering the following:
+<pre>$ conda install -c ospc taxcalc</pre>
+Expected output should contain information about all the additional
+packages that Tax-Calculator needs.  After all that information has
+been shown on the screen, press the <kbd>y</kbd> key to proceed with
+the package installations.</p>
+
+<p><b>Check your installation of tc</b> (the CLI to Tax-Calculator) by
+entering the following:
+<pre>$ tc --test</pre>
+Expected output (after about twenty seconds) should be <kbd>PASSED
+TEST</kbd>.  If you get <kbd>FAILED TEST</kbd>, something when wrong
+in the installation process.  If the installation test fails, please
+report your experience on
+the <a href="http://list.ospc.org/mailman/listinfo/users_list.ospc.org">Tax-Calculator
+users mailing list</a> or in an email to one of the core maintainers
+of Tax-Calculator listed at the bottom of the <i>What is TaxBrain?</i>
+page at <a href="http://www.ospc.org/taxbrain/">this website</a>.
+
+<p>If your installation passes the test, you are ready to begin using
+tc to analyze your tax reforms.  Continue reading this section for
+information about how to do that.  But if you want a quick hint about
+the range of tc capabilities, enter the following:
+<pre>$ tc --help</pre>
+</p>
+ 
 <p><a href="#cli">Back to Section Contents</a></p>
 
 
@@ -229,6 +280,13 @@ installation and file preparation work may be worth it to you.</p>
 
 
 <h3 id="cli-tab-results">Tabulate Reform Results</h3>
+
+<p>Text goes here.</p>
+
+<p>More text goes here.</p>
+
+
+<h3 id="cli-taxbrain-upload">Upload Files to TaxBrain</h3>
 
 <p>Text goes here.</p>
 

--- a/taxcalc/docs/index.htmx
+++ b/taxcalc/docs/index.htmx
@@ -178,6 +178,7 @@ installation and file preparation work may be worth it to you.</p>
 <p><a href="#cli-install-test">Install/Test tc CLI</a></p>
 <p><a href="#cli-spec-reform">Specify Tax Reform</a></p>
 <p><a href="#cli-spec-assump">Specify Analysis Assumptions</a></p>
+<p><a href="#cli-spec-funits">Specify Filing Units</a></p>
 <p><a href="#cli-spec-output">Specify Output Options</a></p>
 <p><a href="#cli-init-analysis">Initiate Reform Analysis</a></p>
 <p><a href="#cli-tab-results">Tabulate Reform Results</a></p>
@@ -186,7 +187,7 @@ installation and file preparation work may be worth it to you.</p>
 
 <h3 id="cli-install-test">Install/Test tc CLI</h3>
 
-<p>Installation of tc CLI involves steps:</p>
+<p>Installation of tc CLI involves several steps:</p>
 
 <p><b>Install the free Anaconda Python distribution</b> by going to
 the <a href="https://www.continuum.io/downloads">Continuum Analytics
@@ -202,7 +203,7 @@ and the Anaconda distribution will not interfere with any Python
 installation that came as part of your computer’s operating
 system.</p>
 
-<p><b>Check your Anaconda Python installation </b> by entering the
+<p><b>Check your Anaconda Python installation</b> by entering the
 following two commands at the operating system command prompt (which
 is shown as <kbd>$</kbd> here, but would be <kbd>></kbd> on Windows)
 in any directory:
@@ -224,8 +225,8 @@ the package installations.</p>
 <p><b>Check your installation of tc</b> (the CLI to Tax-Calculator) by
 entering the following:
 <pre>$ tc --test</pre>
-Expected output (after about twenty seconds) should be <kbd>PASSED
-TEST</kbd>.  If you get <kbd>FAILED TEST</kbd>, something when wrong
+Expected output (after about twenty seconds) is <kbd>PASSED
+TEST</kbd>.  If you get <kbd>FAILED TEST</kbd>, something went wrong
 in the installation process.  If the installation test fails, please
 report your experience on
 the <a href="http://list.ospc.org/mailman/listinfo/users_list.ospc.org">Tax-Calculator
@@ -239,20 +240,58 @@ information about how to do that.  But if you want a quick hint about
 the range of tc capabilities, enter the following:
 <pre>$ tc --help</pre>
 </p>
- 
+
+<p>The basic idea of tc tax analysis is that each tax reform is
+specified in a text file using a simple method to describe the details
+of the reform.  If your plan is to use tc to analyze tax reforms on
+your local computer, it is best to read the remaining parts of this
+section in order.  If your plan is to upload reform files to TaxBrain
+and view results there (and/or download those results to your computer
+for further analysis), you can read the next section on how of specify
+a tax reform file and then skip to the last part of this section on
+how to upload a reform file to TaxBrain.</p>
+
 <p><a href="#cli">Back to Section Contents</a></p>
 
 
 <h3 id="cli-spec-reform">Specify Tax Reform</h3>
 
-<p>Text goes here.</p>
+<p>The details of a tax reform are contained in a text file that you
+write with a text editor.  The reform is expressed by specifying which
+tax policy parameters are changed from their current-law values by the
+reform.  The timing and magnitude of these policy parameter changes
+are written in JSON, a simple and widely-used data-specification
+language.</p>
 
-<p>More text goes here.</p>
+<p>For several examples of reform files and the general rules for
+writing JSON reform files, go
+to <a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/reforms/REFORMS.md">this
+page</a>.</p>
+
+<p>If you want to upload reform files to TaxBrain for static analysis
+(rather than use the tc CLI on your computer for analysis), go to this
+section's last part, which discusses reform file uploading.  If you
+want to assume any responses to your tax reform (that is, if you want
+to conduct non-static analysis), read the next part before going to
+the last part.</p>
 
 <p><a href="#cli">Back to Section Contents</a></p>
 
 
 <h3 id="cli-spec-assump">Specify Analysis Assumptions</h3>
+
+<p>Text goes here.</p>
+
+<p>If you want to upload policy reform and response assumption files
+to TaxBrain, you can go directly to this section's last part, which
+discusses TaxBrain file uploading.  If you want to analyze your
+tax reforms on your local computer, go to the next part on how to
+specify tax filing units used in the analysis.</p>
+
+<p><a href="#cli">Back to Section Contents</a></p>
+
+
+<h3 id="cli-spec-funits">Specify Filing Units</h3>
 
 <p>Text goes here.</p>
 

--- a/taxcalc/reforms/README.md
+++ b/taxcalc/reforms/README.md
@@ -1,11 +1,12 @@
-This directory contains examples of tax reform provisions that can be
-combined and modified to construct tax reform proposals stored in text
-files on your local computer.
+This directory contains examples of tax reform files that can be
+combined and modified to construct your own tax reform proposals
+stored in text files on your local computer.
 
 Such reform proposals can then be uploaded to the [TaxBrain
-webapp](http://www.ospc.org/taxbrain/file/) (or used on your local
-computer) to estimate reform effects.
+webapp](http://www.ospc.org/taxbrain/file/) for analysis, or be
+analyzed on your local computer using the tc CLI (command-line
+interface) to Tax-Calculator, as described in the [user
+documentation](http://open-source-economics.github.io/Tax-Calculator/).
 
-[This document](REFORMS.md) provides access to the reform proposals
-that are currently available.
-
+[This document](REFORMS.md) provides access to several reform files
+that represent recent tax reform proposals.

--- a/taxcalc/reforms/REFORMS.md
+++ b/taxcalc/reforms/REFORMS.md
@@ -5,8 +5,9 @@ way to specify in a text file the collection of reform provisions that
 make up a reform proposal.  When stored on your local computer, such
 reform files can be used to estimate reform effects either by
 uploading to the [TaxBrain webapp](http://www.ospc.org/taxbrain/file/)
-or by using the `--reform` option to the `tc.py` command-line
-interface to Tax-Calculator.
+or by using the `--reform` option of the [tc
+CLI](http://open-source-economics.github.io/Tax-Calculator/#cli)
+(command-line interface) to Tax-Calculator.
 
 Here we provide links to several reform files that specify historical
 reform proposals, and then provide a more general explanation of the
@@ -62,8 +63,9 @@ separate, head of household, widow, separate.
 
 The following hypothetical payroll tax reforms illustrate the
 flexibility that reform files provide in expressing complex tax
-reforms.  Note that the current-law values of each tax parameter
-are shown in [this JSON file](../current_law_policy.json).
+reforms.  Note that the current-law values of each tax parameter are
+shown in the [user
+documentation](http://open-source-economics.github.io/Tax-Calculator/#pol).
 
 [Raise OASDI and HI payroll tax rates](ptaxes0.json)
 


### PR DESCRIPTION
This pull request adds text for the first few parts of the `tc CLI` section of the user documentation.

The changes in this pull request will be visible at [this webpage](http://open-source-economics.github.io/Tax-Calculator/) moments after this pull request is merged.  Any comments or suggestions on the partial draft are welcome.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @GoFroggyRun @codykallen @zrisher 