### PR TITLE
Add arrays_not_lists argument to Calculator.read_json_parameter_files function

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -467,7 +467,7 @@ class Calculator(object):
                                 'growdiff_baseline', 'growdiff_response'])
 
     @staticmethod
-    def _read_json_policy_reform_text(text_string, arrays_not_lists=True):
+    def _read_json_policy_reform_text(text_string, arrays_not_lists):
         """
         Strip //-comments from text_string and return 1 dict based on the JSON.
         Specified text is JSON with at least 1 high-level string:object pair:
@@ -522,7 +522,7 @@ class Calculator(object):
         return rpol_dict
 
     @staticmethod
-    def _read_json_econ_assump_text(text_string, arrays_not_lists=True):
+    def _read_json_econ_assump_text(text_string, arrays_not_lists):
         """
         Strip //-comments from text_string and return 4 dict based on the JSON.
         Specified text is JSON with at least 4 high-level string:object pairs:
@@ -597,7 +597,7 @@ class Calculator(object):
         return (cons_dict, behv_dict, gdiff_base_dict, gdiff_resp_dict)
 
     @staticmethod
-    def _convert_parameter_dict(param_key_dict, arrays_not_lists=True):
+    def _convert_parameter_dict(param_key_dict, arrays_not_lists):
         """
         Converts specified param_key_dict into a dictionary whose primary
         keys are calendary years, and hence, is suitable as the argument to

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -421,7 +421,8 @@ class Calculator(object):
         return calc
 
     @staticmethod
-    def read_json_param_files(reform_filename, assump_filename):
+    def read_json_param_files(reform_filename, assump_filename,
+                              arrays_not_lists=True):
         """
         Read JSON files and call Calculator.read_json_*_text methods
         returning a single dictionary containing five key:dict pairs:
@@ -432,7 +433,9 @@ class Calculator(object):
             rpol_dict = dict()
         elif os.path.isfile(reform_filename):
             txt = open(reform_filename, 'r').read()
-            rpol_dict = Calculator.read_json_policy_reform_text(txt)
+            rpol_dict = (
+                Calculator._read_json_policy_reform_text(txt, arrays_not_lists)
+            )
         else:
             msg = 'policy reform file {} could not be found'
             raise ValueError(msg.format(reform_filename))
@@ -446,7 +449,8 @@ class Calculator(object):
             (cons_dict,
              behv_dict,
              gdiff_base_dict,
-             gdiff_resp_dict) = Calculator.read_json_econ_assump_text(txt)
+             gdiff_resp_dict) = (
+                 Calculator._read_json_econ_assump_text(txt, arrays_not_lists))
         else:
             msg = 'economic assumption file {} could not be found'
             raise ValueError(msg.format(assump_filename))
@@ -463,7 +467,7 @@ class Calculator(object):
                                 'growdiff_baseline', 'growdiff_response'])
 
     @staticmethod
-    def read_json_policy_reform_text(text_string):
+    def _read_json_policy_reform_text(text_string, arrays_not_lists=True):
         """
         Strip //-comments from text_string and return 1 dict based on the JSON.
         Specified text is JSON with at least 1 high-level string:object pair:
@@ -476,14 +480,12 @@ class Calculator(object):
           and string years as secondary keys.  See tests/test_calculate.py for
           an extended example of a commented JSON policy reform text
           that can be read by this method.
-        Note that parameter code in the policy object is enclosed inside a
-          pair of double pipe characters (||) as shown in the REFORM_CONTENTS
-          string in the tests/test_calculate.py file.
         Returned dictionary rpol_dict
            has integer years as primary keys
            and string parameters as secondary keys.
         The returned dictionary is suitable as the argument to
-           the Policy implement_reform(rpol_dict) method.
+           the Policy implement_reform(rpol_dict) method ONLY if
+           the function argument arrays_not_lists is True.
         """
         # strip out //-comments without changing line numbers
         json_str = re.sub('//.*', ' ', text_string)
@@ -515,11 +517,12 @@ class Calculator(object):
                 msg = 'key "{}" should be in economic assumption file'
                 raise ValueError(msg.format(rkey))
         # convert the policy dictionary in raw_dict
-        rpol_dict = Calculator.convert_parameter_dict(raw_dict['policy'])
+        rpol_dict = Calculator._convert_parameter_dict(raw_dict['policy'],
+                                                       arrays_not_lists)
         return rpol_dict
 
     @staticmethod
-    def read_json_econ_assump_text(text_string):
+    def _read_json_econ_assump_text(text_string, arrays_not_lists=True):
         """
         Strip //-comments from text_string and return 4 dict based on the JSON.
         Specified text is JSON with at least 4 high-level string:object pairs:
@@ -545,8 +548,10 @@ class Calculator(object):
         The returned dictionaries are suitable as the arguments to
            the Consumption.update_consumption(cons_dict) method, or
            the Behavior.update_behavior(behv_dict) method, or
-           the Growdiff.update_growdiff(gdiff_dict) method.
+           the Growdiff.update_growdiff(gdiff_dict) method,
+        but ONLY if the function argument arrays_not_lists is True.
         """
+        # pylint: disable=too-many-locals
         # strip out //-comments without changing line numbers
         json_str = re.sub('//.*', ' ', text_string)
         # convert JSON text into a Python dictionary
@@ -578,30 +583,36 @@ class Calculator(object):
                 raise ValueError(msg.format(rkey))
         # convert the assumption dictionaries in raw_dict
         key = 'consumption'
-        cons_dict = Calculator.convert_parameter_dict(raw_dict[key])
+        cons_dict = Calculator._convert_parameter_dict(raw_dict[key],
+                                                       arrays_not_lists)
         key = 'behavior'
-        behv_dict = Calculator.convert_parameter_dict(raw_dict[key])
+        behv_dict = Calculator._convert_parameter_dict(raw_dict[key],
+                                                       arrays_not_lists)
         key = 'growdiff_baseline'
-        gdiff_base_dict = Calculator.convert_parameter_dict(raw_dict[key])
+        gdiff_base_dict = Calculator._convert_parameter_dict(raw_dict[key],
+                                                             arrays_not_lists)
         key = 'growdiff_response'
-        gdiff_resp_dict = Calculator.convert_parameter_dict(raw_dict[key])
+        gdiff_resp_dict = Calculator._convert_parameter_dict(raw_dict[key],
+                                                             arrays_not_lists)
         return (cons_dict, behv_dict, gdiff_base_dict, gdiff_resp_dict)
 
     @staticmethod
-    def convert_parameter_dict(param_key_dict):
+    def _convert_parameter_dict(param_key_dict, arrays_not_lists=True):
         """
         Converts specified param_key_dict into a dictionary whose primary
-          keys are calendary years, and hence, is suitable as the argument to
+        keys are calendary years, and hence, is suitable as the argument to
           the Policy.implement_reform() method, or
           the Consumption.update_consumption() method, or
           the Behavior.update_behavior() method, or
-          the Growdiff.update_growdiff() method.
+          the Growdiff.update_growdiff() method,
+        but only if function argument is arrays_not_lists=True.
         Specified input dictionary has string parameter primary keys and
            string years as secondary keys.
         Returned dictionary has integer years as primary keys and
            string parameters as secondary keys.
         """
-        # convert year skey strings to integers and lists into np.arrays
+        # convert year skey strings into integers and
+        # optionally convert lists into np.arrays
         year_param = dict()
         for pkey, sdict in param_key_dict.items():
             if not isinstance(pkey, six.string_types):
@@ -617,8 +628,10 @@ class Calculator(object):
                     raise ValueError(msg.format(skey))
                 else:
                     year = int(skey)
-                rdict[year] = (np.array(val)
-                               if isinstance(val, list) else val)
+                if isinstance(val, list) and arrays_not_lists:
+                    rdict[year] = np.array(val)
+                else:
+                    rdict[year] = val
             year_param[pkey] = rdict
         # convert year_param dictionary to year_key_dict dictionary
         year_key_dict = dict()

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -644,13 +644,16 @@ def test_read_bad_json_assump_file(bad1assumpfile, bad2assumpfile,
 
 def test_convert_parameter_dict():
     with pytest.raises(ValueError):
-        rdict = Calculator.convert_parameter_dict({2013: {'2013': [40000]}})
+        rdict = Calculator._convert_parameter_dict({2013: {'2013': [40000]}})
     with pytest.raises(ValueError):
-        rdict = Calculator.convert_parameter_dict({'_II_em': {2013: [40000]}})
+        rdict = Calculator._convert_parameter_dict({'_II_em': {2013: [40000]}})
     with pytest.raises(ValueError):
-        rdict = Calculator.convert_parameter_dict({4567: {2013: [40000]}})
+        rdict = Calculator._convert_parameter_dict({4567: {2013: [40000]}})
     with pytest.raises(ValueError):
-        rdict = Calculator.convert_parameter_dict({'_II_em': 40000})
+        rdict = Calculator._convert_parameter_dict({'_II_em': 40000})
+    rdict = Calculator._convert_parameter_dict({'_II_em': {'2013': [40000]}},
+                                               arrays_not_lists=False)
+    assert isinstance(rdict, dict)
 
 
 def test_calc_all(reform_file, rawinputfile):

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -644,13 +644,17 @@ def test_read_bad_json_assump_file(bad1assumpfile, bad2assumpfile,
 
 def test_convert_parameter_dict():
     with pytest.raises(ValueError):
-        rdict = Calculator._convert_parameter_dict({2013: {'2013': [40000]}})
+        rdict = Calculator._convert_parameter_dict({2013: {'2013': [40000]}},
+                                                   arrays_not_lists=True)
     with pytest.raises(ValueError):
-        rdict = Calculator._convert_parameter_dict({'_II_em': {2013: [40000]}})
+        rdict = Calculator._convert_parameter_dict({'_II_em': {2013: [40000]}},
+                                                   arrays_not_lists=True)
     with pytest.raises(ValueError):
-        rdict = Calculator._convert_parameter_dict({4567: {2013: [40000]}})
+        rdict = Calculator._convert_parameter_dict({4567: {2013: [40000]}},
+                                                   arrays_not_lists=True)
     with pytest.raises(ValueError):
-        rdict = Calculator._convert_parameter_dict({'_II_em': 40000})
+        rdict = Calculator._convert_parameter_dict({'_II_em': 40000},
+                                                   arrays_not_lists=True)
     rdict = Calculator._convert_parameter_dict({'_II_em': {'2013': [40000]}},
                                                arrays_not_lists=False)
     assert isinstance(rdict, dict)

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -30,7 +30,8 @@ def test_reform_json(reforms_path):  # pylint: disable=redefined-outer-name
         jpf_text = jfile.read()
         # check that jpf_text has "policy" that can be implemented as a reform
         if '"policy"' in jpf_text:
-            policy_dict = Calculator.read_json_policy_reform_text(jpf_text)
+            # pylint: disable=protected-access
+            policy_dict = Calculator._read_json_policy_reform_text(jpf_text)
             policy = Policy()
             policy.implement_reform(policy_dict)
         else:  # jpf_text is not a valid JSON policy reform file

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -31,7 +31,10 @@ def test_reform_json(reforms_path):  # pylint: disable=redefined-outer-name
         # check that jpf_text has "policy" that can be implemented as a reform
         if '"policy"' in jpf_text:
             # pylint: disable=protected-access
-            policy_dict = Calculator._read_json_policy_reform_text(jpf_text)
+            policy_dict = (
+                Calculator._read_json_policy_reform_text(jpf_text,
+                                                         arrays_not_lists=True)
+            )
             policy = Policy()
             policy.implement_reform(policy_dict)
         else:  # jpf_text is not a valid JSON policy reform file

--- a/taxcalc/tests/test_responses.py
+++ b/taxcalc/tests/test_responses.py
@@ -35,8 +35,9 @@ def test_response_json(responses_path):  # pylint: disable=redefined-outer-name
                          '"growdiff_baseline"' in jpf_text and
                          '"growdiff_response"' in jpf_text)
         if response_file:
+            # pylint: disable=protected-access
             (con, beh, gdiff_base,
-             gdiff_resp) = Calculator.read_json_econ_assump_text(jpf_text)
+             gdiff_resp) = Calculator._read_json_econ_assump_text(jpf_text)
             cons = Consumption()
             cons.update_consumption(con)
             behv = Behavior()

--- a/taxcalc/tests/test_responses.py
+++ b/taxcalc/tests/test_responses.py
@@ -37,7 +37,9 @@ def test_response_json(responses_path):  # pylint: disable=redefined-outer-name
         if response_file:
             # pylint: disable=protected-access
             (con, beh, gdiff_base,
-             gdiff_resp) = Calculator._read_json_econ_assump_text(jpf_text)
+             gdiff_resp) = (
+                 Calculator._read_json_econ_assump_text(jpf_text,
+                                                        arrays_not_lists=True))
             cons = Consumption()
             cons.update_consumption(con)
             behv = Behavior()


### PR DESCRIPTION
This pull request adds flexibility to the `Calculator.read_json_parameter_files` function by adding a function argument `arrays_not_lists=True`.

This addition means that the `Calculator.read_json_parameter_files` function can be called as before and everything will work as before.  That is, there is no change in tax logic or results.

But clients of Tax-Calculator can now call the `Calculator.read_json_parameter_files` function with `arrays_not_lists=False` and get dictionaries that contain lists rather than numpy arrays.  This extra flexibility has been added to support the requirement of clients like TaxBrain.  Those TaxBrain requirements are described in [webapp-public pull request 556](https://github.com/OpenSourcePolicyCenter/webapp-public/pull/556).  This extra flexibility in the `Calculator.read_json_parameter_files` function implies, at a minimum, that the 114 lines of code in 556-proposed `webapp/apps/formatters.py` file are no longer needed.  This eliminates substantial code duplication between the Tax-Calculator and webapp-public repositories.

@MattHJensen @brittainhard @PeterDSteinberg 
