### PR TITLE
Weighted average MTR function

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -441,22 +441,11 @@ class Calculator(object):
         Returns
             wmtr: overall weighted average marginal tax rate
         """
-        # check validity of income_type parameter
-        if income_type not in Calculator.MTR_VALID_VARIABLES:
-            msg = 'mtr income_type="{}" is not valid'
-            raise ValueError(msg.format(income_type))
-        # check validity of mtr_measure
-        if mtr_measure not in ['itax', 'ptax', 'combined']:
-            msg = 'mtr_measure is not "itax", "ptax" or "combined"'
-            raise ValueError(msg)
-        # check validity of weight_type
-        if weight_type not in ['none', 'income', 'abs']:
-            msg = 'weight_type is not "none", "income", or "abs"'
-            raise ValueError(msg)
-        # check validity of pos_control
-        if pos_control not in ['none', 'posti', 'posinc']:
-            msg = 'pos_control is not "none", "posti", or "posinc"'
-            raise ValueError(msg)
+        # check validity of parameter inputs
+        assert income_type in Calculator.MTR_VALID_VARIABLES
+        assert mtr_meaure in ['itax', 'ptax', 'combined']
+        assert weight_type in ['none', 'income', 'abs']
+        assert pos_control in ['none', 'posti', 'posinc']
         # collect mtr array
         (mtr_ptax, mtr_itax,
          mtr_combined) = self.mtr(variable_str=income_type)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -443,7 +443,7 @@ class Calculator(object):
         """
         # check validity of parameter inputs
         assert income_type in Calculator.MTR_VALID_VARIABLES
-        assert mtr_meaure in ['itax', 'ptax', 'combined']
+        assert mtr_measure in ['itax', 'ptax', 'combined']
         assert weight_type in ['none', 'income', 'abs']
         assert pos_control in ['none', 'posti', 'posinc']
         # collect mtr array

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -406,6 +406,84 @@ class Calculator(object):
         # return the three marginal tax rate arrays
         return (mtr_payrolltax, mtr_incometax, mtr_combined)
 
+    def wmtr(self, income_type='e00200p', mtr_measure='combined',
+             weight_type='income', pos_control='none'):
+    	"""
+        Calculates the weighted average marginal tax rate on an income type.
+
+        Parameters
+        ----------
+        income_type: string
+            specifies type of income or expense that is increased to compute
+            the marginal tax rates. Valid values are the same as for
+            variable_str in the Calculator.mtr function.
+
+        mtr_measure: string
+            options:
+                'itax': marginal individual income tax rate;
+                'ptax': marginal payroll tax rate; and
+                'combined': sum of marginal income and payroll tax rates.
+            specifies which type of marginal tax rate to use
+
+        weight_type: string
+            options:
+                'none': simple average of MTRs
+                'income': average of MTRs, weighted by income_type
+                'abs': average of MTRs, weighted by abs(income_type)
+            specifies the weighting formula to use
+        pos_control: string
+            options:
+                'none': include all filing units
+                'posti': exclude filing units with negative taxable income
+                'posinc': exclude filing units with negative of income type
+            excludes filing units with negative income
+
+        Returns
+            wmtr: overall weighted average marginal tax rate
+        """
+        # check validity of income_type parameter
+        if income_type not in Calculator.MTR_VALID_VARIABLES:
+            msg = 'mtr income_type="{}" is not valid'
+            raise ValueError(msg.format(income_type))
+        # check validity of mtr_measure
+        if mtr_measure not in ['itax', 'ptax', 'combined']:
+            msg = 'mtr_measure is not "itax", "ptax" or "combined"'
+            raise ValueError(msg)
+        # check validity of weight_type
+        if weight_type not in ['none', 'income', 'abs']:
+            msg = 'weight_type is not "none", "income", or "abs"'
+            raise ValueError(msg)
+        # check validity of pos_control
+        if pos_control not in ['none', 'posti', 'posinc']:
+            msg = 'pos_control is not "none", "posti", or "abs"'
+            raise ValueError(msg)
+        # collect mtr array
+        (mtr_ptax, mtr_itax,
+         mtr_combined) = self.mtr(variable_str=income_type)
+        income = getattr(self.records, income_type)
+        if mtr_measure == 'itax':
+            mtr1 = mtr_itax
+        elif mtr_measure == 'ptax':
+            mtr1 = mtr_ptax
+        elif mtr_measure == 'combined':
+            mtr1 = mtr_combined
+        # select weights
+        if weight_type == 'none':
+            wgt = self.records.s006
+        elif weight_type == 'income':
+            wgt = self.records.s006 * income
+        elif weight_type == 'abs':
+            wgt = (self.records.s006 *
+                   np.abs(income))
+        # select units to exclude (or not)
+        if pos_control == 'posti':
+            wgt = np.where(self.records.c04800 > 0, wgt, 0.)
+        elif pos_control == 'posinc':
+            wgt = np.where(income > 0, wgt, 0)
+        # calculate weighted average marginal tax rate
+        wmtr = sum(mtr1 * wgt) / sum(wgt)
+        return wmtr
+
     def current_law_version(self):
         """
         Return Calculator object same as self except with current-law policy.

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -455,7 +455,7 @@ class Calculator(object):
             raise ValueError(msg)
         # check validity of pos_control
         if pos_control not in ['none', 'posti', 'posinc']:
-            msg = 'pos_control is not "none", "posti", or "abs"'
+            msg = 'pos_control is not "none", "posti", or "posinc"'
             raise ValueError(msg)
         # collect mtr array
         (mtr_ptax, mtr_itax,

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -408,7 +408,7 @@ class Calculator(object):
 
     def wmtr(self, income_type='e00200p', mtr_measure='combined',
              weight_type='income', pos_control='none'):
-    	"""
+        """
         Calculates the weighted average marginal tax rate on an income type.
 
         Parameters
@@ -473,8 +473,7 @@ class Calculator(object):
         elif weight_type == 'income':
             wgt = self.records.s006 * income
         elif weight_type == 'abs':
-            wgt = (self.records.s006 *
-                   np.abs(income))
+            wgt = (self.records.s006 * np.abs(income))
         # select units to exclude (or not)
         if pos_control == 'posti':
             wgt = np.where(self.records.c04800 > 0, wgt, 0.)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -214,9 +214,9 @@ def test_Calculator_wmtr(records_2009):
     calc = Calculator(policy=Policy(), records=records_2009)
     recs_pre_e00200p = copy.deepcopy(calc.records.e00200p)
     # test calling Calculator.wmtr on several income types
-    assert type(calc.wmtr(income_type='e00200p')) == numpy.float64
-    assert type(calc.wmtr(income_type='p23250')) == numpy.float64
-    assert type(calc.wmtr(income_type='e00650')) == numpy.float64
+    assert type(calc.wmtr(income_type='e00200p')) == np.float64
+    assert type(calc.wmtr(income_type='p23250')) == np.float64
+    assert type(calc.wmtr(income_type='e00650')) == np.float64
     # Since e00200p is non-negative, test that different methods
     #    to control for that produce the same result
     wmtr1 = calc.wmtr(income_type='e00200p', weight_type='income')

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -214,14 +214,14 @@ def test_Calculator_wmtr(records_2009):
     calc = Calculator(policy=Policy(), records=records_2009)
     recs_pre_e00200p = copy.deepcopy(calc.records.e00200p)
     # test calling Calculator.wmtr on several income types
-    assert type(wmtr(income_type='e00200p')) == numpy.float64
-    assert type(wmtr(income_type='p23250')) == numpy.float64
-    assert type(wmtr(income_type='e00650')) == numpy.float64
+    assert type(calc.wmtr(income_type='e00200p')) == numpy.float64
+    assert type(calc.wmtr(income_type='p23250')) == numpy.float64
+    assert type(calc.wmtr(income_type='e00650')) == numpy.float64
     # Since e00200p is non-negative, test that different methods
     #    to control for that produce the same result
-    wmtr1 = wmtr(income_type='e00200p', weight_type='income')
-    wmtr2 = wmtr(income_type='e00200p', weight_type='abs')
-    wmtr3 = wmtr(income_type='e00200p', pos_control='posinc')
+    wmtr1 = calc.wmtr(income_type='e00200p', weight_type='income')
+    wmtr2 = calc.wmtr(income_type='e00200p', weight_type='abs')
+    wmtr3 = calc.wmtr(income_type='e00200p', pos_control='posinc')
     assert np.allclose(wmtr1, wmtr2, wmtr3)
 
 

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -216,7 +216,7 @@ def test_Calculator_wmtr(records_2009):
     # test calling Calculator.wmtr on several income types
     assert type(calc.wmtr(income_type='e00200p')) == np.float64
     assert type(calc.wmtr(income_type='p23250')) == np.float64
-    assert type(calc.wmtr(income_type='e00650')) == np.float64
+    assert type(calc.wmtr(income_type='e00900p')) == np.float64
     # Since e00200p is non-negative, test that different methods
     #    to control for that produce the same result
     wmtr1 = calc.wmtr(income_type='e00200p', weight_type='income')

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -217,6 +217,12 @@ def test_Calculator_wmtr(records_2009):
     assert type(calc.wmtr(income_type='e00200p')) == np.float64
     assert type(calc.wmtr(income_type='p23250')) == np.float64
     assert type(calc.wmtr(income_type='e00900p')) == np.float64
+    assert type(calc.wmtr(income_type='e00200p',
+                          mtr_measure='itax')) == np.float64
+    assert type(calc.wmtr(income_type='e00200p',
+                          mtr_measure='ptax')) == np.float64
+    assert type(calc.wmtr(income_type='e00200p',
+                          pos_control='posti')) == np.float64
     # Since e00200p is non-negative, test that different methods
     #    to control for that produce the same result
     wmtr1 = calc.wmtr(income_type='e00200p', weight_type='income')

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -210,6 +210,21 @@ def test_Calculator_mtr(records_2009):
     assert type(mtr_combined) == np.ndarray
 
 
+def test_Calculator_wmtr(records_2009):
+    calc = Calculator(policy=Policy(), records=records_2009)
+    recs_pre_e00200p = copy.deepcopy(calc.records.e00200p)
+    # test calling Calculator.wmtr on several income types
+    assert type(wmtr(income_type='e00200p')) == numpy.float64
+    assert type(wmtr(income_type='p23250')) == numpy.float64
+    assert type(wmtr(income_type='e00650')) == numpy.float64
+    # Since e00200p is non-negative, test that different methods
+    #    to control for that produce the same result
+    wmtr1 = wmtr(income_type='e00200p', weight_type='income')
+    wmtr2 = wmtr(income_type='e00200p', weight_type='abs')
+    wmtr3 = wmtr(income_type='e00200p', pos_control='posinc')
+    assert np.allclose(wmtr1, wmtr2, wmtr3)
+
+
 def test_Calculator_mtr_when_PT_rates_differ():
     reform = {2013: {'_II_rt1': [0.40],
                      '_II_rt2': [0.40],

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -223,6 +223,8 @@ def test_Calculator_wmtr(records_2009):
                           mtr_measure='ptax')) == np.float64
     assert type(calc.wmtr(income_type='e00200p',
                           pos_control='posti')) == np.float64
+    assert type(calc.wmtr(income_type='e00200p',
+                          weight_type='none')) == np.float64
     # Since e00200p is non-negative, test that different methods
     #    to control for that produce the same result
     wmtr1 = calc.wmtr(income_type='e00200p', weight_type='income')


### PR DESCRIPTION
This PR adds a function to calculate the weighted average effective marginal tax rate for all filers.

Based on a previous discussion with @jdebacker, there are complications to calculating a weighted average if the income type used for the weighting can be negative (capital gains, Sch. C, etc.). I give three methods to deal with this. 
- Use the absolute value of the income type for the weight.
- Restrict the average to only filers with positive income of that type.
- Restrict the average to only filers with positive taxable income.

I also added a test for the wmtr function.

