### PR TITLE
Remove dropq_utils results function and use utils results function

### DIFF
--- a/taxcalc/dropq/dropq.py
+++ b/taxcalc/dropq/dropq.py
@@ -10,10 +10,9 @@ import time
 import numpy as np
 import pandas as pd
 from taxcalc.dropq.dropq_utils import (dropq_calculate,
-                                       results,
                                        random_seed,
                                        dropq_summary)
-from taxcalc import TABLE_LABELS, proportional_change_gdp
+from taxcalc import results, TABLE_LABELS, proportional_change_gdp
 
 
 # specify constants
@@ -54,8 +53,8 @@ def run_nth_year_tax_calc_model(year_n, start_year,
                                            mask_computed=True)
 
     # extract raw results from calc1 and calc2
-    rawres1 = results(calc1)
-    rawres2 = results(calc2)
+    rawres1 = results(calc1.records)
+    rawres2 = results(calc2.records)
 
     # seed random number generator with a seed value based on user_mods
     seed = random_seed(user_mods)

--- a/taxcalc/dropq/dropq_utils.py
+++ b/taxcalc/dropq/dropq_utils.py
@@ -13,7 +13,7 @@ from taxcalc import (Policy, Records, Calculator,
 from taxcalc.utils import (add_income_bins, add_weighted_income_bins,
                            means_and_comparisons, get_sums,
                            weighted, weighted_avg_allcols,
-                           create_distribution_table,
+                           create_distribution_table, results,
                            STATS_COLUMNS, TABLE_COLUMNS, WEBAPP_INCOME_BINS)
 
 
@@ -36,16 +36,6 @@ def check_user_mods(user_mods):
     extra_keys = actual_keys - expected_keys
     if len(extra_keys) > 0:
         raise ValueError('user_mods has extra keys: {}'.format(extra_keys))
-
-
-def results(calc):
-    """
-    Return DataFrame containing results for STATS_COLUMNS Records variables.
-    """
-    outputs = []
-    for col in STATS_COLUMNS:
-        outputs.append(getattr(calc.records, col))
-    return pd.DataFrame(data=np.column_stack(outputs), columns=STATS_COLUMNS)
 
 
 def dropq_calculate(year_n, start_year,
@@ -111,8 +101,8 @@ def dropq_calculate(year_n, start_year,
         calc1p.calc_all()
         assert calc1p.current_year == start_year
         # compute mask that shows which of the calc1 and calc1p results differ
-        res1 = results(calc1)
-        res1p = results(calc1p)
+        res1 = results(calc1.records)
+        res1p = results(calc1p.records)
         mask = (res1.iitax != res1p.iitax)
     else:
         mask = None

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -4,7 +4,8 @@ import pandas as pd
 import pytest
 from taxcalc.dropq.dropq_utils import *
 from taxcalc.dropq import *
-from taxcalc import Policy, Records, Calculator, multiyear_diagnostic_table
+from taxcalc import (Policy, Records, Calculator,
+                     multiyear_diagnostic_table, results)
 
 
 USER_MODS = {
@@ -168,7 +169,7 @@ def test_dropq_dist_table(groupby, result_type, puf_1991_path):
     calc = Calculator(policy=Policy(),
                       records=Records(data=pd.read_csv(puf_1991_path)))
     calc.calc_all()
-    res = results(calc)
+    res = results(calc.records)
     mask = np.ones(len(res.index))
     (res, _) = drop_records(res, res, mask)
     if groupby == 'other_income_bins' or result_type == 'other_avg':
@@ -195,8 +196,8 @@ def test_dropq_diff_table(groupby, res_column, puf_1991_path):
     calc2 = Calculator(policy=pol2, records=recs2)
     calc1.calc_all()
     calc2.calc_all()
-    res1 = results(calc1)
-    res2 = results(calc2)
+    res1 = results(calc1.records)
+    res2 = results(calc2.records)
     assert len(res1.index) == len(res2.index)
     mask = np.ones(len(res1.index))
     (res1, res2) = drop_records(res1, res2, mask)


### PR DESCRIPTION
This pull request removes the redundant `results` function in `dropq_utils.py` and uses in the dropq logic the `results` function in `taxcalc/utils.py` instead.  The duplicate function dates from the time when dropq logic was in a separate repository.

There is no change in tax logic or results.