### PR TITLE
specify that CG elasticity is a semi-elasticity

### DIFF
--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -32,7 +32,7 @@
     },
 
     "_BE_cg": {
-        "long_name": "Elasticity of long-term capital gains",
+        "long_name": "Semi-elasticity of long-term capital gains",
         "description": "Defined as change in logarithm of long-term capital gains divided by change in marginal tax rate (MTR) on long-term capital gains caused by the reform.  Must be zero or negative.  Read Behavior.response documentation for discussion of appropriate values.",
         "section_1": "Behavior",
         "section_2": "Capital Gains",


### PR DESCRIPTION
@salimfurth asked: Can we change the [TaxBrain] interface to say semi-elasticity of long-term capital gains as the parameter label?

The TaxBrain interface pulls from the _BE_cg long_name. 

@codykallen, I'll merge w your +1. 