### PR TITLE
Rename main function in taxcalc/cli/tc.py

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 build:
   entry_points:
-    - tc = taxcalc.cli.tc:main
+    - tc = taxcalc.cli.tc:cli_tc_main
 
 requirements:
   build:

--- a/taxcalc/cli/__init__.py
+++ b/taxcalc/cli/__init__.py
@@ -1,1 +1,1 @@
-from taxcalc.cli.tc import main
+from taxcalc.cli.tc import cli_tc_main

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -16,7 +16,7 @@ TEST_INPUT_FILENAME = 'test.csv'
 TEST_TAXYEAR = 2017
 
 
-def main():
+def cli_tc_main():
     """
     Contains command-line interface (CLI) to Tax-Calculator TaxCalcIO class.
     """
@@ -139,7 +139,7 @@ def main():
         retcode = 0
     # return exit code
     return retcode
-# end of main function code
+# end of cli_tc_main function code
 
 
 EXPECTED_TEST_OUTPUT_FILENAME = 'test-{}-out.csv'.format(str(TEST_TAXYEAR)[2:])
@@ -187,4 +187,4 @@ def _compare_test_output_files():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    sys.exit(cli_tc_main())


### PR DESCRIPTION
Cosmetic change that leaves taxcalc logic and results unchanged.
Change avoids possible function name collisions.
