### PR TITLE
fix record description

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -263,7 +263,6 @@ class Behavior(ParametersBase):
         """
         Check that behavioral-response elasticities have valid values.
         """
-        # pylint: disable=too-many-branches
         msg = '{} elasticity cannot be {} in year {}; value is {}'
         pos = 'positive'
         neg = 'negative'

--- a/taxcalc/comparison/reform_results.py
+++ b/taxcalc/comparison/reform_results.py
@@ -13,13 +13,13 @@ USAGE: python reform_results.py
 # pep8 --ignore=E402 reform_results.py
 # pylint --disable=locally-disabled reform_results.py
 
-import json
-import pandas as pd
 import os
 import sys
+import json
+import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, "..", ".."))
-# pylint: disable=import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Policy, Records, Calculator, Behavior
 PUF_PATH = os.path.join(CUR_PATH, "..", "..", "puf.csv")
 PUF_DATA = pd.read_csv(PUF_PATH)

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -82,7 +82,6 @@ class Consumption(ParametersBase):
         Return true if any MPC parameters are positive for current_year;
         return false if all MPC parameters are zero.
         """
-        # pylint: disable=no-member
         for var in Consumption.RESPONSE_VARS:
             if getattr(self, 'MPC_{}'.format(var)) > 0.0:
                 return True
@@ -94,7 +93,6 @@ class Consumption(ParametersBase):
         """
         if not isinstance(records, Records):
             raise ValueError('records is not a Records object')
-        # pylint: disable=no-member
         for var in Consumption.RESPONSE_VARS:
             records_var = getattr(records, var)
             mpc_var = getattr(self, 'MPC_{}'.format(var))

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -30,7 +30,7 @@ def id_wrapper(*dec_args, **dec_kwargs):  # pylint: disable=unused-argument
 
 
 try:
-    import numba  # pylint: disable=wrong-import-order,wrong-import-position
+    import numba
     jit = numba.jit  # pylint: disable=invalid-name
     DO_JIT = True
 except (ImportError, AttributeError):

--- a/taxcalc/docs/make.py
+++ b/taxcalc/docs/make.py
@@ -11,8 +11,9 @@ import json
 from collections import OrderedDict
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-# pylint: disable=wrong-import-position,import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Policy
+
 
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 INPUT_FILENAME = 'index.htmx'

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -658,7 +658,7 @@ def GainsTax(e00650, c01000, c23650, p23250, e01100, e58990,
     the special taxation of long-term capital gains and qualified dividends
     if CG_nodiff is false
     """
-    # pylint: disable=too-many-statements,too-many-branches
+    # pylint: disable=too-many-statements
     if c01000 > 0. or c23650 > 0. or p23250 > 0. or e01100 > 0. or e00650 > 0.:
         hasqdivltcg = 1  # has qualified dividends or long-term capital gains
     else:
@@ -939,20 +939,21 @@ def EITC(MARS, DSI, EIC, c00100, e00300, e00400, e00600, c01000,
                 # enforce age eligibility rule for those with no EITC-eligible
                 # kids assuming that an unknown age_* value implies EITC age
                 # eligibility
-                # pylint: disable=bad-continuation,too-many-boolean-expressions
+                # pylint: disable=too-many-boolean-expressions
                 if MARS == 2:
-                    if (age_head == 0 or age_spouse == 0 or
-                        (age_head >= EITC_MinEligAge and
-                         age_head <= EITC_MaxEligAge) or
-                        (age_spouse >= EITC_MinEligAge and
-                         age_spouse <= EITC_MaxEligAge)):
+                    if (age_head == 0 or
+                            age_spouse == 0 or
+                            (age_head >= EITC_MinEligAge and
+                             age_head <= EITC_MaxEligAge) or
+                            (age_spouse >= EITC_MinEligAge and
+                             age_spouse <= EITC_MaxEligAge)):
                         c59660 = eitc
                     else:
                         c59660 = 0.
                 else:  # if MARS != 2
                     if (age_head == 0 or
-                        (age_head >= EITC_MinEligAge and
-                         age_head <= EITC_MaxEligAge)):
+                            (age_head >= EITC_MinEligAge and
+                             age_head <= EITC_MaxEligAge)):
                         c59660 = eitc
                     else:
                         c59660 = 0.

--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -69,6 +69,7 @@ class Growfactors(object):
         self._first_year = min(gfdf.index)
         self._last_year = max(gfdf.index)
         # set gfdf as attribute of class
+        self.gfdf = pd.DataFrame()
         setattr(self, 'gfdf', gfdf)
         # specify factors as being unused (that is, not yet accessed)
         self.used = False
@@ -91,7 +92,6 @@ class Growfactors(object):
         """
         Return list of price inflation rates rounded to four decimal digits
         """
-        # pylint: disable=no-member
         self.used = True
         if firstyear > lastyear:
             msg = 'first_year={} > last_year={}'
@@ -102,6 +102,7 @@ class Growfactors(object):
         if lastyear > self.last_year:
             msg = 'last_year={} > Growfactors.last_year={}'
             raise ValueError(msg.format(lastyear, self.last_year))
+        # pylint: disable=no-member
         rates = [round((self.gfdf['ACPIU'][cyr] - 1.0), 4)
                  for cyr in range(firstyear, lastyear + 1)]
         return rates
@@ -110,7 +111,6 @@ class Growfactors(object):
         """
         Return list of wage growth rates rounded to four decimal digits
         """
-        # pylint: disable=no-member
         self.used = True
         if firstyear > lastyear:
             msg = 'firstyear={} > lastyear={}'
@@ -121,6 +121,7 @@ class Growfactors(object):
         if lastyear > self.last_year:
             msg = 'lastyear={} > Growfactors.last_year={}'
             raise ValueError(msg.format(lastyear, self.last_year))
+        # pylint: disable=no-member
         rates = [round((self.gfdf['AWAGE'][cyr] - 1.0), 4)
                  for cyr in range(firstyear, lastyear + 1)]
         return rates
@@ -139,7 +140,7 @@ class Growfactors(object):
         if year > self.last_year:
             msg = 'year={} > Growfactors.last_year={}'
             raise ValueError(msg.format(year, self.last_year))
-        return self.gfdf[name][year]  # pylint: disable=no-member
+        return self.gfdf[name][year]
 
     def update(self, name, year, diff):
         """
@@ -148,4 +149,4 @@ class Growfactors(object):
         if self.used:
             msg = 'cannot update growfactors after they have been used'
             raise ValueError(msg)
-        self.gfdf[name][year] += diff  # pylint: disable=no-member
+        self.gfdf[name][year] += diff

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -56,8 +56,6 @@ class Policy(ParametersBase):
         """
         Policy class constructor.
         """
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-branches
         super(Policy, self).__init__()
 
         if not isinstance(gfactors, Growfactors):

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -240,9 +240,7 @@ class Records(object):
         """
         Applies to variables the grow factors for specified calendar year.
         """
-        # pylint: disable=too-many-statements
-        # pylint: disable=too-many-locals
-        # pylint: disable=unsubscriptable-object
+        # pylint: disable=too-many-locals,too-many-statements
         AWAGE = self.gfactors.factor_value('AWAGE', year)
         AINTS = self.gfactors.factor_value('AINTS', year)
         ADIVS = self.gfactors.factor_value('ADIVS', year)

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -403,17 +403,17 @@
     },
     "nu18": {
       "type": "int",
-      "desc": "Number of people under 18 years old in the tax unit",
+      "desc": "Number of people under 18 years old in the filing unit",
       "form": {"2013-2016": "imputed from CPS data"}
     },
     "n1821": {
       "type": "int",
-      "desc": "Number of people over 18 and under 21 years old in the tax unit",
+      "desc": "Number of people over 18 and under 21 years old in the filing unit",
       "form": {"2013-2016": "imputed from CPS data"}
     },
     "n21": {
       "type": "int",
-      "desc": "Number of people 21 years old or older in the tax unit",
+      "desc": "Number of people 21 years old or older in the filing unit",
       "form": {"2013-2016": "imputed from CPS data"}
     },
     "p08000": {

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -403,17 +403,17 @@
     },
     "nu18": {
       "type": "int",
-      "desc": "Number of dependents under 18 years old",
+      "desc": "Number of people under 18 years old in the tax unit",
       "form": {"2013-2016": "imputed from CPS data"}
     },
     "n1821": {
       "type": "int",
-      "desc": "Number of dependents over 18 and under 21 years old",
+      "desc": "Number of people over 18 and under 21 years old in the tax unit",
       "form": {"2013-2016": "imputed from CPS data"}
     },
     "n21": {
       "type": "int",
-      "desc": "Number of dependents 21 years old or older",
+      "desc": "Number of people 21 years old or older in the tax unit",
       "form": {"2013-2016": "imputed from CPS data"}
     },
     "p08000": {

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -59,8 +59,7 @@ class TaxCalcIO(object):
         """
         TaxCalcIO class constructor, which must be followed by init() call.
         """
-        # pylint: disable=too-many-branches
-        # pylint: disable=too-many-statements
+        # pylint: disable=too-many-branches,too-many-statements
         self.errmsg = ''
         # check name and existence of INPUT file
         inp = 'x'
@@ -595,8 +594,7 @@ class TaxCalcIO(object):
         -------
         Nothing
         """
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-arguments,too-many-locals
         progress = 'STARTING ANALYSIS FOR YEAR {}'
         gdiff_dict = {Policy.JSON_START_YEAR: {}}
         for year in range(Policy.JSON_START_YEAR, tax_year + 1):

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -213,8 +213,7 @@ def test_dropq_diff_table(groupby, res_column, puf_1991_path):
 
 
 @pytest.mark.requires_pufcsv
-def test_with_pufcsv(puf_path):  # pylint: disable=redefined-outer-name
-    # pylint: disable=too-many-locals
+def test_with_pufcsv(puf_path):
     # specify usermods dictionary in code
     start_year = 2016
     reform_year = start_year + 1

--- a/taxcalc/tests/test_functions.py
+++ b/taxcalc/tests/test_functions.py
@@ -9,8 +9,7 @@ import os
 import re
 import ast
 import six
-# pylint: disable=import-error
-from taxcalc import Records
+from taxcalc import Records  # pylint: disable=import-error
 
 
 class GetFuncDefs(ast.NodeVisitor):

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -33,13 +33,12 @@ def puf_path(tests_path):
 
 
 @pytest.mark.requires_pufcsv
-def test_agg(tests_path, puf_path):
+def test_agg(tests_path, puf_path):  # pylint: disable=redefined-outer-name
     """
     Test Tax-Calculator aggregate taxes with no policy reform using
     the full-sample puf.csv and a two-percent sub-sample of puf.csv
     """
     # pylint: disable=too-many-locals,too-many-statements
-    # for fixture args, pylint: disable=redefined-outer-name
     nyrs = 10
     # create a Policy object (clp) containing current-law policy parameters
     clp = Policy()
@@ -155,7 +154,7 @@ def mtr_bin_counts(mtr_data, bin_edges, recid):
 
 
 @pytest.mark.requires_pufcsv
-def test_mtr(tests_path, puf_path):
+def test_mtr(tests_path, puf_path):  # pylint: disable=redefined-outer-name
     """
     Test Tax-Calculator marginal tax rates with no policy reform using puf.csv
 
@@ -164,7 +163,6 @@ def test_mtr(tests_path, puf_path):
     which is then compared for differences with EXPECTED_MTR_RESULTS.
     """
     # pylint: disable=too-many-locals,too-many-statements
-    # for fixture args, pylint: disable=redefined-outer-name
     assert len(PTAX_MTR_BIN_EDGES) == len(ITAX_MTR_BIN_EDGES)
     # construct actual results string, res
     res = ''
@@ -178,7 +176,7 @@ def test_mtr(tests_path, puf_path):
     clp.set_year(MTR_TAX_YEAR)
     # create a Records object (puf) containing puf.csv input records
     puf = Records(data=puf_path)
-    recid = puf.RECID  # pylint: disable=no-member
+    recid = puf.RECID
     # create a Calculator object using clp policy and puf records
     calc = Calculator(policy=clp, records=puf)
     res += '{} = {}\n'.format('Total number of data records', puf.dim)

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -8,8 +8,7 @@ Test example JSON policy reform files in taxcalc/reforms directory
 import os
 import glob
 import pytest
-# pylint: disable=import-error
-from taxcalc import Calculator, Policy
+from taxcalc import Calculator, Policy  # pylint: disable=import-error
 
 
 @pytest.fixture(scope='session')

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -9,8 +9,7 @@ import os
 import tempfile
 import pytest
 import pandas as pd
-# pylint: disable=import-error
-from taxcalc import TaxCalcIO, Growdiff
+from taxcalc import TaxCalcIO, Growdiff  # pylint: disable=import-error
 
 
 @pytest.mark.parametrize("input_data, reform, assump", [

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -693,7 +693,7 @@ def ascii_output(csv_filename, ascii_filename):
         def pdf_recid(recid):
             """ Return Pandas DataFrame recid value for specified recid """
             return recid - 1
-        recids = map(pdf_recid, recids)  # pylint: disable=bad-builtin
+        recids = map(pdf_recid, recids)
         pdf = pdf.ix[recids]  # pylint: disable=no-member
     # do transposition
     out = pdf.T.reset_index()  # pylint: disable=no-member
@@ -1378,7 +1378,7 @@ def read_egg_csv(fname, **kwargs):
         path_in_egg = os.path.join('taxcalc', fname)
         vdf = pd.read_csv(resource_stream(Requirement.parse('taxcalc'),
                                           path_in_egg), **kwargs)
-    except:  # pylint: disable=bare-except
+    except:
         raise ValueError('could not read {} data from egg'.format(fname))
     return vdf
 
@@ -1393,7 +1393,7 @@ def read_egg_json(fname):
         pdict = json.loads(resource_stream(Requirement.parse('taxcalc'),
                                            path_in_egg).read().decode('utf-8'),
                            object_pairs_hook=OrderedDict)
-    except:  # pylint: disable=bare-except
+    except:
         raise ValueError('could not read {} data from egg'.format(fname))
     return pdict
 

--- a/taxcalc/validation/csv_extract.py
+++ b/taxcalc/validation/csv_extract.py
@@ -12,7 +12,7 @@ import os
 import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-# pylint: disable=wrong-import-position,import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Records
 
 

--- a/taxcalc/validation/csv_input.py
+++ b/taxcalc/validation/csv_input.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..'))
-# pylint: disable=wrong-import-position,import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Records
 
 # specify maximum allowed values for command-line parameters

--- a/taxcalc/validation/taxsim/simpletaxio.py
+++ b/taxcalc/validation/taxsim/simpletaxio.py
@@ -12,7 +12,7 @@ import six
 import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..', '..', '..'))
-# pylint: disable=wrong-import-position,import-error
+# pylint: disable=import-error,wrong-import-position
 from taxcalc import Policy, Records, Calculator
 
 
@@ -67,7 +67,6 @@ class SimpleTaxIO(object):
         SimpleTaxIO class constructor.
         """
         # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-branches
         # check that input_filename is a string
         if not isinstance(input_filename, six.string_types):
             msg = 'SimpleTaxIO.ctor input_filename is not a string'
@@ -157,7 +156,7 @@ class SimpleTaxIO(object):
             self.calc.calc_all()
             (mtr_ptax, mtr_itax,
              _) = self.calc.mtr(wrt_full_compensation=False)
-            cr_taxyr = self.calc.records.FLPDYR  # pylint: disable=no-member
+            cr_taxyr = self.calc.records.FLPDYR
             for idx in range(0, self.calc.records.dim):
                 indyr = cr_taxyr[idx]
                 if indyr == calcyr:

--- a/taxcalc/validation/taxsim/test_simpletaxio.py
+++ b/taxcalc/validation/taxsim/test_simpletaxio.py
@@ -111,12 +111,14 @@ def test_incorrect_creation(filename, exact):
         )
 
 
+# for fixture args, pylint: disable=redefined-outer-name
+
+
 @pytest.mark.parametrize("reform", ['badname.json', list()])
 def test_invalid_creation_w_file(input_file, reform):
     """
     Test incorrect SimpleTaxIO instantiation with input_file
     """
-    # for fixture args, pylint: disable=redefined-outer-name
     with pytest.raises(ValueError):
         SimpleTaxIO(
             input_filename=input_file.name,
@@ -127,7 +129,7 @@ def test_invalid_creation_w_file(input_file, reform):
         )
 
 
-def test_1(input_file):  # pylint: disable=redefined-outer-name
+def test_1(input_file):
     """
     Test SimpleTaxIO instantiation with no policy reform.
     """
@@ -141,17 +143,16 @@ def test_1(input_file):  # pylint: disable=redefined-outer-name
     # test extracting of weight and debugging variables
     crecs = simtax.calc.records
     SimpleTaxIO.DVAR_NAMES = ['f2441']
-    # pylint: disable=unused-variable
     ovar = SimpleTaxIO.extract_output(crecs, 0,
                                       exact=True, extract_weight=True)
+    assert ovar
     SimpleTaxIO.DVAR_NAMES = ['badvar']
     with pytest.raises(ValueError):
         ovar = SimpleTaxIO.extract_output(crecs, 0)
     SimpleTaxIO.DVAR_NAMES = []
 
 
-def test_2(input_file,  # pylint: disable=redefined-outer-name
-           reform_file):  # pylint: disable=redefined-outer-name
+def test_2(input_file, reform_file):
     """
     Test SimpleTaxIO instantiation with a policy reform from JSON file.
     """
@@ -163,7 +164,7 @@ def test_2(input_file,  # pylint: disable=redefined-outer-name
     assert simtax.number_input_lines() == NUM_INPUT_LINES
     # check that reform was implemented as specified above in REFORM_CONTENTS
     syr = simtax.start_year()
-    # pylint: disable=protected-access,no-member
+    # pylint: disable=protected-access
     amt_brk1 = simtax.policy._AMT_brk1
     assert amt_brk1[2015 - syr] == 200000
     assert amt_brk1[2016 - syr] > 200000
@@ -186,7 +187,7 @@ def test_2(input_file,  # pylint: disable=redefined-outer-name
     assert amt_em[2022 - syr, 0] > amt_em[2021 - syr, 0]
 
 
-def test_3(input_file):  # pylint: disable=redefined-outer-name
+def test_3(input_file):
     """
     Test SimpleTaxIO calculate method with a policy reform from dictionary.
     """


### PR DESCRIPTION
This PR simply corrects an error in the `records_variables.json` I just noticed. `nu18`, `n1821`, and `n21` we're previously described as the number of _dependents_ in those age ranges when they actually represent the number of people in the tax units. There is no change to the tax logic in this PR.

@martinholmer @MattHJensen 