### PR TITLE
Fix Records._adjust method to work with numpy 1.13.1

### DIFF
--- a/conda.recipe/install_local_taxcalc_package.sh
+++ b/conda.recipe/install_local_taxcalc_package.sh
@@ -9,6 +9,8 @@
 
 echo "STARTING : `date`"
 
+echo "BUILD-PREP..."
+
 # uninstall any existing taxcalc conda package
 conda list taxcalc | awk '$1~/taxcalc/{rc=1}END{exit(rc)}'
 if [ $? -eq 1 ]; then
@@ -28,12 +30,14 @@ pversion=$(conda list python | awk '$1=="python"{print substr($2,1,3)}')
 
 # build taxcalc conda package for this version of Python
 conda build --python $pversion . 2>&1 | awk '$1~/BUILD/||$1~/TEST/'
-conda build purge
 
 # install taxcalc conda package
+echo "INSTALLATION..."
 conda install taxcalc=0.0.0 --use-local --yes 2>&1 > /dev/null
 
 # clean-up after package build
+echo "CLEAN-UP..."
+conda build purge
 cd ..
 rm -fr build/*
 rmdir build/

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -343,10 +343,12 @@ class Records(object):
     def _adjust(self, year):
         """
         Adjust value of income variables to match SOI distributions
+        Note: adjustment must leave variables as numpy.ndarray type
         """
         if len(self.ADJ) != 0:
             # Interest income
-            self.e00300 *= self.ADJ['INT{}'.format(year)][self.agi_bin]
+            adj_array = self.ADJ['INT{}'.format(year)][self.agi_bin].values
+            self.e00300 *= adj_array
 
     def _read_data(self, data, exact_calcs):
         """


### PR DESCRIPTION
This pull request fixes a problem that arises when using the new numpy 1.13.1 package.  The problem manifested itself with the CLI to Tax-Calculator, tc, crashing when the --dump or --sqldb option is used.  This happens because the pandas 0.20.2 package that uses numpy 1.13.1 behaves differently than the pandas 0.20.2 package that uses numpy 1.12.1.  The change in behavior is that formerly when calling the pandas DataFrame constructor a mixture of numpy.ndarray and pandas.Series objects (of the same dimension) were OK, but not with the new version of pandas.  This is not too dissimilar from the decorator problem diagnosed by @talumbau in pull request #1470.  The fix is to revise the Records._adjust method so that variable `e00300` continues to be a numpy.ndarray (like all the other read and calculated variables) after the adjustment.  In the old code `e00300` was being turned into a pandas.Series object because it was being multiplied by the pandas object ADJ.

The new code works under both the old numpy 1.12.2 and the new numpy 1.13.1.

There is no change in Tax-Calculator logic; only a change to be more consistent about data types, which seems to be a requirement under the newest pandas version that relies on numpy 1.13.1.

@MattHJensen @Amy-Xu @andersonfrailey @hdoupe 