### PR TITLE
Add new unit test to check for taxcalc package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,4 @@ dependencies:
 - pylint
 - coverage
 - pytest-pep8
-- conda
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,5 @@ dependencies:
 - pylint
 - coverage
 - pytest-pep8
+- conda
 

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -3,9 +3,12 @@ import subprocess
 import pytest
 
 
+@pytest.mark.requires_pufcsv
 def test_for_package_existence():
     """
-    Ensure that no conda taxcalc package is installed when running pytest
+    Ensure that no conda taxcalc package is installed when running pytest.
+    Primarily to help developers catch mistaken installations of taxcalc;
+    the requires_pufcsv mark prevents test from running on GitHub.
     """
     out = subprocess.check_output(['conda', 'list', 'taxcalc']).decode('ascii')
     envless_out = out.replace('taxcalc-dev', 'environment')

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -1,9 +1,12 @@
-import pytest
-import subprocess
 import re
+import subprocess
+import pytest
 
 
 def test_for_package_existence():
+    """
+    Ensure that no conda taxcalc package is installed when running pytest
+    """
     out = subprocess.check_output(['conda', 'list', 'taxcalc'])
-    if re.search('taxcalc', out.decode('utf-8')) is not None:
+    if re.search('taxcalc'.encode('ascii'), out.encode('ascii')) is not None:
         assert 'taxcalc package' == 'installed'

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -2,11 +2,11 @@ import re
 import subprocess
 import pytest
 
-
+@pytest.mark.one
 def test_for_package_existence():
     """
     Ensure that no conda taxcalc package is installed when running pytest
     """
     out = subprocess.check_output(['conda', 'list', 'taxcalc'])
-    if re.search('taxcalc'.encode('ascii'), out.encode('ascii')) is not None:
+    if re.search('taxcalc', out.decode('ascii')) is not None:
         assert 'taxcalc package' == 'installed'

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -1,0 +1,9 @@
+import pytest
+import subprocess
+import re
+
+
+def test_for_package_existence():
+    res = subprocess.check_output(['conda', 'list', 'taxcalc'])
+    if re.search('taxcalc', res) is not None:
+        assert 'taxcalc package' == 'installed'

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -7,6 +7,7 @@ def test_for_package_existence():
     """
     Ensure that no conda taxcalc package is installed when running pytest
     """
-    out = subprocess.check_output(['conda', 'list', 'taxcalc'])
-    if re.search('taxcalc', out.decode('ascii')) is not None:
+    out = subprocess.check_output(['conda', 'list', 'taxcalc']).decode('ascii')
+    envless_out = out.replace('taxcalc-dev', 'environment')
+    if re.search('taxcalc', envless_out) is not None:
         assert 'taxcalc package' == 'installed'

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -4,6 +4,6 @@ import re
 
 
 def test_for_package_existence():
-    res = subprocess.check_output(['conda', 'list', 'taxcalc'])
-    if re.search('taxcalc', res) is not None:
+    out = subprocess.check_output(['conda', 'list', 'taxcalc'])
+    if re.search('taxcalc', out.decode('utf-8')) is not None:
         assert 'taxcalc package' == 'installed'

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -2,7 +2,7 @@ import re
 import subprocess
 import pytest
 
-@pytest.mark.one
+
 def test_for_package_existence():
     """
     Ensure that no conda taxcalc package is installed when running pytest


### PR DESCRIPTION
This pull request adds a new pytest that will fail whenever the unit tests are run when a taxcalc package is installed.  This test is meant to help alert developers to the confusing situation described in issue #1231.