### PR TITLE
Add option to repeal personal exemptions for deps under age 18

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -505,6 +505,22 @@
         "value": [0.02]
     },
 
+    "_II_no_em_nu18": {
+        "long_name": "Repeal personal exemptions for dependents under age 18",
+        "description": "Total personal exemptions will be decreased by the number of dependents under the age of 18",
+        "section_1": "Personal Exemptions",
+        "section_2": "Repeal Personal Exemptions for Dependents Under Age 18",
+        "irs_ref": "",
+        "notes": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "start_year": 2013,
+        "cpi_inflated": false,
+        "col_var": "",
+        "col_label": "",
+        "value": [false]
+    },
+
     "_STD": {
         "long_name": "Standard deduction amount",
         "description": "Amount filing unit can use as a standard deduction.",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -311,7 +311,8 @@ def UBI(nu18, n1821, n21, UBI1, UBI2, UBI3, UBI_ecrt,
 def AGI(ymod1, c02500, c02900, XTOT, MARS, sep, DSI, exact,
         II_em, II_em_ps, II_prt,
         II_credit, II_credit_ps, II_credit_prt, taxable_ubi,
-        c00100, pre_c04600, c04600, personal_credit):
+        c00100, pre_c04600, c04600, personal_credit,
+        II_no_em_nu18, nu18):
     """
     AGI function: compute Adjusted Gross Income, c00100,
                   compute personal exemption amount, c04600, and
@@ -320,7 +321,10 @@ def AGI(ymod1, c02500, c02900, XTOT, MARS, sep, DSI, exact,
     # calculate AGI assuming no foreign earned income exclusion
     c00100 = ymod1 + c02500 - c02900 + taxable_ubi
     # calculate personal exemption amount
-    pre_c04600 = XTOT * II_em
+    if II_no_em_nu18:  # repeal of personal exemptions for deps. under 18
+        pre_c04600 = max(0, XTOT - nu18) * II_em
+    else:
+        pre_c04600 = XTOT * II_em
     if DSI:
         pre_c04600 = 0.
     # phase-out personal exemption amount

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -646,7 +646,8 @@ def test_clp_section_titles(tests_path):
         'Personal Exemptions': {
             'Personal And Dependent Exemption Amount': 0,
             # 'Personal Exemption Phaseout Starting Income': 0,
-            'Personal Exemption Phaseout Rate': 0
+            'Personal Exemption Phaseout Rate': 0,
+            'Repeal Personal Exemptions for Dependents Under Age 18': 0,
         },
         'Standard Deduction': {
             'Standard Deduction Amount': 0,


### PR DESCRIPTION
This PR adds a policy parameter, `_II_no_em_nu18`, as described in issue #1409.

cc @MattHJensen @martinholmer 