### PR TITLE
Update pylint-disable comments after upgrading pylint from 1.5.4 to 1.6.4

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -263,7 +263,6 @@ class Behavior(ParametersBase):
         """
         Check that behavioral-response elasticities have valid values.
         """
-        # pylint: disable=too-many-branches
         msg = '{} elasticity cannot be {} in year {}; value is {}'
         pos = 'positive'
         neg = 'negative'

--- a/taxcalc/comparison/reform_results.py
+++ b/taxcalc/comparison/reform_results.py
@@ -13,13 +13,13 @@ USAGE: python reform_results.py
 # pep8 --ignore=E402 reform_results.py
 # pylint --disable=locally-disabled reform_results.py
 
-import json
-import pandas as pd
 import os
 import sys
+import json
+import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, "..", ".."))
-# pylint: disable=import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Policy, Records, Calculator, Behavior
 PUF_PATH = os.path.join(CUR_PATH, "..", "..", "puf.csv")
 PUF_DATA = pd.read_csv(PUF_PATH)

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -82,7 +82,6 @@ class Consumption(ParametersBase):
         Return true if any MPC parameters are positive for current_year;
         return false if all MPC parameters are zero.
         """
-        # pylint: disable=no-member
         for var in Consumption.RESPONSE_VARS:
             if getattr(self, 'MPC_{}'.format(var)) > 0.0:
                 return True
@@ -94,7 +93,6 @@ class Consumption(ParametersBase):
         """
         if not isinstance(records, Records):
             raise ValueError('records is not a Records object')
-        # pylint: disable=no-member
         for var in Consumption.RESPONSE_VARS:
             records_var = getattr(records, var)
             mpc_var = getattr(self, 'MPC_{}'.format(var))

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -30,7 +30,7 @@ def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
 
 
 try:
-    import numba  # pylint: disable=wrong-import-order,wrong-import-position
+    import numba
     jit = numba.jit  # pylint: disable=invalid-name
     DO_JIT = True
 except (ImportError, AttributeError):

--- a/taxcalc/docs/make.py
+++ b/taxcalc/docs/make.py
@@ -11,8 +11,9 @@ import json
 from collections import OrderedDict
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-# pylint: disable=wrong-import-position,import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Policy
+
 
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 INPUT_FILENAME = 'index.htmx'

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -658,7 +658,7 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
     the special taxation of long-term capital gains and qualified dividends
     if CG_nodiff is false
     """
-    # pylint: disable=too-many-statements,too-many-branches
+    # pylint: disable=too-many-statements
     if c01000 > 0. or c23650 > 0. or p23250 > 0. or e01100 > 0. or e00650 > 0.:
         hasqdivltcg = 1  # has qualified dividends or long-term capital gains
     else:
@@ -939,20 +939,21 @@ def EITC(MARS, DSI, EIC, c00100, e00300, e00400, e00600, c01000,
                 # enforce age eligibility rule for those with no EITC-eligible
                 # kids assuming that an unknown age_* value implies EITC age
                 # eligibility
-                # pylint: disable=bad-continuation,too-many-boolean-expressions
+                # pylint: disable=too-many-boolean-expressions
                 if MARS == 2:
-                    if (age_head == 0 or age_spouse == 0 or
-                        (age_head >= EITC_MinEligAge and
-                         age_head <= EITC_MaxEligAge) or
-                        (age_spouse >= EITC_MinEligAge and
-                         age_spouse <= EITC_MaxEligAge)):
+                    if (age_head == 0 or
+                            age_spouse == 0 or
+                            (age_head >= EITC_MinEligAge and
+                             age_head <= EITC_MaxEligAge) or
+                            (age_spouse >= EITC_MinEligAge and
+                             age_spouse <= EITC_MaxEligAge)):
                         c59660 = eitc
                     else:
                         c59660 = 0.
                 else:  # if MARS != 2
                     if (age_head == 0 or
-                        (age_head >= EITC_MinEligAge and
-                         age_head <= EITC_MaxEligAge)):
+                            (age_head >= EITC_MinEligAge and
+                             age_head <= EITC_MaxEligAge)):
                         c59660 = eitc
                     else:
                         c59660 = 0.

--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -69,6 +69,7 @@ class Growfactors(object):
         self._first_year = min(gfdf.index)
         self._last_year = max(gfdf.index)
         # set gfdf as attribute of class
+        self.gfdf = pd.DataFrame()
         setattr(self, 'gfdf', gfdf)
         # specify factors as being unused (that is, not yet accessed)
         self.used = False
@@ -91,7 +92,6 @@ class Growfactors(object):
         """
         Return list of price inflation rates rounded to four decimal digits
         """
-        # pylint: disable=no-member
         self.used = True
         if firstyear > lastyear:
             msg = 'first_year={} > last_year={}'
@@ -102,6 +102,7 @@ class Growfactors(object):
         if lastyear > self.last_year:
             msg = 'last_year={} > Growfactors.last_year={}'
             raise ValueError(msg.format(lastyear, self.last_year))
+        # pylint: disable=no-member
         rates = [round((self.gfdf['ACPIU'][cyr] - 1.0), 4)
                  for cyr in range(firstyear, lastyear + 1)]
         return rates
@@ -110,7 +111,6 @@ class Growfactors(object):
         """
         Return list of wage growth rates rounded to four decimal digits
         """
-        # pylint: disable=no-member
         self.used = True
         if firstyear > lastyear:
             msg = 'firstyear={} > lastyear={}'
@@ -121,6 +121,7 @@ class Growfactors(object):
         if lastyear > self.last_year:
             msg = 'lastyear={} > Growfactors.last_year={}'
             raise ValueError(msg.format(lastyear, self.last_year))
+        # pylint: disable=no-member
         rates = [round((self.gfdf['AWAGE'][cyr] - 1.0), 4)
                  for cyr in range(firstyear, lastyear + 1)]
         return rates
@@ -139,7 +140,7 @@ class Growfactors(object):
         if year > self.last_year:
             msg = 'year={} > Growfactors.last_year={}'
             raise ValueError(msg.format(year, self.last_year))
-        return self.gfdf[name][year]  # pylint: disable=no-member
+        return self.gfdf[name][year]
 
     def update(self, name, year, diff):
         """
@@ -148,4 +149,4 @@ class Growfactors(object):
         if self.used:
             msg = 'cannot update growfactors after they have been used'
             raise ValueError(msg)
-        self.gfdf[name][year] += diff  # pylint: disable=no-member
+        self.gfdf[name][year] += diff

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -56,8 +56,6 @@ class Policy(ParametersBase):
         """
         Policy class constructor.
         """
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-branches
         super(Policy, self).__init__()
 
         if not isinstance(gfactors, Growfactors):

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -240,9 +240,7 @@ class Records(object):
         """
         Applies to variables the grow factors for specified calendar year.
         """
-        # pylint: disable=too-many-statements
-        # pylint: disable=too-many-locals
-        # pylint: disable=unsubscriptable-object
+        # pylint: disable=too-many-locals,too-many-statements
         AWAGE = self.gfactors.factor_value('AWAGE', year)
         AINTS = self.gfactors.factor_value('AINTS', year)
         ADIVS = self.gfactors.factor_value('ADIVS', year)

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -59,8 +59,7 @@ class TaxCalcIO(object):
         """
         TaxCalcIO class constructor, which must be followed by init() call.
         """
-        # pylint: disable=too-many-branches
-        # pylint: disable=too-many-statements
+        # pylint: disable=too-many-branches,too-many-statements
         self.errmsg = ''
         # check name and existence of INPUT file
         inp = 'x'
@@ -595,8 +594,7 @@ class TaxCalcIO(object):
         -------
         Nothing
         """
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-arguments,too-many-locals
         progress = 'STARTING ANALYSIS FOR YEAR {}'
         gdiff_dict = {Policy.JSON_START_YEAR: {}}
         for year in range(Policy.JSON_START_YEAR, tax_year + 1):

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -213,8 +213,7 @@ def test_dropq_diff_table(groupby, res_column, puf_1991_path):
 
 
 @pytest.mark.requires_pufcsv
-def test_with_pufcsv(puf_path):  # pylint: disable=redefined-outer-name
-    # pylint: disable=too-many-locals
+def test_with_pufcsv(puf_path):
     # specify usermods dictionary in code
     start_year = 2016
     reform_year = start_year + 1

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -9,8 +9,7 @@ import os
 import re
 import ast
 import six
-# pylint: disable=import-error
-from taxcalc import Records
+from taxcalc import Records  # pylint: disable=import-error
 
 
 class GetFuncDefs(ast.NodeVisitor):

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -33,13 +33,12 @@ def puf_path(tests_path):
 
 
 @pytest.mark.requires_pufcsv
-def test_agg(tests_path, puf_path):
+def test_agg(tests_path, puf_path):  # pylint: disable=redefined-outer-name
     """
     Test Tax-Calculator aggregate taxes with no policy reform using
     the full-sample puf.csv and a two-percent sub-sample of puf.csv
     """
     # pylint: disable=too-many-locals,too-many-statements
-    # for fixture args, pylint: disable=redefined-outer-name
     nyrs = 10
     # create a Policy object (clp) containing current-law policy parameters
     clp = Policy()
@@ -155,7 +154,7 @@ def mtr_bin_counts(mtr_data, bin_edges, recid):
 
 
 @pytest.mark.requires_pufcsv
-def test_mtr(tests_path, puf_path):
+def test_mtr(tests_path, puf_path):  # pylint: disable=redefined-outer-name
     """
     Test Tax-Calculator marginal tax rates with no policy reform using puf.csv
 
@@ -164,7 +163,6 @@ def test_mtr(tests_path, puf_path):
     which is then compared for differences with EXPECTED_MTR_RESULTS.
     """
     # pylint: disable=too-many-locals,too-many-statements
-    # for fixture args, pylint: disable=redefined-outer-name
     assert len(PTAX_MTR_BIN_EDGES) == len(ITAX_MTR_BIN_EDGES)
     # construct actual results string, res
     res = ''
@@ -178,7 +176,7 @@ def test_mtr(tests_path, puf_path):
     clp.set_year(MTR_TAX_YEAR)
     # create a Records object (puf) containing puf.csv input records
     puf = Records(data=puf_path)
-    recid = puf.RECID  # pylint: disable=no-member
+    recid = puf.RECID
     # create a Calculator object using clp policy and puf records
     calc = Calculator(policy=clp, records=puf)
     res += '{} = {}\n'.format('Total number of data records', puf.dim)

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -8,8 +8,7 @@ Test example JSON policy reform files in taxcalc/reforms directory
 import os
 import glob
 import pytest
-# pylint: disable=import-error
-from taxcalc import Calculator, Policy
+from taxcalc import Calculator, Policy  # pylint: disable=import-error
 
 
 @pytest.fixture(scope='session')

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -9,8 +9,7 @@ import os
 import tempfile
 import pytest
 import pandas as pd
-# pylint: disable=import-error
-from taxcalc import TaxCalcIO, Growdiff
+from taxcalc import TaxCalcIO, Growdiff  # pylint: disable=import-error
 
 
 @pytest.mark.parametrize("input_data, reform, assump", [

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import math
 import filecmp
 import tempfile
@@ -267,6 +268,8 @@ def test_weighted_share_of_total():
 EPSILON = 1e-5
 
 
+@pytest.mark.skipif(sys.version_info == (3,4),
+                    reason="name is string (not interval) in Python 3.4")
 def test_add_income_bins():
     dta = np.arange(1, 1e6, 5000)
     dfx = pd.DataFrame(data=dta, columns=['expanded_income'])
@@ -288,6 +291,8 @@ def test_add_income_bins():
         idx += 1
 
 
+@pytest.mark.skipif(sys.version_info == (3,4),
+                    reason="name is string (not interval) in Python 3.4")
 def test_add_income_bins_soi():
     dta = np.arange(1, 1e6, 5000)
     dfx = pd.DataFrame(data=dta, columns=['expanded_income'])
@@ -310,6 +315,8 @@ def test_add_income_bins_soi():
         idx += 1
 
 
+@pytest.mark.skipif(sys.version_info == (3,4),
+                    reason="name is string (not interval) in Python 3.4")
 def test_add_income_bins_specify_bins():
     dta = np.arange(1, 1e6, 5000)
     dfx = pd.DataFrame(data=dta, columns=['expanded_income'])

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -1,4 +1,12 @@
-# pylint: disable=missing-docstring,invalid-name
+"""
+Tests of Tax-Calculator utility functions.
+"""
+# CODING-STYLE CHECKS:
+# pep8 --ignore=E402 test_utils.py
+# pylint --disable=locally-disabled test_utils.py
+#
+# pylint: disable=missing-docstring
+
 import os
 import sys
 import math
@@ -30,17 +38,17 @@ from taxcalc.utils import (TABLE_COLUMNS, TABLE_LABELS, STATS_COLUMNS,
                            certainty_equivalent, ce_aftertax_income)
 
 
-data = [[1.0, 2, 'a'],
+DATA = [[1.0, 2, 'a'],
         [-1.0, 4, 'a'],
         [3.0, 6, 'a'],
         [2.0, 4, 'b'],
         [3.0, 6, 'b']]
 
-weight_data = [[1.0, 2.0, 10.0],
+WEIGHT_DATA = [[1.0, 2.0, 10.0],
                [2.0, 4.0, 20.0],
                [3.0, 6.0, 30.0]]
 
-data_float = [[1.0, 2, 'a'],
+DATA_FLOAT = [[1.0, 2, 'a'],
               [-1.0, 4, 'a'],
               [0.0000000001, 3, 'a'],
               [-0.0000000001, 1, 'a'],
@@ -51,37 +59,37 @@ data_float = [[1.0, 2, 'a'],
               [3.0, 6, 'b']]
 
 
-def test_expand_1D_short_array():
-    x = np.array([4, 5, 9], dtype='i4')
+def test_expand_1d_short_array():
+    ary = np.array([4, 5, 9], dtype='i4')
     exp2 = np.array([9.0 * math.pow(1.02, i) for i in range(1, 8)])
     exp1 = np.array([4, 5, 9])
     exp = np.zeros(10)
     exp[:3] = exp1
     exp[3:] = exp2
-    res = Policy.expand_1D(x, inflate=True, inflation_rates=[0.02] * 10,
+    res = Policy.expand_1D(ary, inflate=True, inflation_rates=[0.02] * 10,
                            num_years=10)
     assert np.allclose(exp, res, atol=0.0, rtol=1.0E-7)
 
 
-def test_expand_1D_variable_rates():
-    x = np.array([4, 5, 9], dtype='f4')
+def test_expand_1d_variable_rates():
+    ary = np.array([4, 5, 9], dtype='f4')
     irates = [0.02, 0.02, 0.03, 0.035]
     exp = np.array([4, 5, 9, 9 * 1.03, 9 * 1.03 * 1.035])
-    res = Policy.expand_1D(x, inflate=True, inflation_rates=irates,
+    res = Policy.expand_1D(ary, inflate=True, inflation_rates=irates,
                            num_years=5)
     assert np.allclose(exp.astype('f4', casting='unsafe'), res)
 
 
-def test_expand_1D_scalar():
-    x = 10.0
-    exp = np.array([10.0 * math.pow(1.02, i) for i in range(0, 10)])
-    res = Policy.expand_1D(x, inflate=True, inflation_rates=[0.02] * 10,
+def test_expand_1d_scalar():
+    val = 10.0
+    exp = np.array([val * math.pow(1.02, i) for i in range(0, 10)])
+    res = Policy.expand_1D(val, inflate=True, inflation_rates=[0.02] * 10,
                            num_years=10)
     assert np.allclose(exp, res)
 
 
-def test_expand_1D_accept_None():
-    x = [4., 5., None]
+def test_expand_1d_accept_none():
+    lst = [4., 5., None]
     irates = [0.02, 0.02, 0.03, 0.035]
     exp = []
     cur = 5.0 * 1.02
@@ -91,31 +99,33 @@ def test_expand_1D_accept_None():
     cur *= 1.035
     exp.append(cur)
     exp = np.array(exp)
-    res = Policy.expand_array(x, inflate=True, inflation_rates=irates,
+    res = Policy.expand_array(lst, inflate=True, inflation_rates=irates,
                               num_years=5)
     assert np.allclose(exp.astype('f4', casting='unsafe'), res)
 
 
-def test_expand_2D_short_array():
-    x = np.array([[1, 2, 3]], dtype=np.float64)
+def test_expand_2d_short_array():
+    # does not recognize np.float64 as datatype, so pylint: disable=no-member
+    ary = np.array([[1, 2, 3]], dtype=np.float64)
     val = np.array([1, 2, 3], dtype=np.float64)
     exp2 = np.array([val * math.pow(1.02, i) for i in range(1, 5)])
     exp1 = np.array([1, 2, 3], dtype=np.float64)
     exp = np.zeros((5, 3))
     exp[:1] = exp1
     exp[1:] = exp2
-    res = Policy.expand_2D(x, inflate=True, inflation_rates=[0.02] * 5,
+    res = Policy.expand_2D(ary, inflate=True, inflation_rates=[0.02] * 5,
                            num_years=5)
     assert np.allclose(exp, res)
 
 
-def test_expand_2D_variable_rates():
-    x = np.array([[1, 2, 3]], dtype=np.float64)
+def test_expand_2d_variable_rates():
+    # does not recognize np.float64 as datatype, so pylint: disable=no-member
+    ary = np.array([[1, 2, 3]], dtype=np.float64)
     cur = np.array([1, 2, 3], dtype=np.float64)
     irates = [0.02, 0.02, 0.02, 0.03, 0.035]
     exp2 = []
     for i in range(0, 4):
-        idx = i + len(x) - 1
+        idx = i + len(ary) - 1
         cur = np.array(cur * (1.0 + irates[idx]))
         print('cur is ', cur)
         exp2.append(cur)
@@ -123,7 +133,7 @@ def test_expand_2D_variable_rates():
     exp = np.zeros((5, 3), dtype=np.float64)
     exp[:1] = exp1
     exp[1:] = exp2
-    res = Policy.expand_2D(x, inflate=True, inflation_rates=irates,
+    res = Policy.expand_2D(ary, inflate=True, inflation_rates=irates,
                            num_years=5)
     assert np.allclose(exp, res)
 
@@ -182,13 +192,13 @@ def test_create_tables(puf_1991, weights_1991):
 
 def test_weighted_count_lt_zero():
     assert count_lt_zero([0.0, 1, -1, 0, -2.2, 1.1]) == 2
-    df1 = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
+    df1 = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
     grped = df1.groupby('label')
     diffs = grped.apply(weighted_count_lt_zero, 'tax_diff')
     exp = pd.Series(data=[4, 0], index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)
-    df2 = pd.DataFrame(data=data_float, columns=['tax_diff', 's006', 'label'])
+    df2 = pd.DataFrame(data=DATA_FLOAT, columns=['tax_diff', 's006', 'label'])
     grped = df2.groupby('label')
     diffs = grped.apply(weighted_count_lt_zero, 'tax_diff')
     exp = pd.Series(data=[4, 0], index=['a', 'b'])
@@ -198,13 +208,13 @@ def test_weighted_count_lt_zero():
 
 def test_weighted_count_gt_zero():
     assert count_gt_zero([0.0, 1, -1, 0, -2.2, 1.1]) == 2
-    df1 = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
+    df1 = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
     grped = df1.groupby('label')
     diffs = grped.apply(weighted_count_gt_zero, 'tax_diff')
     exp = pd.Series(data=[8, 10], index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)
-    df2 = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
+    df2 = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
     grped = df2.groupby('label')
     diffs = grped.apply(weighted_count_gt_zero, 'tax_diff')
     exp = pd.Series(data=[8, 10], index=['a', 'b'])
@@ -213,73 +223,73 @@ def test_weighted_count_gt_zero():
 
 
 def test_weighted_count():
-    df = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
-    grped = df.groupby('label')
-    diffs = grped.apply(weighted_count)
+    dfx = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
+    grouped = dfx.groupby('label')
+    diffs = grouped.apply(weighted_count)
     exp = pd.Series(data=[12, 10], index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)
 
 
 def test_weighted_mean():
-    df = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
-    grped = df.groupby('label')
-    diffs = grped.apply(weighted_mean, 'tax_diff')
+    dfx = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
+    grouped = dfx.groupby('label')
+    diffs = grouped.apply(weighted_mean, 'tax_diff')
     exp = pd.Series(data=[16.0 / 12.0, 26.0 / 10.0], index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)
 
 
 def test_wage_weighted():
-    df = pd.DataFrame(data=weight_data, columns=['var', 's006', 'e00200'])
-    wvar = wage_weighted(df, 'var')
+    dfx = pd.DataFrame(data=WEIGHT_DATA, columns=['var', 's006', 'e00200'])
+    wvar = wage_weighted(dfx, 'var')
     assert round(wvar, 4) == 2.5714
 
 
 def test_agi_weighted():
-    df = pd.DataFrame(data=weight_data, columns=['var', 's006', 'c00100'])
-    wvar = agi_weighted(df, 'var')
+    dfx = pd.DataFrame(data=WEIGHT_DATA, columns=['var', 's006', 'c00100'])
+    wvar = agi_weighted(dfx, 'var')
     assert round(wvar, 4) == 2.5714
 
 
 def test_expanded_income_weighted():
-    df = pd.DataFrame(data=weight_data,
-                      columns=['var', 's006', 'expanded_income'])
-    wvar = expanded_income_weighted(df, 'var')
+    dfx = pd.DataFrame(data=WEIGHT_DATA,
+                       columns=['var', 's006', 'expanded_income'])
+    wvar = expanded_income_weighted(dfx, 'var')
     assert round(wvar, 4) == 2.5714
 
 
 def test_weighted_sum():
-    df = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
-    grped = df.groupby('label')
-    diffs = grped.apply(weighted_sum, 'tax_diff')
+    dfx = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
+    grouped = dfx.groupby('label')
+    diffs = grouped.apply(weighted_sum, 'tax_diff')
     exp = pd.Series(data=[16.0, 26.0], index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)
 
 
 def test_weighted_perc_inc():
-    df = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
-    grped = df.groupby('label')
-    diffs = grped.apply(weighted_perc_inc, 'tax_diff')
+    dfx = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
+    grouped = dfx.groupby('label')
+    diffs = grouped.apply(weighted_perc_inc, 'tax_diff')
     exp = pd.Series(data=[8. / 12., 1.0], index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)
 
 
 def test_weighted_perc_dec():
-    df = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
-    grped = df.groupby('label')
-    diffs = grped.apply(weighted_perc_dec, 'tax_diff')
+    dfx = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
+    grouped = dfx.groupby('label')
+    diffs = grouped.apply(weighted_perc_dec, 'tax_diff')
     exp = pd.Series(data=[4. / 12., 0.0], index=['a', 'b'])
     exp.index.name = 'label'
     assert_series_equal(exp, diffs)
 
 
 def test_weighted_share_of_total():
-    df = pd.DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
-    grped = df.groupby('label')
-    diffs = grped.apply(weighted_share_of_total, 'tax_diff', 42.0)
+    dfx = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
+    grouped = dfx.groupby('label')
+    diffs = grouped.apply(weighted_share_of_total, 'tax_diff', 42.0)
     exp = pd.Series(data=[16.0 / 42.001, 26.0 / 42.001],
                     index=['a', 'b'])
     exp.index.name = 'label'
@@ -289,7 +299,6 @@ def test_weighted_share_of_total():
 EPSILON = 1e-5
 
 
-@pytest.mark.one
 @pytest.mark.skipif((sys.version_info.major == 3 and
                      sys.version_info.minor == 4),
                     reason="name is string (not interval) in Python 3.4")
@@ -301,14 +310,14 @@ def test_add_income_bins():
     dfr = add_income_bins(dfx, compare_with='tpc', bins=None)
     groupedr = dfr.groupby('bins')
     idx = 1
-    for name, group in groupedr:
+    for name, _ in groupedr:
         assert name.closed == 'right'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
     dfl = add_income_bins(dfx, compare_with='tpc', bins=None, right=False)
     groupedl = dfl.groupby('bins')
     idx = 1
-    for name, group in groupedl:
+    for name, _ in groupedl:
         assert name.closed == 'left'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
@@ -326,14 +335,14 @@ def test_add_income_bins_soi():
     dfr = add_income_bins(dfx, compare_with='soi', bins=None)
     groupedr = dfr.groupby('bins')
     idx = 1
-    for name, group in groupedr:
+    for name, _ in groupedr:
         assert name.closed == 'right'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
     dfl = add_income_bins(dfx, compare_with='soi', bins=None, right=False)
     groupedl = dfl.groupby('bins')
     idx = 1
-    for name, group in groupedl:
+    for name, _ in groupedl:
         assert name.closed == 'left'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
@@ -342,21 +351,21 @@ def test_add_income_bins_soi():
 @pytest.mark.skipif((sys.version_info.major == 3 and
                      sys.version_info.minor == 4),
                     reason="name is string (not interval) in Python 3.4")
-def test_add_income_bins_specify_bins():
+def test_add_exp_income_bins():
     dta = np.arange(1, 1e6, 5000)
     dfx = pd.DataFrame(data=dta, columns=['expanded_income'])
     bins = [-1e14, 0, 4999, 9999, 14999, 19999, 29999, 32999, 43999, 1e14]
     dfr = add_income_bins(dfx, bins=bins)
     groupedr = dfr.groupby('bins')
     idx = 1
-    for name, group in groupedr:
+    for name, _ in groupedr:
         assert name.closed == 'right'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
     dfl = add_income_bins(dfx, bins=bins, right=False)
     groupedl = dfl.groupby('bins')
     idx = 1
-    for name, group in groupedl:
+    for name, _ in groupedl:
         assert name.closed == 'left'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
@@ -370,19 +379,19 @@ def test_add_income_bins_raises():
 
 
 def test_add_weighted_income_bins():
-    df = pd.DataFrame(data=data, columns=['expanded_income', 's006', 'label'])
-    df = add_weighted_income_bins(df, num_bins=100)
-    bin_labels = df['bins'].unique()
+    dfx = pd.DataFrame(data=DATA, columns=['expanded_income', 's006', 'label'])
+    dfb = add_weighted_income_bins(dfx, num_bins=100)
+    bin_labels = dfb['bins'].unique()
     default_labels = set(range(1, 101))
     for lab in bin_labels:
         assert lab in default_labels
-    # Custom labels
-    df = add_weighted_income_bins(df, weight_by_income_measure=True)
-    assert 'bins' in df
+    # custom labels
+    dfb = add_weighted_income_bins(dfx, weight_by_income_measure=True)
+    assert 'bins' in dfb
     custom_labels = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
-    df = add_weighted_income_bins(df, labels=custom_labels)
-    assert 'bins' in df
-    bin_labels = df['bins'].unique()
+    dfb = add_weighted_income_bins(dfx, labels=custom_labels)
+    assert 'bins' in dfb
+    bin_labels = dfb['bins'].unique()
     for lab in bin_labels:
         assert lab in custom_labels
 
@@ -391,14 +400,14 @@ def test_add_columns():
     cols = [[1000, 40, -10, 0, 10],
             [100, 8, 9, 100, 20],
             [-1000, 38, 90, 800, 30]]
-    df = pd.DataFrame(data=cols,
-                      columns=['c00100', 'c04470', 'standard',
-                               'c09600', 's006'])
-    add_columns(df)
-    assert_equal(df.c04470, np.array([40, 0, 0]))
-    assert_equal(df.num_returns_ItemDed, np.array([10, 0, 0]))
-    assert_equal(df.num_returns_StandardDed, np.array([0, 20, 0]))
-    assert_equal(df.num_returns_AMT, np.array([0, 20, 30]))
+    dfx = pd.DataFrame(data=cols,
+                       columns=['c00100', 'c04470', 'standard',
+                                'c09600', 's006'])
+    add_columns(dfx)
+    assert_equal(dfx.c04470, np.array([40, 0, 0]))
+    assert_equal(dfx.num_returns_ItemDed, np.array([10, 0, 0]))
+    assert_equal(dfx.num_returns_StandardDed, np.array([0, 20, 0]))
+    assert_equal(dfx.num_returns_AMT, np.array([0, 20, 30]))
 
 
 def test_dist_table_sum_row(records_2009):
@@ -407,17 +416,17 @@ def test_dist_table_sum_row(records_2009):
     # Create a Calculator
     calc1 = Calculator(policy=policy1, records=records_2009)
     calc1.calc_all()
-    t1 = create_distribution_table(calc1.records,
-                                   groupby='small_income_bins',
-                                   result_type='weighted_sum')
-    t2 = create_distribution_table(calc1.records,
-                                   groupby='large_income_bins',
-                                   result_type='weighted_sum')
-    assert np.allclose(t1[-1:], t2[-1:])
-    t3 = create_distribution_table(calc1.records,
-                                   groupby='small_income_bins',
-                                   result_type='weighted_avg')
-    assert isinstance(t3, pd.DataFrame)
+    tb1 = create_distribution_table(calc1.records,
+                                    groupby='small_income_bins',
+                                    result_type='weighted_sum')
+    tb2 = create_distribution_table(calc1.records,
+                                    groupby='large_income_bins',
+                                    result_type='weighted_sum')
+    assert np.allclose(tb1[-1:], tb2[-1:])
+    tb3 = create_distribution_table(calc1.records,
+                                    groupby='small_income_bins',
+                                    result_type='weighted_avg')
+    assert isinstance(tb3, pd.DataFrame)
 
 
 def test_diff_table_sum_row(puf_1991, weights_1991):
@@ -470,7 +479,8 @@ def test_row_classifier(puf_1991, weights_1991):
     assert_array_equal(calc1_s006, calc2_s006)
 
 
-def test_expand_2D_already_filled():
+def test_expand_2d_already_filled():
+    # pylint: disable=invalid-name
     _II_brk2 = [[36000, 72250, 36500, 48600, 72500, 36250],
                 [38000, 74000, 36900, 49400, 73800, 36900],
                 [40000, 74900, 37450, 50200, 74900, 37450]]
@@ -479,7 +489,8 @@ def test_expand_2D_already_filled():
     assert_equal(res, np.array(_II_brk2))
 
 
-def test_expand_2D_partial_expand():
+def test_expand_2d_partial_expand():
+    # pylint: disable=invalid-name
     _II_brk2 = [[36000, 72250, 36500, 48600, 72500, 36250],
                 [38000, 74000, 36900, 49400, 73800, 36900],
                 [40000, 74900, 37450, 50200, 74900, 37450]]
@@ -502,16 +513,17 @@ def test_expand_2D_partial_expand():
     assert_equal(res, exp)
 
 
-def test_strip_Nones():
-    x = [None, None]
-    assert Policy.strip_Nones(x) == []
-    x = [1, 2, None]
-    assert Policy.strip_Nones(x) == [1, 2]
-    x = [[1, 2, 3], [4, None, None]]
-    assert Policy.strip_Nones(x) == [[1, 2, 3], [4, -1, -1]]
+def test_strip_nones():
+    lst = [None, None]
+    assert Policy.strip_Nones(lst) == []
+    lst = [1, 2, None]
+    assert Policy.strip_Nones(lst) == [1, 2]
+    lst = [[1, 2, 3], [4, None, None]]
+    assert Policy.strip_Nones(lst) == [[1, 2, 3], [4, -1, -1]]
 
 
-def test_expand_2D_accept_None():
+def test_expand_2d_accept_none():
+    # pylint: disable=invalid-name
     _II_brk2 = [[36000, 72250, 36500, 48600, 72500],
                 [38000, 74000, 36900, 49400, 73800],
                 [40000, 74900, 37450, 50200, 74900],
@@ -544,8 +556,8 @@ def test_expand_2D_accept_None():
     assert_equal(pol.II_brk2, exp_2019)
 
 
-def test_expand_2D_accept_None_additional_row():
-    # pylint: disable=too-many-locals
+def test_expand_2d_accept_none_add_row():
+    # pylint: disable=invalid-name,too-many-locals
     _II_brk2 = [[36000, 72250, 36500, 48600, 72500],
                 [38000, 74000, 36900, 49400, 73800],
                 [40000, 74900, 37450, 50200, 74900],
@@ -569,7 +581,7 @@ def test_expand_2D_accept_None_additional_row():
                               inflation_rates=inflation_rates, num_years=5)
     assert_equal(res, exp)
 
-    user_mods = {2016: {u'_II_brk2': _II_brk2}}
+    user_mods = {2016: {'_II_brk2': _II_brk2}}
     syr = 2013
     pol = Policy(start_year=syr)
     irates = pol.inflation_rates()
@@ -703,7 +715,7 @@ def test_multiyear_diagnostic_table(records_2009):
     assert isinstance(adt, pd.DataFrame)
 
 
-def test_multiyear_diagnostic_table_wo_behv(records_2009):
+def test_myr_diag_table_wo_behv(records_2009):
     pol = Policy()
     reform = {
         2013: {
@@ -722,7 +734,7 @@ def test_multiyear_diagnostic_table_wo_behv(records_2009):
     assert_almost_equal(liabilities_x, liabilities_y, 2)
 
 
-def test_multiyear_diagnostic_table_w_behv(records_2009):
+def test_myr_diag_table_w_behv(records_2009):
     pol = Policy()
     behv = Behavior()
     calc = Calculator(policy=pol, records=records_2009, behavior=behv)
@@ -756,32 +768,33 @@ def csvfile():
            '9,10,11,12,0\n'
            '100,200,300,400,500\n'
            '123.45,678.912,000.000,87,92')
-    f = tempfile.NamedTemporaryFile(mode='a', delete=False)
-    f.write(txt + '\n')
-    f.close()
+    csvf = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    csvf.write(txt + '\n')
+    csvf.close()
     # Must close and then yield for Windows platform
-    yield f
-    os.remove(f.name)
+    yield csvf
+    os.remove(csvf.name)
 
 
 @pytest.yield_fixture
 def asciifile():
-    x = (
+    txt = (
         'A              \t1              \t100            \t123.45         \n'
         'B              \t2              \t200            \t678.912        \n'
         'C              \t3              \t300            \t000.000        \n'
         'D              \t4              \t400            \t87             \n'
         'EFGH           \t0              \t500            \t92             '
     )
-    f = tempfile.NamedTemporaryFile(mode='a', delete=False)
-    f.write(x + '\n')
-    f.close()
+    ascf = tempfile.NamedTemporaryFile(mode='a', delete=False)
+    ascf.write(txt + '\n')
+    ascf.close()
     # Must close and then yield for Windows platform
-    yield f
-    os.remove(f.name)
+    yield ascf
+    os.remove(ascf.name)
 
 
-def test_ascii_output_function(csvfile, asciifile):
+def test_ascii_output(csvfile,  # pylint: disable=redefined-outer-name
+                      asciifile):  # pylint: disable=redefined-outer-name
     output_test = tempfile.NamedTemporaryFile(mode='a', delete=False)
     ascii_output(csv_filename=csvfile.name, ascii_filename=output_test.name)
     assert filecmp.cmp(output_test.name, asciifile.name)
@@ -850,7 +863,7 @@ def test_read_egg_json():
         read_egg_json('bad_filename')
 
 
-def test_create_and_delete_temporary_file():
+def test_create_delete_temp_file():
     # test temporary_filename() and delete_file() functions
     fname = temporary_filename()
     with open(fname, 'w') as tmpfile:

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -627,7 +627,7 @@ def test_write_graph_file(records_2009):
     htmlfname = temporary_filename(suffix='.html')
     try:
         write_graph_file(gplot, htmlfname, 'title')
-    except:  # pylint: disable=bare-except
+    except:
         if os.path.isfile(htmlfname):
             try:
                 os.remove(htmlfname)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -276,12 +276,14 @@ def test_add_income_bins():
     grpd = df.groupby('bins')
     grps = [grp for grp in grpd]
     for g, num in zip(grps, bins[1:-1]):
-        assert g[0].endswith(str(num) + ']')
+        range = '{}'.format(g[0])
+        assert range.endswith(str(num) + '.0]')
     grpdl = add_income_bins(df, compare_with='tpc', bins=None, right=False)
     grpdl = grpdl.groupby('bins')
     grps = [grp for grp in grpdl]
     for g, num in zip(grps, bins[1:-1]):
-        assert g[0].endswith(str(num) + ')')
+        range = '{}'.format(g[0])
+        assert range.endswith(str(num) + '.0)')
 
 
 def test_add_income_bins_soi():
@@ -294,12 +296,14 @@ def test_add_income_bins_soi():
     grpd = df.groupby('bins')
     grps = [grp for grp in grpd]
     for g, num in zip(grps, bins[1:-1]):
-        assert g[0].endswith(str(num) + ']')
+        range = '{}'.format(g[0])
+        assert range.endswith(str(num) + '.0]')
     grpdl = add_income_bins(df, compare_with='soi', bins=None, right=False)
     grpdl = grpdl.groupby('bins')
     grps = [grp for grp in grpdl]
     for g, num in zip(grps, bins[1:-1]):
-        assert g[0].endswith(str(num) + ')')
+        range = '{}'.format(g[0])
+        assert range.endswith(str(num) + '.0)')
 
 
 def test_add_income_bins_specify_bins():
@@ -311,12 +315,14 @@ def test_add_income_bins_specify_bins():
     grpd = df.groupby('bins')
     grps = [grp for grp in grpd]
     for g, num in zip(grps, bins[1:-1]):
-        assert g[0].endswith(str(num) + ']')
+        range = '{}'.format(g[0])
+        assert range.endswith(str(num) + '.0]')
     grpdl = add_income_bins(df, bins=bins, right=False)
     grpdl = grpdl.groupby('bins')
     grps = [grp for grp in grpdl]
     for g, num in zip(grps, bins[1:-1]):
-        assert g[0].endswith(str(num) + ')')
+        range = '{}'.format(g[0])
+        assert range.endswith(str(num) + '.0)')
 
 
 def test_add_income_bins_raises():

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -268,7 +268,7 @@ def test_weighted_share_of_total():
 EPSILON = 1e-5
 
 
-@pytest.mark.skipif(sys.version_info == (3,4),
+@pytest.mark.skipif(sys.version_info == (3, 4),
                     reason="name is string (not interval) in Python 3.4")
 def test_add_income_bins():
     dta = np.arange(1, 1e6, 5000)
@@ -291,7 +291,7 @@ def test_add_income_bins():
         idx += 1
 
 
-@pytest.mark.skipif(sys.version_info == (3,4),
+@pytest.mark.skipif(sys.version_info == (3, 4),
                     reason="name is string (not interval) in Python 3.4")
 def test_add_income_bins_soi():
     dta = np.arange(1, 1e6, 5000)
@@ -315,7 +315,7 @@ def test_add_income_bins_soi():
         idx += 1
 
 
-@pytest.mark.skipif(sys.version_info == (3,4),
+@pytest.mark.skipif(sys.version_info == (3, 4),
                     reason="name is string (not interval) in Python 3.4")
 def test_add_income_bins_specify_bins():
     dta = np.arange(1, 1e6, 5000)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -267,23 +267,28 @@ def test_weighted_share_of_total():
     assert_series_equal(exp, diffs)
 
 
+EPSILON = 1e-2
+
+
 def test_add_income_bins():
     data = np.arange(1, 1e6, 5000)
     df = DataFrame(data=data, columns=['expanded_income'])
     bins = [-1e14, 0, 9999, 19999, 29999, 39999, 49999, 74999, 99999,
             200000, 1e14]
-    df = add_income_bins(df, compare_with='tpc', bins=None)
-    grpd = df.groupby('bins')
-    grps = [grp for grp in grpd]
-    for g, num in zip(grps, bins[1:-1]):
-        range = '{}'.format(g[0])
-        assert range.endswith(str(num) + '.0]')
-    grpdl = add_income_bins(df, compare_with='tpc', bins=None, right=False)
-    grpdl = grpdl.groupby('bins')
-    grps = [grp for grp in grpdl]
-    for g, num in zip(grps, bins[1:-1]):
-        range = '{}'.format(g[0])
-        assert range.endswith(str(num) + '.0)')
+    dfr = add_income_bins(df, compare_with='tpc', bins=None)
+    groupedr = dfr.groupby('bins')
+    idx = 1
+    for name, group in groupedr:
+        assert name.closed == 'right'
+        assert abs(name.right - bins[idx]) < EPSILON
+        idx += 1
+    dfl = add_income_bins(df, compare_with='tpc', bins=None, right=False)
+    groupedl = dfl.groupby('bins')
+    idx = 1
+    for name, group in groupedl:
+        assert name.closed == 'left'
+        assert abs(name.right - bins[idx]) < EPSILON
+        idx += 1
 
 
 def test_add_income_bins_soi():
@@ -292,18 +297,20 @@ def test_add_income_bins_soi():
     bins = [-1e14, 0, 4999, 9999, 14999, 19999, 24999, 29999, 39999,
             49999, 74999, 99999, 199999, 499999, 999999, 1499999,
             1999999, 4999999, 9999999, 1e14]
-    df = add_income_bins(df, compare_with='soi', bins=None)
-    grpd = df.groupby('bins')
-    grps = [grp for grp in grpd]
-    for g, num in zip(grps, bins[1:-1]):
-        range = '{}'.format(g[0])
-        assert range.endswith(str(num) + '.0]')
-    grpdl = add_income_bins(df, compare_with='soi', bins=None, right=False)
-    grpdl = grpdl.groupby('bins')
-    grps = [grp for grp in grpdl]
-    for g, num in zip(grps, bins[1:-1]):
-        range = '{}'.format(g[0])
-        assert range.endswith(str(num) + '.0)')
+    dfr = add_income_bins(df, compare_with='soi', bins=None)
+    groupedr = dfr.groupby('bins')
+    idx = 1
+    for name, group in groupedr:
+        assert name.closed == 'right'
+        assert abs(name.right - bins[idx]) < EPSILON
+        idx += 1
+    dfl = add_income_bins(df, compare_with='soi', bins=None, right=False)
+    groupedl = dfl.groupby('bins')
+    idx = 1
+    for name, group in groupedl:
+        assert name.closed == 'left'
+        assert abs(name.right - bins[idx]) < EPSILON
+        idx += 1
 
 
 def test_add_income_bins_specify_bins():
@@ -311,18 +318,20 @@ def test_add_income_bins_specify_bins():
     df = DataFrame(data=data, columns=['expanded_income'])
     bins = [-1e14, 0, 4999, 9999, 14999, 19999, 29999, 32999, 43999,
             1e14]
-    df = add_income_bins(df, bins=bins)
-    grpd = df.groupby('bins')
-    grps = [grp for grp in grpd]
-    for g, num in zip(grps, bins[1:-1]):
-        range = '{}'.format(g[0])
-        assert range.endswith(str(num) + '.0]')
-    grpdl = add_income_bins(df, bins=bins, right=False)
-    grpdl = grpdl.groupby('bins')
-    grps = [grp for grp in grpdl]
-    for g, num in zip(grps, bins[1:-1]):
-        range = '{}'.format(g[0])
-        assert range.endswith(str(num) + '.0)')
+    dfr = add_income_bins(df, bins=bins)
+    groupedr = dfr.groupby('bins')
+    idx = 1
+    for name, group in groupedr:
+        assert name.closed == 'right'
+        assert abs(name.right - bins[idx]) < EPSILON
+        idx += 1
+    dfl = add_income_bins(df, bins=bins, right=False)
+    groupedl = dfl.groupby('bins')
+    idx = 1
+    for name, group in groupedl:
+        assert name.closed == 'left'
+        assert abs(name.right - bins[idx]) < EPSILON
+        idx += 1
 
 
 def test_add_income_bins_raises():

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -693,7 +693,7 @@ def ascii_output(csv_filename, ascii_filename):
         def pdf_recid(recid):
             """ Return Pandas DataFrame recid value for specified recid """
             return recid - 1
-        recids = map(pdf_recid, recids)  # pylint: disable=bad-builtin
+        recids = map(pdf_recid, recids)
         pdf = pdf.ix[recids]  # pylint: disable=no-member
     # do transposition
     out = pdf.T.reset_index()  # pylint: disable=no-member
@@ -1378,7 +1378,7 @@ def read_egg_csv(fname, **kwargs):
         path_in_egg = os.path.join('taxcalc', fname)
         vdf = pd.read_csv(resource_stream(Requirement.parse('taxcalc'),
                                           path_in_egg), **kwargs)
-    except:  # pylint: disable=bare-except
+    except:
         raise ValueError('could not read {} data from egg'.format(fname))
     return vdf
 
@@ -1393,7 +1393,7 @@ def read_egg_json(fname):
         pdict = json.loads(resource_stream(Requirement.parse('taxcalc'),
                                            path_in_egg).read().decode('utf-8'),
                            object_pairs_hook=OrderedDict)
-    except:  # pylint: disable=bare-except
+    except:
         raise ValueError('could not read {} data from egg'.format(fname))
     return pdict
 

--- a/taxcalc/validation/csv_extract.py
+++ b/taxcalc/validation/csv_extract.py
@@ -12,7 +12,7 @@ import os
 import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-# pylint: disable=wrong-import-position,import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Records
 
 

--- a/taxcalc/validation/csv_input.py
+++ b/taxcalc/validation/csv_input.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-# pylint: disable=wrong-import-position,import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Records
 
 # specify maximum allowed values for command-line parameters

--- a/taxcalc/validation/taxsim/simpletaxio.py
+++ b/taxcalc/validation/taxsim/simpletaxio.py
@@ -12,7 +12,7 @@ import six
 import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..', '..'))
-# pylint: disable=wrong-import-position,import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Policy, Records, Calculator
 
 
@@ -67,7 +67,6 @@ class SimpleTaxIO(object):
         SimpleTaxIO class constructor.
         """
         # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-branches
         # check that input_filename is a string
         if not isinstance(input_filename, six.string_types):
             msg = 'SimpleTaxIO.ctor input_filename is not a string'
@@ -157,7 +156,7 @@ class SimpleTaxIO(object):
             self.calc.calc_all()
             (mtr_ptax, mtr_itax,
              _) = self.calc.mtr(wrt_full_compensation=False)
-            cr_taxyr = self.calc.records.FLPDYR  # pylint: disable=no-member
+            cr_taxyr = self.calc.records.FLPDYR
             for idx in range(0, self.calc.records.dim):
                 indyr = cr_taxyr[idx]
                 if indyr == calcyr:

--- a/taxcalc/validation/taxsim/test_simpletaxio.py
+++ b/taxcalc/validation/taxsim/test_simpletaxio.py
@@ -111,12 +111,14 @@ def test_incorrect_creation(filename, exact):
         )
 
 
+# for fixture args, pylint: disable=redefined-outer-name
+
+
 @pytest.mark.parametrize("reform", ['badname.json', list()])
 def test_invalid_creation_w_file(input_file, reform):
     """
     Test incorrect SimpleTaxIO instantiation with input_file
     """
-    # for fixture args, pylint: disable=redefined-outer-name
     with pytest.raises(ValueError):
         SimpleTaxIO(
             input_filename=input_file.name,
@@ -127,7 +129,7 @@ def test_invalid_creation_w_file(input_file, reform):
         )
 
 
-def test_1(input_file):  # pylint: disable=redefined-outer-name
+def test_1(input_file):
     """
     Test SimpleTaxIO instantiation with no policy reform.
     """
@@ -141,17 +143,16 @@ def test_1(input_file):  # pylint: disable=redefined-outer-name
     # test extracting of weight and debugging variables
     crecs = simtax.calc.records
     SimpleTaxIO.DVAR_NAMES = ['f2441']
-    # pylint: disable=unused-variable
     ovar = SimpleTaxIO.extract_output(crecs, 0,
                                       exact=True, extract_weight=True)
+    assert ovar
     SimpleTaxIO.DVAR_NAMES = ['badvar']
     with pytest.raises(ValueError):
         ovar = SimpleTaxIO.extract_output(crecs, 0)
     SimpleTaxIO.DVAR_NAMES = []
 
 
-def test_2(input_file,  # pylint: disable=redefined-outer-name
-           reform_file):  # pylint: disable=redefined-outer-name
+def test_2(input_file, reform_file):
     """
     Test SimpleTaxIO instantiation with a policy reform from JSON file.
     """
@@ -163,7 +164,7 @@ def test_2(input_file,  # pylint: disable=redefined-outer-name
     assert simtax.number_input_lines() == NUM_INPUT_LINES
     # check that reform was implemented as specified above in REFORM_CONTENTS
     syr = simtax.start_year()
-    # pylint: disable=protected-access,no-member
+    # pylint: disable=protected-access
     amt_brk1 = simtax.policy._AMT_brk1
     assert amt_brk1[2015 - syr] == 200000
     assert amt_brk1[2016 - syr] > 200000
@@ -186,7 +187,7 @@ def test_2(input_file,  # pylint: disable=redefined-outer-name
     assert amt_em[2022 - syr, 0] > amt_em[2021 - syr, 0]
 
 
-def test_3(input_file):  # pylint: disable=redefined-outer-name
+def test_3(input_file):
     """
     Test SimpleTaxIO calculate method with a policy reform from dictionary.
     """


### PR DESCRIPTION
This pull request changes (mostly deletes) several pylint-disable comments to reflect the new pylint version 1.6.4 that is part of the Anaconda 4.3.1 distribution.  One example of the changes is that the default maximum number of branches in a method/function allowed before a pylint warning is raised has been increased (so some disable=too-many-branches comments have been removed).

This pull request causes no change in tax logic or results.
