### PR TITLE
Add checking of start_year and year_n values to dropq logic

### DIFF
--- a/taxcalc/dropq/dropq_utils.py
+++ b/taxcalc/dropq/dropq_utils.py
@@ -20,6 +20,22 @@ from taxcalc.utils import (add_income_bins, add_weighted_income_bins,
 EPSILON = 1e-3
 
 
+def check_years(start_year, year_n):
+    """
+    Ensure start_year and year_n values are consistent with Policy constants.
+    """
+    if start_year < Policy.JSON_START_YEAR:
+        msg = 'start_year={} < Policy.JSON_START_YEAR={}'
+        raise ValueError(msg.format(start_year, Policy.JSON_START_YEAR))
+    if year_n < 0:
+        msg = 'year_n={} < 0'
+        raise ValueError(msg.format(year_n))
+    if (start_year + year_n) > Policy.LAST_BUDGET_YEAR:
+        msg = '(start_year={} + year_n={}) > Policy.LAST_BUDGET_YEAR={}'
+        raise ValueError(msg.format(start_year, year_n,
+                                    Policy.LAST_BUDGET_YEAR))
+
+
 def check_user_mods(user_mods):
     """
     Ensure specified user_mods is properly structured.
@@ -52,7 +68,7 @@ def dropq_calculate(year_n, start_year,
       mask is boolean array if compute_mask=True or None otherwise
     """
     # pylint: disable=too-many-arguments,too-many-locals,too-many-statements
-
+    check_years(start_year, year_n)
     check_user_mods(user_mods)
 
     # specify Consumption instance

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -60,6 +60,15 @@ def puf_path(tests_path):
     return os.path.join(tests_path, '..', '..', 'puf.csv')
 
 
+@pytest.mark.parametrize('start_year, year_n',
+                         [(2000, 0),
+                          (2013, -1),
+                          (2017, 10)])
+def test_check_years_errors(start_year, year_n):
+    with pytest.raises(ValueError):
+        check_years(start_year, year_n)
+
+
 def test_check_user_mods_errors():
     check_user_mods(USER_MODS)
     seed1 = random_seed(USER_MODS)


### PR DESCRIPTION
This pull request adds checking of the values of the `start_year` and `year_n` values passed to dropq functions in order to ensure that the passed values are consistent with several Policy constants.

This pull request does not change any tax-calculating or dropq logic; it just provides error messages quicker than before.  And hopefully the new error messages will be more informative than before.

The new checking logic is tested in the new `test_check_years_errors` function in the `test_dropq.py` file.

@MattHJensen @hdoupe @PeterDSteinberg @brittainhard 