### PR TITLE
Add new read_json_param_files test

### DIFF
--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -453,6 +453,17 @@ def assump_file():
             pass  # sometimes we can't remove a generated temporary file
 
 
+def test_read_json_reform_file_two_ways(reform_file, assump_file):
+    """
+    Test when using file name and file contents in read_json_param_files
+    """
+    pd1 = Calculator.read_json_param_files(reform_file.name, assump_file.name,
+                                           arrays_not_lists=False)
+    pd2 = Calculator.read_json_param_files(REFORM_CONTENTS, ASSUMP_CONTENTS,
+                                           arrays_not_lists=False)
+    assert pd1 == pd2
+
+
 @pytest.mark.parametrize("set_year", [False, True])
 def test_read_json_reform_file_and_implement_reform(reform_file,
                                                     assump_file,


### PR DESCRIPTION
Add test showing `Calculator.read_json_param_files` returns same dictionary when using file name and file content arguments.  No change in tax-calculating logic or tax results.