### PR TITLE
Temporary avoidance of numpy 1.13.1, which causes test errors

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,7 +9,7 @@ build:
 requirements:
   build:
     - python
-    - numpy >=1.12.1
+    - numpy ==1.12.1
     - pandas >=0.20.1
     - numba
     - toolz
@@ -17,7 +17,7 @@ requirements:
     - bokeh >=0.12.3
   run:
     - python
-    - numpy >=1.12.1
+    - numpy ==1.12.1
     - pandas >=0.20.1
     - numba
     - toolz


### PR DESCRIPTION
Within the past few days, conda packages were made available for numpy 1.13.1.  Before that the most recent version of numpy was 1.12.1.

But, for some reason, the use by Tax-Calculator of the new numpy 1.13.1 package (along with others that rely on numpy) cause many test errors.

This pull request temporarily pins numpy to 1.12.1 in the requirements sections of the `conda.recipes/meta.yaml` file.  Previous pull request #1466 pinned numpy to 1.12.1 in the `environment.yml` file that specifies the `taxcalc_dev` environment.  The change in all places is to convert `taxcalc >=1.12.1` to `taxcalc ==1.12.1`.

I will post a Tax-Calculator issue that describes the nature of the errors, which may require some code changes or may be rooted in a bug in one of the new packages that relies on numpy 1.13.

