### PR TITLE
Add conditional import of bokeh package in utils.py

### DIFF
--- a/taxcalc/cli/install_local_taxcalc_package.sh
+++ b/taxcalc/cli/install_local_taxcalc_package.sh
@@ -26,6 +26,7 @@ fi
 # build taxcalc conda package
 cd ../../conda.recipe/
 conda build --python 2.7 . 2>&1 | awk '$1~/BUILD/||$1~/TEST/'
+conda build purge
 
 # install taxcalc conda package
 conda install taxcalc=0.0.0 --use-local --yes 2>&1 > /dev/null

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -16,8 +16,11 @@ from pkg_resources import resource_stream, Requirement
 import six
 import numpy as np
 import pandas as pd
-import bokeh.io as bio
-import bokeh.plotting as bp
+try:
+    import bokeh.io as bio
+    import bokeh.plotting as bp
+except ImportError:
+    pass
 from taxcalc._utils import *
 
 


### PR DESCRIPTION
Original intention was to add bokeh package to conda.recipe, but still have no answer to question about `slug size` of taxcalc package.  These changes work around this lack of information for the time being.