### PR TITLE
Initial version of public API for Tax-Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ procedures](TESTING.md).  The Tax-Calculator [release
 history](RELEASES.md) provides a summary of past and current
 development work.
 
-If you are relying on Tax-Calculator capabilities in your own project,
-be sure to read the definition of the [Tax-Calculator Public
+If you are relying on Tax-Calculator capabilities in your own software
+development project, be sure to read the definition of the
+[Tax-Calculator Public
 API](http://taxcalc.readthedocs.io/en/latest/public_api.html).
 
 Citing Tax-Calculator

--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ procedures](TESTING.md).  The Tax-Calculator [release
 history](RELEASES.md) provides a summary of past and current
 development work.
 
-If you are relying on Tax-Calculator capabilities in your own software
-development project, be sure to read the definition of the
-[Tax-Calculator Public
+If you are relying on Tax-Calculator capabilities in your own project,
+be sure to read the definition of the [Tax-Calculator Public
 API](http://taxcalc.readthedocs.io/en/latest/public_api.html).
 
 Citing Tax-Calculator

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,7 +13,8 @@ Release 0.9.0 on 2017-??-??
 - Initial specification of public API removes several unused utility
   functions and makes private several Tax-Calculator members whose
   only role is to support public members
-  [[#1424](https://github.com/open-source-economics/Tax-Calculator/pull/1424)]
+  [[#1424](https://github.com/open-source-economics/Tax-Calculator/pull/1424)
+  by Martin Holmer]
 
 **New Features**
 - ...

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,7 +17,9 @@ Release 0.9.0 on 2017-??-??
   by Martin Holmer]
 
 **New Features**
-- ...
+- Add nonrefundable personal credit reform options
+  [[#1427](https://github.com/open-source-economics/Tax-Calculator/pull/1427)
+  by William Ensor]
 
 **Bug Fixes**
 - None

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,17 +4,22 @@ Go
 [here](https://github.com/open-source-economics/Tax-Calculator/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
-Release 0.8.6 on 2017-06-???
+Release 0.9.0 on 2017-??-??
 ---------------------------
 (last merged pull request is
-[???](www.))
+[#xxxx](https://github.com/open-source-economics/Tax-Calculator/pull/xxxx))
 
 **API Changes**
+- Initial specification of public API removes several unused utility
+  functions and makes private several Tax-Calculator members whose
+  only role is to support public members
+  [[#1424](https://github.com/open-source-economics/Tax-Calculator/pull/1424)]
 
 **New Features**
+- ...
 
 **Bug Fixes**
-
+- None
 
 Release 0.8.5 on 2017-06-08
 ---------------------------

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -8,7 +8,6 @@ from taxcalc.growdiff import *
 from taxcalc.records import *
 from taxcalc.taxcalcio import *
 from taxcalc.utils import *
-from taxcalc.decorators import *
 from taxcalc.macro_elasticity import *
 from taxcalc.dropq import *
 from taxcalc.cli import *

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -8,7 +8,6 @@ from taxcalc.growdiff import *
 from taxcalc.records import *
 from taxcalc.taxcalcio import *
 from taxcalc.utils import *
-from taxcalc._utils import *
 from taxcalc.decorators import *
 from taxcalc.macro_elasticity import *
 from taxcalc.dropq import *

--- a/taxcalc/_utils.py
+++ b/taxcalc/_utils.py
@@ -5,26 +5,8 @@ PRIVATE utility functions for Tax-Calculator PUBLIC utility functions.
 # pep8 --ignore=E402 _utils.py
 # pylint --disable=locally-disabled _utils.py
 
-import json
-import random
-import pandas as pd
-
 
 EPSILON = 1e-9
-
-
-def count_gt_zero(data):
-    """
-    Return unweighted count of positive data items.
-    """
-    return sum([1 for item in data if item > 0])
-
-
-def count_lt_zero(data):
-    """
-    Return unweighted count of negative data items.
-    """
-    return sum([1 for item in data if item < 0])
 
 
 def weighted_count_lt_zero(pdf, col_name, tolerance=-0.001):
@@ -102,59 +84,3 @@ def weighted_perc_dec(pdf, col_name):
     """
     return (float(weighted_count_lt_zero(pdf, col_name)) /
             float(weighted_count(pdf) + EPSILON))
-
-
-def ascii_output(csv_filename, ascii_filename):
-    """
-    Converts csv output from Calculator into ascii output with uniform
-    columns and transposes data so columns are rows and rows are columns.
-    In an ipython notebook, you can import this function from the utils module.
-    """
-    # ** List of integers corresponding to the numbers of the rows in the
-    #    csv file, only rows in list will be recorded in final output.
-    #    If left as [], results in entire file are being converted to ascii.
-    #    Put in order from smallest to largest, for example:
-    #    recids = [33180, 64023, 68020, 74700, 84723, 98001, 107039, 108820]
-    recids = [1, 4, 5]
-    # ** Number of characters in each column, must be a nonnegative integer.
-    col_size = 15
-    # read csv_filename into a Pandas DataFrame
-    pdf = pd.read_csv(csv_filename, dtype=object)
-    # keep only listed recids if recids list is not empty
-    if recids != []:
-        def pdf_recid(recid):
-            """ Return Pandas DataFrame recid value for specified recid """
-            return recid - 1
-        recids = map(pdf_recid, recids)
-        pdf = pdf.ix[recids]  # pylint: disable=no-member
-    # do transposition
-    out = pdf.T.reset_index()  # pylint: disable=no-member
-    # format data into uniform columns
-    fstring = '{:' + str(col_size) + '}'
-    out = out.applymap(fstring.format)
-    # write ascii output to specified ascii_filename
-    out.to_csv(ascii_filename, header=False, index=False, sep='\t')
-
-
-def read_json_from_file(path):
-    """
-    Return a dict of data loaded from the json file stored at path.
-    """
-    with open(path, 'r') as rfile:
-        data = json.load(rfile)
-    return data
-
-
-def write_json_to_file(data, path, indent=4, sort_keys=False):
-    """
-    Write data to a file at path in json format.
-    """
-    with open(path, 'w') as wfile:
-        json.dump(data, wfile, indent=indent, sort_keys=sort_keys)
-
-
-def temporary_filename(suffix=''):
-    """
-    Return string containing filename.
-    """
-    return 'tmp{}{}'.format(random.randint(10000000, 99999999), suffix)

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -3,8 +3,8 @@ Tax-Calculator abstract base parameters class.
 """
 import os
 import json
-from abc import ABCMeta
-from collections import OrderedDict
+import abc
+import collections as collect
 import numpy as np
 from taxcalc.utils import read_egg_json
 
@@ -15,7 +15,7 @@ class ParametersBase(object):
     other groups of parameters that need to have a set_year method.
     Override this __init__ method and DEFAULTS_FILENAME.
     """
-    __metaclass__ = ABCMeta
+    __metaclass__ = abc.ABCMeta
 
     DEFAULTS_FILENAME = None
 
@@ -234,7 +234,8 @@ class ParametersBase(object):
                             cls.DEFAULTS_FILENAME)
         if os.path.exists(path):
             with open(path) as pfile:
-                params_dict = json.load(pfile, object_pairs_hook=OrderedDict)
+                params_dict = json.load(pfile,
+                                        object_pairs_hook=collect.OrderedDict)
         else:
             params_dict = read_egg_json(cls.DEFAULTS_FILENAME)
         return params_dict

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -11,8 +11,8 @@ import os
 import math
 import copy
 import json
-from collections import defaultdict, OrderedDict
-from pkg_resources import resource_stream, Requirement
+import collections
+import pkg_resources
 import six
 import numpy as np
 import pandas as pd
@@ -204,7 +204,7 @@ def get_sums(pdf, not_available=False):
     -------
     Pandas Series object containing column sums indexed by pdf colum names.
     """
-    sums = defaultdict(lambda: 0)
+    sums = collections.defaultdict(lambda: 0)
     for col in pdf.columns.values.tolist():
         if col != 'bins':
             if not_available:
@@ -488,7 +488,7 @@ def create_diagnostic_table(calc):
         # aggregate weighted values expressed in millions or billions
         in_millions = 1.0e-6
         in_billions = 1.0e-9
-        odict = OrderedDict()
+        odict = collections.OrderedDict()
         # total number of filing units
         odict['Returns (#m)'] = recs.s006.sum() * in_millions
         # adjusted gross income
@@ -1241,8 +1241,12 @@ def read_egg_csv(fname, **kwargs):
     """
     try:
         path_in_egg = os.path.join('taxcalc', fname)
-        vdf = pd.read_csv(resource_stream(Requirement.parse('taxcalc'),
-                                          path_in_egg), **kwargs)
+        vdf = pd.read_csv(
+            pkg_resources.resource_stream(
+                pkg_resources.Requirement.parse('taxcalc'),
+                path_in_egg),
+            **kwargs
+        )
     except:
         raise ValueError('could not read {} data from egg'.format(fname))
     return vdf
@@ -1255,9 +1259,12 @@ def read_egg_json(fname):
     """
     try:
         path_in_egg = os.path.join('taxcalc', fname)
-        pdict = json.loads(resource_stream(Requirement.parse('taxcalc'),
-                                           path_in_egg).read().decode('utf-8'),
-                           object_pairs_hook=OrderedDict)
+        pdict = json.loads(
+            pkg_resources.resource_stream(
+                pkg_resources.Requirement.parse('taxcalc'),
+                path_in_egg).read().decode('utf-8'),
+            object_pairs_hook=collections.OrderedDict
+        )
     except:
         raise ValueError('could not read {} data from egg'.format(fname))
     return pdict

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -21,7 +21,13 @@ try:
     import bokeh.plotting as bp
 except ImportError:
     pass
-from taxcalc._utils import *
+from taxcalc._utils import (weighted_count_lt_zero,
+                            weighted_count_gt_zero,
+                            weighted_count, weighted_mean,
+                            wage_weighted, agi_weighted,
+                            expanded_income_weighted,
+                            weighted_perc_inc, weighted_perc_dec,
+                            EPSILON)
 
 
 STATS_COLUMNS = ['expanded_income', 'c00100', 'aftertax_income', 'standard',
@@ -163,7 +169,7 @@ def means_and_comparisons(col_name, gpdf, weighted_total):
         Nested function that returns the ratio of
         weighted_sum(pdf, col_name) and the specified total.
         """
-        return float(weighted_sum(pdf, col_name)) / (float(total) + EPSILON)
+        return weighted_sum(pdf, col_name) / (float(total) + EPSILON)
     # tabulate who has a tax cut and who has a tax increase
     diffs = gpdf.apply(weighted_count_lt_zero, col_name)
     diffs = pd.DataFrame(data=diffs, columns=['tax_cut'])

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -21,13 +21,13 @@ try:
     import bokeh.plotting as bp
 except ImportError:
     pass
-from taxcalc._utils import (weighted_count_lt_zero,
-                            weighted_count_gt_zero,
-                            weighted_count, weighted_mean,
-                            wage_weighted, agi_weighted,
-                            expanded_income_weighted,
-                            weighted_perc_inc, weighted_perc_dec,
-                            EPSILON)
+from taxcalc.utilsprvt import (weighted_count_lt_zero,
+                               weighted_count_gt_zero,
+                               weighted_count, weighted_mean,
+                               wage_weighted, agi_weighted,
+                               expanded_income_weighted,
+                               weighted_perc_inc, weighted_perc_dec,
+                               EPSILON)
 
 
 STATS_COLUMNS = ['expanded_income', 'c00100', 'aftertax_income', 'standard',

--- a/taxcalc/utilsprvt.py
+++ b/taxcalc/utilsprvt.py
@@ -2,8 +2,8 @@
 PRIVATE utility functions for Tax-Calculator PUBLIC utility functions.
 """
 # CODING-STYLE CHECKS:
-# pep8 --ignore=E402 _utils.py
-# pylint --disable=locally-disabled _utils.py
+# pep8 --ignore=E402 utilsprvt.py
+# pylint --disable=locally-disabled utilsprvt.py
 
 
 EPSILON = 1e-9


### PR DESCRIPTION
This is the last of a series of pull requests that taken together define a **public API** for Tax-Calculator.  The other pull requests in this series are #1404, #1406, #1412 and #1419.  The definition of the public API is at [this automatically-generated Read-the-Docs web page](http://taxcalc.readthedocs.io/en/latest/public_api.html), which will be updated after this pull request is merged.

The point of defining a Tax-Calculator public API is to make it more clear to those who rely on Tax-Calculator (via the taxcalc conda package) what members (class methods and functions) are intended to be stable over time and changed only with prior notice and what members are private implementation details that are subject to change without notice.  Given this this public API, future releases of Tax-Calculator will follow the rules of **semantic versioning**, a short description of which is available at [this web page](http://semver.org).  The following is from the Summary section of that document:
```
Given a version number MAJOR.MINOR.PATCH, increment the:

MAJOR version when you make incompatible API changes,
MINOR version when you add functionality in a backwards-compatible manner, and
PATCH version when you make backwards-compatible bug fixes.
```
Following the discussion in that document, the plan is to stay at MAJOR version 0 for some time until we have confidence that the public API is stable.  Only then would we consider incrementing the MAJOR version number to 1.

Meanwhile, we can adopt semantic versioning by identifying the next release as 0.9.0.  And the subsequent release of added features would be 0.10.0, and the one after that would be 0.11.0.  If we need to fix a bug in 0.9.0 before issuing the 0.10.0 release, that bug-fix release would be 0.9.1.  This approach to release numbering is wide-spread.  For example, both numpy and pandas are using semantic versioning with numpy at a more mature 1.x.x stage and the younger pandas project at the 0.x.x development stage (where API changes can occur with notice at any MINOR version).

Since Tax-Calculator is still at the 0.x.x stage of development, you should feel free to initiate a discussion about the public API, such as suggesting new public members, requesting revisions to public members, or suggesting converting some public members to private status.  If you have a suggestion about the public API, please raise an issue in the Tax-Calculator repository.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @GoFroggyRun @codykallen @zrisher 
@hdoupe @econ02 @PeterDSteinberg @brittainhard @rickecon @jdebacker 
