### PR TITLE
Divide utility functions into public and private

### DIFF
--- a/read-the-docs/source/public_api.rst
+++ b/read-the-docs/source/public_api.rst
@@ -113,4 +113,3 @@ taxcalc.utils
 
 .. automodule:: taxcalc.utils
    :members:
-   :exclude-members: _add_columns, _diagnostic_table_odict, _weighted_share_of_total

--- a/read-the-docs/source/public_api.rst
+++ b/read-the-docs/source/public_api.rst
@@ -113,3 +113,4 @@ taxcalc.utils
 
 .. automodule:: taxcalc.utils
    :members:
+   :exclude-members: _add_columns, _diagnostic_table_odict, _weighted_share_of_total

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -8,6 +8,7 @@ from taxcalc.growdiff import *
 from taxcalc.records import *
 from taxcalc.taxcalcio import *
 from taxcalc.utils import *
+from taxcalc._utils import *
 from taxcalc.decorators import *
 from taxcalc.macro_elasticity import *
 from taxcalc.dropq import *

--- a/taxcalc/_utils.py
+++ b/taxcalc/_utils.py
@@ -1,0 +1,160 @@
+"""
+PRIVATE utility functions for Tax-Calculator PUBLIC utility functions.
+"""
+# CODING-STYLE CHECKS:
+# pep8 --ignore=E402 _utils.py
+# pylint --disable=locally-disabled _utils.py
+
+import json
+import random
+import pandas as pd
+
+
+EPSILON = 1e-9
+
+
+def count_gt_zero(data):
+    """
+    Return unweighted count of positive data items.
+    """
+    return sum([1 for item in data if item > 0])
+
+
+def count_lt_zero(data):
+    """
+    Return unweighted count of negative data items.
+    """
+    return sum([1 for item in data if item < 0])
+
+
+def weighted_count_lt_zero(pdf, col_name, tolerance=-0.001):
+    """
+    Return weighted count of negative Pandas DateFrame col_name items.
+    """
+    return pdf[pdf[col_name] < tolerance]['s006'].sum()
+
+
+def weighted_count_gt_zero(pdf, col_name, tolerance=0.001):
+    """
+    Return weighted count of positive Pandas DateFrame col_name items.
+    """
+    return pdf[pdf[col_name] > tolerance]['s006'].sum()
+
+
+def weighted_count(pdf):
+    """
+    Return weighted count of items in Pandas DataFrame.
+    """
+    return pdf['s006'].sum()
+
+
+def weighted_mean(pdf, col_name):
+    """
+    Return weighted mean of Pandas DataFrame col_name items.
+    """
+    return (float((pdf[col_name] * pdf['s006']).sum()) /
+            float(pdf['s006'].sum() + EPSILON))
+
+
+def wage_weighted(pdf, col_name):
+    """
+    Return wage-weighted mean of Pandas DataFrame col_name items.
+    """
+    swght = 's006'
+    wage = 'e00200'
+    return (float((pdf[col_name] * pdf[swght] * pdf[wage]).sum()) /
+            float((pdf[swght] * pdf[wage]).sum() + EPSILON))
+
+
+def agi_weighted(pdf, col_name):
+    """
+    Return AGI-weighted mean of Pandas DataFrame col_name items.
+    """
+    swght = 's006'
+    agi = 'c00100'
+    return (float((pdf[col_name] * pdf[swght] * pdf[agi]).sum()) /
+            float((pdf[swght] * pdf[agi]).sum() + EPSILON))
+
+
+def expanded_income_weighted(pdf, col_name):
+    """
+    Return expanded-income-weighted mean of Pandas DataFrame col_name items.
+    """
+    swght = 's006'
+    expinc = 'expanded_income'
+    return (float((pdf[col_name] * pdf[swght] * pdf[expinc]).sum()) /
+            float((pdf[swght] * pdf[expinc]).sum() + EPSILON))
+
+
+def weighted_perc_inc(pdf, col_name):
+    """
+    Return weighted fraction (not percent) of positive values for the
+    variable with col_name in the specified Pandas DataFrame.
+    """
+    return (float(weighted_count_gt_zero(pdf, col_name)) /
+            float(weighted_count(pdf) + EPSILON))
+
+
+def weighted_perc_dec(pdf, col_name):
+    """
+    Return weighted fraction (not percent) of negative values for the
+    variable with col_name in the specified Pandas DataFrame.
+    """
+    return (float(weighted_count_lt_zero(pdf, col_name)) /
+            float(weighted_count(pdf) + EPSILON))
+
+
+def ascii_output(csv_filename, ascii_filename):
+    """
+    Converts csv output from Calculator into ascii output with uniform
+    columns and transposes data so columns are rows and rows are columns.
+    In an ipython notebook, you can import this function from the utils module.
+    """
+    # ** List of integers corresponding to the numbers of the rows in the
+    #    csv file, only rows in list will be recorded in final output.
+    #    If left as [], results in entire file are being converted to ascii.
+    #    Put in order from smallest to largest, for example:
+    #    recids = [33180, 64023, 68020, 74700, 84723, 98001, 107039, 108820]
+    recids = [1, 4, 5]
+    # ** Number of characters in each column, must be a nonnegative integer.
+    col_size = 15
+    # read csv_filename into a Pandas DataFrame
+    pdf = pd.read_csv(csv_filename, dtype=object)
+    # keep only listed recids if recids list is not empty
+    if recids != []:
+        def pdf_recid(recid):
+            """ Return Pandas DataFrame recid value for specified recid """
+            return recid - 1
+        recids = map(pdf_recid, recids)
+        pdf = pdf.ix[recids]  # pylint: disable=no-member
+    # do transposition
+    out = pdf.T.reset_index()  # pylint: disable=no-member
+    # format data into uniform columns
+    fstring = '{:' + str(col_size) + '}'
+    out = out.applymap(fstring.format)
+    # write ascii output to specified ascii_filename
+    out.to_csv(ascii_filename, header=False, index=False, sep='\t')
+
+
+def read_json_from_file(path):
+    """
+    Return a dict of data loaded from the json file stored at path.
+    """
+    with open(path, 'r') as rfile:
+        data = json.load(rfile)
+    return data
+
+
+def write_json_to_file(data, path, indent=4, sort_keys=False):
+    """
+    Write data to a file at path in json format.
+    """
+    with open(path, 'w') as wfile:
+        json.dump(data, wfile, indent=indent, sort_keys=sort_keys)
+
+
+def temporary_filename(suffix=''):
+    """
+    Return string containing filename.
+    """
+    return 'tmp{}{}'.format(random.randint(10000000, 99999999), suffix)

--- a/taxcalc/filings/forms/tax_form.py
+++ b/taxcalc/filings/forms/tax_form.py
@@ -1,7 +1,7 @@
 import six
 
 from taxcalc.filings.forms.errors import UnsupportedFormYearError
-from taxcalc.utils import string_to_number
+from taxcalc.filings.forms.utils import string_to_number
 
 
 class TaxForm(object):

--- a/taxcalc/filings/forms/us1040.py
+++ b/taxcalc/filings/forms/us1040.py
@@ -1,5 +1,5 @@
 from taxcalc.filings.forms.tax_form import TaxForm
-from taxcalc.utils import string_to_number
+from taxcalc.filings.forms.utils import string_to_number
 
 
 class US1040(TaxForm):

--- a/taxcalc/filings/forms/us1040sa.py
+++ b/taxcalc/filings/forms/us1040sa.py
@@ -1,5 +1,5 @@
 from taxcalc.filings.forms.tax_form import TaxForm
-from taxcalc.utils import string_to_number
+from taxcalc.filings.forms.utils import string_to_number
 
 
 class US1040SA(TaxForm):

--- a/taxcalc/filings/forms/us1040se.py
+++ b/taxcalc/filings/forms/us1040se.py
@@ -1,5 +1,5 @@
 from taxcalc.filings.forms.tax_form import TaxForm
-from taxcalc.utils import string_to_number
+from taxcalc.filings.forms.utils import string_to_number
 
 
 class US1040SE(TaxForm):

--- a/taxcalc/filings/forms/utils.py
+++ b/taxcalc/filings/forms/utils.py
@@ -1,0 +1,15 @@
+"""
+Utility functions used in taxcalc/filings/forms logic.
+"""
+
+
+def string_to_number(string):
+    """
+    Return either integer or float conversion of specified string.
+    """
+    if not string:
+        return 0
+    try:
+        return int(string)
+    except ValueError:
+        return float(string)

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -18,12 +18,11 @@ from taxcalc.behavior import Behavior
 from taxcalc.growdiff import Growdiff
 from taxcalc.growfactors import Growfactors
 from taxcalc.calculate import Calculator
-from taxcalc.utils import delete_file
-from taxcalc.utils import ce_aftertax_income
-from taxcalc.utils import atr_graph_data, mtr_graph_data
-from taxcalc.utils import xtr_graph_plot, write_graph_file
-from taxcalc.utils import add_weighted_income_bins
-from taxcalc.utils import unweighted_sum, weighted_sum
+from taxcalc.utils import (delete_file, ce_aftertax_income,
+                           atr_graph_data, mtr_graph_data,
+                           xtr_graph_plot, write_graph_file,
+                           add_weighted_income_bins,
+                           unweighted_sum, weighted_sum)
 
 
 class TaxCalcIO(object):
@@ -246,7 +245,7 @@ class TaxCalcIO(object):
 
     def tax_year(self):
         """
-        Returns year for which TaxCalcIO calculations are being done.
+        Return calendar year for which TaxCalcIO calculations are being done.
         """
         return self.calc.policy.current_year
 
@@ -496,7 +495,7 @@ class TaxCalcIO(object):
 
     def minimal_output(self):
         """
-        Extract minimal output and return as pandas DataFrame.
+        Extract minimal output and return it as Pandas DataFrame.
         """
         varlist = ['RECID', 'YEAR', 'WEIGHT', 'INCTAX', 'LSTAX', 'PAYTAX']
         odict = dict()
@@ -553,7 +552,7 @@ class TaxCalcIO(object):
 
     def dump_output(self, mtr_inctax, mtr_paytax):
         """
-        Extract dump output and return it as pandas DataFrame.
+        Extract dump output and return it as Pandas DataFrame.
         """
         # specify mtr values in percentage terms
         self.calc.records.mtr_inctax[:] = mtr_inctax * 100.

--- a/taxcalc/tests/filings/forms/test_tax_form.py
+++ b/taxcalc/tests/filings/forms/test_tax_form.py
@@ -2,7 +2,15 @@ import pytest
 
 from taxcalc.filings.forms import TaxForm
 from taxcalc.filings.forms import UnsupportedFormYearError
-from taxcalc.utils import string_to_number
+from taxcalc.filings.forms.utils import string_to_number
+
+
+def test_string_to_number():
+    assert string_to_number(None) == 0
+    assert string_to_number('') == 0
+    assert string_to_number('1') == 1
+    assert string_to_number('1.') == 1.
+    assert string_to_number('1.23') == 1.23
 
 
 def test_tax_form_creation_valid():

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -19,19 +19,19 @@ import pytest
 # pylint: disable=import-error
 from taxcalc import Policy, Records, Behavior, Calculator, ParametersBase
 from taxcalc.utils import (TABLE_COLUMNS, TABLE_LABELS, STATS_COLUMNS,
-                           create_distribution_table, _add_columns,
-                           create_difference_table, delete_file,
+                           create_distribution_table,
+                           create_difference_table,
                            count_lt_zero, weighted_count_lt_zero,
                            count_gt_zero, weighted_count_gt_zero,
                            weighted_count, weighted_sum, weighted_mean,
                            wage_weighted, agi_weighted,
-                           expanded_income_weighted, _weighted_share_of_total,
+                           expanded_income_weighted,
                            weighted_perc_inc, weighted_perc_dec,
                            add_income_bins, add_weighted_income_bins,
                            multiyear_diagnostic_table,
                            mtr_graph_data, atr_graph_data,
                            xtr_graph_plot, write_graph_file,
-                           temporary_filename, ascii_output,
+                           temporary_filename, ascii_output, delete_file,
                            write_json_to_file, read_json_from_file,
                            read_egg_csv, read_egg_json,
                            certainty_equivalent, ce_aftertax_income)
@@ -283,16 +283,6 @@ def test_weighted_perc_dec():
     assert_series_equal(exp, diffs)
 
 
-def test_weighted_share_of_total():
-    dfx = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
-    grouped = dfx.groupby('label')
-    diffs = grouped.apply(_weighted_share_of_total, 'tax_diff', 42.0)
-    exp = pd.Series(data=[16.0 / 42.001, 26.0 / 42.001],
-                    index=['a', 'b'])
-    exp.index.name = 'label'
-    assert np.allclose(exp, diffs, rtol=0.0, atol=0.001)
-
-
 EPSILON = 1e-5
 
 
@@ -382,20 +372,6 @@ def test_add_weighted_income_bins():
     bin_labels = dfb['bins'].unique()
     for lab in bin_labels:
         assert lab in custom_labels
-
-
-def test_add_columns():
-    cols = [[1000, 40, -10, 0, 10],
-            [100, 8, 9, 100, 20],
-            [-1000, 38, 90, 800, 30]]
-    dfx = pd.DataFrame(data=cols,
-                       columns=['c00100', 'c04470', 'standard',
-                                'c09600', 's006'])
-    dfx = _add_columns(dfx)
-    assert_equal(dfx.c04470, np.array([40, 0, 0]))
-    assert_equal(dfx.num_returns_ItemDed, np.array([10, 0, 0]))
-    assert_equal(dfx.num_returns_StandardDed, np.array([0, 20, 0]))
-    assert_equal(dfx.num_returns_AMT, np.array([0, 20, 30]))
 
 
 def test_dist_table_sum_row(records_2009):


### PR DESCRIPTION
Move `string_to_number` utility  function to new `taxcalc/filings/forms/utils.py` file.
Move several utility functions used only in by functions in `utils.py` to new `taxcalc/_utils.py` file.
Make three functions in the `utils.py` file, which are called only there, into nested functions.

This activity is part of the ongoing effort to define a **public API** for Tax-Calculator.