### PR TITLE
Revert needs_sphinx from 1.5.6 to 1.3.5

### DIFF
--- a/read-the-docs/source/conf.py
+++ b/read-the-docs/source/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.5.6'
+needs_sphinx = '1.3.5'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
Change because 1.3.5 is hardwired somewhere inaccessible to the Tax-Calculator source code.