### PR TITLE
add (Tax change)/(Pre-reform after-tax income) to distributional tables

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -22,7 +22,8 @@ from taxcalc.functions import (TaxInc, SchXYZTax, GainsTax, AGIsurtax,
                                AmOppCreditParts, EducationTaxCredit,
                                NonrefundableCredits, C1040, IITAX,
                                BenefitSurtax, BenefitLimitation,
-                               FairShareTax, LumpSumTax, ExpandIncome)
+                               FairShareTax, LumpSumTax, ExpandIncome,
+                               AfterTaxIncome)
 from taxcalc.policy import Policy
 from taxcalc.records import Records
 from taxcalc.behavior import Behavior
@@ -217,6 +218,7 @@ class Calculator(object):
         FairShareTax(self.policy, self.records)
         LumpSumTax(self.policy, self.records)
         ExpandIncome(self.policy, self.records)
+        AfterTaxIncome(self.policy, self.records)
 
     def increment_year(self):
         """

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1554,3 +1554,21 @@ def ExpandIncome(c00100, ptax_was, e02400, c02500,
                        employer_fica_share +
                        nontaxable_ubi)  # universal basic income
     return expanded_income
+
+
+@iterate_jit(nopython=True)
+def AfterTaxIncome(combined, expanded_income, aftertax_income):
+    """
+    Calculate after tax income
+
+    Parameters
+    ----------
+    combined: combined tax liability
+    expanded_income: expanded income
+
+    Returns
+    -------
+    aftertax_income: expanded_income - combined
+    """
+    aftertax_income = expanded_income - combined
+    return aftertax_income

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -881,6 +881,11 @@
       "type": "float",
       "desc": "Marginal income tax rate (in percentage terms) on extra taxpayer earnings (e00200p)",
       "form": {}
-    }
+  },
+  "aftertax_income": {
+      "type": "float",
+      "desc": "After tax income. Equal to expanded_income - combined",
+      "form": {}
+  }
   }
 }

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -441,7 +441,8 @@ def test_diff_table_sum_row(puf_1991, weights_1991):
                                      groupby='small_income_bins')
     tdiff2 = create_difference_table(calc1.records, calc2.records,
                                      groupby='large_income_bins')
-    non_digit_cols = ['mean', 'perc_inc', 'perc_cut', 'share_of_change']
+    non_digit_cols = ['mean', 'perc_inc', 'perc_cut', 'share_of_change',
+                      'aftertax_perc']
     digit_cols = [x for x in tdiff1.columns.tolist() if
                   x not in non_digit_cols]
     assert np.allclose(tdiff1[digit_cols][-1:], tdiff2[digit_cols][-1:])


### PR DESCRIPTION
This PR is in response to issue #1371. It adds a column to the differences table that shows
`(tax change) / (pre-reform after tax income)`.

I also added a new variable to the records class `aftertax_income`, which is simply `expanded_income - combined`.

@MattHJensen @martinholmer 