### PR TITLE
Switch back to sphinx.ext.pngmath

### DIFF
--- a/read-the-docs/source/conf.py
+++ b/read-the-docs/source/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
-    'sphinx.ext.imgmath',
+    'sphinx.ext.pngmath',
     'sphinx.ext.viewcode',
 ]
 


### PR DESCRIPTION
Using recommended sphinx.ext.imgmath causes failure at RTD after commit.