### PR TITLE
citation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ estimates using a nationally representative sample of tax filing units
 that is not part of the Tax-Calculator repository.
 
 And, of course, you can get started with Tax-Calculator both ways.
+
+Citing Tax-Calculator
+======================
+Tax-Calculator (Version #.#.#)[Source code], https://github.com/open-source-economics/tax-calculator


### PR DESCRIPTION
Some people are confused about how to cite tax-calculator, so this PR suggests:

Tax-Calculator (Version #.#.#)[Source code], https://github.com/open-source-economics/tax-calculator

This is for users of the python source code. I expect TaxBrain users will not cite Tax-Calculator directly, but will cite TaxBrain instead. 

@martinholmer @feenberg @codykallen @andersonfrailey @Amy-Xu @rickecon @jdebacker @kerkphil @GoFroggyRun 