### PR TITLE
Enhance Calculator.read_json_param_files to accept JSON file contents

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -361,32 +361,48 @@ class Calculator(object):
         returning a single dictionary containing five key:dict pairs:
         'policy':dict, 'consumption':dict, 'behavior':dict,
         'growdiff_baseline':dict and 'growdiff_response':dict.
+
+        Note that either of the first two parameters may be None, in which
+        case an empty dictionary or empty dictionaries will be returned.
+
+        Also note that either of the first two parameters can be strings
+        containing the JSON parameter file contents (rather than filename),
+        in which case the file reading is skipped and the read_json_*_text
+        method is called.
         """
+        # process first reform parameter
         if reform_filename is None:
             rpol_dict = dict()
-        elif os.path.isfile(reform_filename):
-            txt = open(reform_filename, 'r').read()
+        elif isinstance(reform_filename, str):
+            if os.path.isfile(reform_filename):
+                txt = open(reform_filename, 'r').read()
+            else:
+                txt = reform_filename
             rpol_dict = (
-                Calculator._read_json_policy_reform_text(txt, arrays_not_lists)
-            )
+                Calculator._read_json_policy_reform_text(txt,
+                                                         arrays_not_lists))
         else:
-            msg = 'policy reform file {} could not be found'
-            raise ValueError(msg.format(reform_filename))
+            raise ValueError('reform_filename is neither None nor str')
+        # process second assump parameter
         if assump_filename is None:
             cons_dict = dict()
             behv_dict = dict()
             gdiff_base_dict = dict()
             gdiff_resp_dict = dict()
-        elif os.path.isfile(assump_filename):
-            txt = open(assump_filename, 'r').read()
+        elif isinstance(assump_filename, str):
+            if os.path.isfile(assump_filename):
+                txt = open(assump_filename, 'r').read()
+            else:
+                txt = assump_filename
             (cons_dict,
              behv_dict,
              gdiff_base_dict,
              gdiff_resp_dict) = (
-                 Calculator._read_json_econ_assump_text(txt, arrays_not_lists))
+                 Calculator._read_json_econ_assump_text(txt,
+                                                        arrays_not_lists))
         else:
-            msg = 'economic assumption file {} could not be found'
-            raise ValueError(msg.format(assump_filename))
+            raise ValueError('assump_filename is neither None nor str')
+        # construct and return single composite dictionary
         param_dict = dict()
         param_dict['policy'] = rpol_dict
         param_dict['consumption'] = cons_dict

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -562,6 +562,8 @@ def test_read_bad_json_reform_file(bad1reformfile, bad2reformfile,
         Calculator.read_json_param_files(bad2reformfile.name, None)
     with pytest.raises(ValueError):
         Calculator.read_json_param_files(bad3reformfile.name, None)
+    with pytest.raises(ValueError):
+        Calculator.read_json_param_files(list(), None)
 
 
 @pytest.yield_fixture
@@ -640,6 +642,8 @@ def test_read_bad_json_assump_file(bad1assumpfile, bad2assumpfile,
         Calculator.read_json_param_files(None, bad3assumpfile.name)
     with pytest.raises(ValueError):
         Calculator.read_json_param_files(None, 'unknown_file_name')
+    with pytest.raises(ValueError):
+        Calculator.read_json_param_files(None, list())
 
 
 def test_convert_parameter_dict():


### PR DESCRIPTION
This pull request implements the enhancement requested by TaxBrain developers in issue #1443.

It allows the first two arguments of the `Calculator.read_json_param_files` method to be either JSON file names (as now) or JSON file contents (new).  Two new tests were added to the `test_calculate.py` file in order to keep the number of uncovered statements at eight.

This pull request does not change tax-calculating logic, and therefore, tax results are unchanged.

@MattHJensen @brittainhard @PeterDSteinberg 