### PR TITLE
Make reform comparison tests use puf.csv subsample

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -61,7 +61,7 @@ Depending on your computer, the execution time for this incomplete
 suite of tests is a little over one minute.  The `-n4` option calls
 for using as many as four CPU cores for parallel execution of the
 tests.  If you want sequential execution of the tests (which will
-take roughly twice as long to execute), simply omit the `-n4` option.
+take at least twice as long to execute), simply omit the `-n4` option.
 
 **HAVE PUF.CSV**: If you do have access to the `puf.csv` file, copy it
 into the tax-calculator directory at the top of the repository
@@ -77,7 +77,7 @@ py.test -n4
 This will start executing a pytest suite containing hundreds of tests,
 including the tests that require the `puf.csv` file as input.
 Depending on your computer, the execution time for this complete suite
-of unit tests is roughly four minutes.  The `-n4` option calls for
+of unit tests is roughly three minutes.  The `-n4` option calls for
 using as many as four CPU cores for parallel execution of the tests.
 If you want sequential execution of the tests (which will take at
 least twice as long to execute), simply omit the `-n4` option.

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -94,7 +94,7 @@ def reform_results(reform_dict, puf_data):
 
 
 @pytest.mark.requires_pufcsv
-def test_r1(puf_fullsample):
+def test_r1(puf_subsample):
     """
     Comparison test 1
     """
@@ -109,13 +109,13 @@ def test_r1(puf_fullsample):
     """
     expected_res = ('Increase OASDI payroll tax rate by 1 pts'
                     '\n'
-                    'Tax-Calculator,62.2,64.6,68.0,70.8')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,63.1,65.6,69.1,71.7')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r2(puf_fullsample):
+def test_r2(puf_subsample):
     """
     Comparison test 2
     """
@@ -130,13 +130,13 @@ def test_r2(puf_fullsample):
     """
     expected_res = ('Increase OASDI maximum taxable earnings to $177,500'
                     '\n'
-                    'Tax-Calculator,50.2,58.8,55.0,56.9')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,48.7,57.3,53.4,55.1')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r3(puf_fullsample):
+def test_r3(puf_subsample):
     """
     Comparison test 3
     """
@@ -151,13 +151,13 @@ def test_r3(puf_fullsample):
     """
     expected_res = ('Increase HI payroll tax rate by 1 pts'
                     '\n'
-                    'Tax-Calculator,74.7,78.1,81.6,84.9')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,75.1,78.7,82.2,85.3')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r4(puf_fullsample):
+def test_r4(puf_subsample):
     """
     Comparison test 4
     """
@@ -172,13 +172,13 @@ def test_r4(puf_fullsample):
     """
     expected_res = ('Increase Additional Medicare Tax exclusion by $10,000'
                     '\n'
-                    'Tax-Calculator,-0.3,-0.3,-0.3,-0.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-0.3,-0.3,-0.3,-0.3')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r5(puf_fullsample):
+def test_r5(puf_subsample):
     """
     Comparison test 5
     """
@@ -193,13 +193,13 @@ def test_r5(puf_fullsample):
     """
     expected_res = ('Increase Additional Medicare Tax rate by 0.1 pts'
                     '\n'
-                    'Tax-Calculator,0.8,0.9,0.9,1.0')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,0.8,0.8,0.9,1.0')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r6(puf_fullsample):
+def test_r6(puf_subsample):
     """
     Comparison test 6
     """
@@ -218,13 +218,13 @@ def test_r6(puf_fullsample):
     """
     expected_res = ('All OASDI benefits included in AGI'
                     '\n'
-                    'Tax-Calculator,38.7,39.9,41.4,43.6')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,39.2,40.2,41.3,43.4')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r7(puf_fullsample):
+def test_r7(puf_subsample):
     """
     Comparison test 7
     """
@@ -239,13 +239,13 @@ def test_r7(puf_fullsample):
     """
     expected_res = ('No deduction for KEOGH/SEP contributions'
                     '\n'
-                    'Tax-Calculator,7.6,7.8,8.1,8.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,7.9,8.1,8.5,8.7')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r8(puf_fullsample):
+def test_r8(puf_subsample):
     """
     Comparison test 8
     """
@@ -260,13 +260,13 @@ def test_r8(puf_fullsample):
     """
     expected_res = ('No deduction for student-loan interest'
                     '\n'
-                    'Tax-Calculator,1.7,1.8,1.9,2.0')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,1.8,2.0,2.1,2.2')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r9(puf_fullsample):
+def test_r9(puf_subsample):
     """
     Comparison test 9
     """
@@ -281,13 +281,13 @@ def test_r9(puf_fullsample):
     """
     expected_res = ('Eliminate adjustment for self-employment tax'
                     '\n'
-                    'Tax-Calculator,4.2,4.5,4.9,5.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,3.7,3.9,4.3,4.5')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r10(puf_fullsample):
+def test_r10(puf_subsample):
     """
     Comparison test 10
     """
@@ -302,13 +302,13 @@ def test_r10(puf_fullsample):
     """
     expected_res = ('Eliminate adjustment for self-employed health insurance'
                     '\n'
-                    'Tax-Calculator,6.0,6.2,6.3,6.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,5.5,5.6,5.8,5.8')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r11(puf_fullsample):
+def test_r11(puf_subsample):
     """
     Comparison test 11
     """
@@ -323,13 +323,13 @@ def test_r11(puf_fullsample):
     """
     expected_res = ('Eliminate adjustment for alimony payments'
                     '\n'
-                    'Tax-Calculator,2.1,2.2,2.3,2.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,3.1,3.3,3.5,3.4')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r12(puf_fullsample):
+def test_r12(puf_subsample):
     """
     Comparison test 12
     """
@@ -344,13 +344,13 @@ def test_r12(puf_fullsample):
     """
     expected_res = ('Eliminate adjustment for forfeited interest penalty'
                     '\n'
-                    'Tax-Calculator,0.1,0.1,0.1,0.1')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,0.0,0.0,0.1,0.1')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r13(puf_fullsample):
+def test_r13(puf_subsample):
     """
     Comparison test 13
     """
@@ -365,13 +365,13 @@ def test_r13(puf_fullsample):
     """
     expected_res = ('Increase personal and dependent exemption amount by $1000'
                     '\n'
-                    'Tax-Calculator,-32.4,-34.5,-39.1,-40.5')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-33.0,-35.2,-40.0,-41.5')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r14(puf_fullsample):
+def test_r14(puf_subsample):
     """
     Comparison test 14
     """
@@ -388,12 +388,12 @@ def test_r14(puf_fullsample):
                     'by $10,000'
                     '\n'
                     'Tax-Calculator,-0.1,-0.1,-0.1,-0.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r15(puf_fullsample):
+def test_r15(puf_subsample):
     """
     Comparison test 15
     """
@@ -408,13 +408,13 @@ def test_r15(puf_fullsample):
     """
     expected_res = ('Increase personal exemption phaseout rate by 1 pts'
                     '\n'
-                    'Tax-Calculator,0.2,0.2,0.2,0.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,0.3,0.3,0.3,0.3')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r16(puf_fullsample):
+def test_r16(puf_subsample):
     """
     Comparison test 16
     """
@@ -429,13 +429,13 @@ def test_r16(puf_fullsample):
     """
     expected_res = ('Increase standard deduction by $100'
                     '\n'
-                    'Tax-Calculator,-1.0,-2.5,-4.1,-4.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-1.0,-2.6,-4.1,-4.3')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r17(puf_fullsample):
+def test_r17(puf_subsample):
     """
     Comparison test 17
     """
@@ -451,13 +451,13 @@ def test_r17(puf_fullsample):
     """
     expected_res = ('Increase additional stdded for aged/blind by $100'
                     '\n'
-                    'Tax-Calculator,-0.2,-0.3,-0.4,-0.5')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-0.3,-0.3,-0.5,-0.5')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r18(puf_fullsample):
+def test_r18(puf_subsample):
     """
     Comparison test 18
     """
@@ -472,13 +472,13 @@ def test_r18(puf_fullsample):
     """
     expected_res = ('Eliminate real estate itemded'
                     '\n'
-                    'Tax-Calculator,36.0,38.1,40.0,41.9')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,35.7,37.8,39.7,41.5')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r19(puf_fullsample):
+def test_r19(puf_subsample):
     """
     Comparison test 19
     """
@@ -493,13 +493,13 @@ def test_r19(puf_fullsample):
     """
     expected_res = ('Eliminate interest-paid itemded'
                     '\n'
-                    'Tax-Calculator,69.6,74.9,80.1,84.7')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,70.6,76.0,80.8,85.4')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r20(puf_fullsample):
+def test_r20(puf_subsample):
     """
     Comparison test 20
     """
@@ -515,13 +515,13 @@ def test_r20(puf_fullsample):
     """
     expected_res = ('Eliminate both real-estate and state-local-tax itemded'
                     '\n'
-                    'Tax-Calculator,101.2,107.1,113.0,118.5')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,98.9,104.8,110.5,115.7')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r21(puf_fullsample):
+def test_r21(puf_subsample):
     """
     Comparison test 21
     """
@@ -536,13 +536,13 @@ def test_r21(puf_fullsample):
     """
     expected_res = ('Eliminate state-local-tax itemded'
                     '\n'
-                    'Tax-Calculator,66.8,70.3,73.9,77.3')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,66.1,69.5,73.0,76.3')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r22(puf_fullsample):
+def test_r22(puf_subsample):
     """
     Comparison test 22
     """
@@ -557,13 +557,13 @@ def test_r22(puf_fullsample):
     """
     expected_res = ('Eliminate medical itemded'
                     '\n'
-                    'Tax-Calculator,8.2,8.6,7.9,8.1')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,6.9,7.4,6.9,7.2')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r23(puf_fullsample):
+def test_r23(puf_subsample):
     """
     Comparison test 23
     """
@@ -578,13 +578,13 @@ def test_r23(puf_fullsample):
     """
     expected_res = ('Eliminate casualty itemded'
                     '\n'
-                    'Tax-Calculator,0.5,0.5,0.5,0.5')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,0.5,0.5,0.6,0.6')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r24(puf_fullsample):
+def test_r24(puf_subsample):
     """
     Comparison test 24
     """
@@ -599,13 +599,13 @@ def test_r24(puf_fullsample):
     """
     expected_res = ('Eliminate charity itemded'
                     '\n'
-                    'Tax-Calculator,46.8,49.5,52.0,54.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,48.1,51.1,53.8,56.4')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r25(puf_fullsample):
+def test_r25(puf_subsample):
     """
     Comparison test 25
     """
@@ -620,13 +620,13 @@ def test_r25(puf_fullsample):
     """
     expected_res = ('Lower AGI floor for miscellaneous itemded by 1 pts'
                     '\n'
-                    'Tax-Calculator,-2.8,-3.0,-3.1,-3.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-2.9,-3.0,-3.1,-3.3')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r26(puf_fullsample):
+def test_r26(puf_subsample):
     """
     Comparison test 26
     """
@@ -641,13 +641,13 @@ def test_r26(puf_fullsample):
     """
     expected_res = ('Increase itemded maximum phaseout from 80% to 90%'
                     '\n'
-                    'Tax-Calculator,0.2,0.2,0.2,0.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,0.1,0.1,0.1,0.1')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r27(puf_fullsample):
+def test_r27(puf_subsample):
     """
     Comparison test 27
     """
@@ -663,12 +663,12 @@ def test_r27(puf_fullsample):
     expected_res = ('Increase itemded phaseout starting AGI by $10,000'
                     '\n'
                     'Tax-Calculator,0.1,0.1,0.0,0.0')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r28(puf_fullsample):
+def test_r28(puf_subsample):
     """
     Comparison test 28
     """
@@ -683,13 +683,13 @@ def test_r28(puf_fullsample):
     """
     expected_res = ('Increase itemded phaseout rate by 1 pts'
                     '\n'
-                    'Tax-Calculator,4.3,4.5,4.7,4.9')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,4.2,4.4,4.6,4.7')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r29(puf_fullsample):
+def test_r29(puf_subsample):
     """
     Comparison test 29
     """
@@ -705,13 +705,13 @@ def test_r29(puf_fullsample):
     """
     expected_res = ('Limit tax value of itemded to 6% of AGI'
                     '\n'
-                    'Tax-Calculator,20.0,21.0,22.1,23.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,20.8,21.9,22.9,24.3')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r30(puf_fullsample):
+def test_r30(puf_subsample):
     """
     Comparison test 30
     """
@@ -732,13 +732,13 @@ def test_r30(puf_fullsample):
     expected_res = ('Raise LTCG/QDIV tax rates by 2 pts, '
                     'no behavioral response'
                     '\n'
-                    'Tax-Calculator,18.4,19.9,20.2,20.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,18.8,20.5,20.9,21.3')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r31(puf_fullsample):
+def test_r31(puf_subsample):
     """
     Comparison test 31
     """
@@ -761,12 +761,12 @@ def test_r31(puf_fullsample):
                     'with behavioral response'
                     '\n'
                     'Tax-Calculator,4.3,4.5,4.6,4.7')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r32(puf_fullsample):
+def test_r32(puf_subsample):
     """
     Comparison test 32
     """
@@ -794,13 +794,13 @@ def test_r32(puf_fullsample):
     """
     expected_res = ('Increase tax rate in each bracket by 1 pts'
                     '\n'
-                    'Tax-Calculator,58.8,61.2,63.9,66.5')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,59.4,61.9,64.6,67.1')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r33(puf_fullsample):
+def test_r33(puf_subsample):
     """
     Comparison test 33
     """
@@ -828,13 +828,13 @@ def test_r33(puf_fullsample):
     """
     expected_res = ('Increase top four rates by 1 pts'
                     '\n'
-                    'Tax-Calculator,14.2,14.7,15.3,15.7')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,13.7,14.3,14.9,15.4')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r34(puf_fullsample):
+def test_r34(puf_subsample):
     """
     Comparison test 34
     """
@@ -862,13 +862,13 @@ def test_r34(puf_fullsample):
     """
     expected_res = ('Increase top two rates by 1 pts'
                     '\n'
-                    'Tax-Calculator,9.2,9.5,9.8,10.0')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,8.8,9.1,9.4,9.7')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r35(puf_fullsample):
+def test_r35(puf_subsample):
     """
     Comparison test 35
     """
@@ -883,13 +883,13 @@ def test_r35(puf_fullsample):
     """
     expected_res = ('Increase AMT exemption amount by $1000'
                     '\n'
-                    'Tax-Calculator,-1.1,-2.4,-3.9,-4.1')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-1.1,-2.4,-3.9,-4.0')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r36(puf_fullsample):
+def test_r36(puf_subsample):
     """
     Comparison test 36
     """
@@ -904,13 +904,13 @@ def test_r36(puf_fullsample):
     """
     expected_res = ('Increase AMT exemption phaseout starting AMTI by $10,000'
                     '\n'
-                    'Tax-Calculator,-2.6,-3.3,-4.2,-4.3')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-2.5,-3.2,-4.1,-4.2')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r37(puf_fullsample):
+def test_r37(puf_subsample):
     """
     Comparison test 37
     """
@@ -925,13 +925,13 @@ def test_r37(puf_fullsample):
     """
     expected_res = ('Increase AMT exemption phaseout rate by 2 pts'
                     '\n'
-                    'Tax-Calculator,2.7,3.0,3.2,3.3')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,2.6,2.8,3.0,3.1')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r38(puf_fullsample):
+def test_r38(puf_subsample):
     """
     Comparison test 38
     """
@@ -946,13 +946,13 @@ def test_r38(puf_fullsample):
     """
     expected_res = ('Increase AMT rate under the surtax threshold by 2 pts'
                     '\n'
-                    'Tax-Calculator,28.4,30.4,32.3,33.6')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,27.4,29.6,31.5,32.6')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r39(puf_fullsample):
+def test_r39(puf_subsample):
     """
     Comparison test 39
     """
@@ -967,13 +967,13 @@ def test_r39(puf_fullsample):
     """
     expected_res = ('Increase AMT rate above the surtax threshold by 2 pts'
                     '\n'
-                    'Tax-Calculator,9.2,9.8,10.4,10.8')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,8.7,9.4,10.0,10.5')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r40(puf_fullsample):
+def test_r40(puf_subsample):
     """
     Comparison test 40
     """
@@ -988,13 +988,13 @@ def test_r40(puf_fullsample):
     """
     expected_res = ('Increase AMT surtax threshold by $10,000'
                     '\n'
-                    'Tax-Calculator,-0.5,-0.7,-0.9,-0.9')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-0.5,-0.6,-0.8,-0.9')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r41(puf_fullsample):
+def test_r41(puf_subsample):
     """
     Comparison test 41
     """
@@ -1009,13 +1009,13 @@ def test_r41(puf_fullsample):
     """
     expected_res = ('Eliminate child tax credit'
                     '\n'
-                    'Tax-Calculator,51.1,50.6,49.9,49.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,51.3,50.9,50.2,49.8')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r42(puf_fullsample):
+def test_r42(puf_subsample):
     """
     Comparison test 42
     """
@@ -1030,13 +1030,13 @@ def test_r42(puf_fullsample):
     """
     expected_res = ('Increase child tax credit phaseout rate by 1 pts'
                     '\n'
-                    'Tax-Calculator,0.5,0.5,0.5,0.6')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,0.5,0.5,0.5,0.5')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r43(puf_fullsample):
+def test_r43(puf_subsample):
     """
     Comparison test 43
     """
@@ -1052,12 +1052,12 @@ def test_r43(puf_fullsample):
     expected_res = ('Increase child tax credit phaseout starting MAGI by $1000'
                     '\n'
                     'Tax-Calculator,-0.2,-0.2,-0.2,-0.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r44(puf_fullsample):
+def test_r44(puf_subsample):
     """
     Comparison test 44
     """
@@ -1072,13 +1072,13 @@ def test_r44(puf_fullsample):
     """
     expected_res = ('Total EITC cost'
                     '\n'
-                    'Tax-Calculator,65.5,64.8,64.8,66.3')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,67.3,67.0,67.4,69.1')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r45(puf_fullsample):
+def test_r45(puf_subsample):
     """
     Comparison test 45
     """
@@ -1093,13 +1093,13 @@ def test_r45(puf_fullsample):
     """
     expected_res = ('Increase EITC phaseout rate by 1 pts'
                     '\n'
-                    'Tax-Calculator,1.2,1.2,1.2,1.2')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,1.2,1.1,1.1,1.2')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r46(puf_fullsample):
+def test_r46(puf_subsample):
     """
     Comparison test 46
     """
@@ -1114,13 +1114,13 @@ def test_r46(puf_fullsample):
     """
     expected_res = ('Increase EITC phaseout starting AGI by $1000'
                     '\n'
-                    'Tax-Calculator,-2.1,-2.7,-3.3,-3.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-2.1,-2.6,-3.1,-3.2')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r47(puf_fullsample):
+def test_r47(puf_subsample):
     """
     Comparison test 47
     """
@@ -1135,13 +1135,13 @@ def test_r47(puf_fullsample):
     """
     expected_res = ('Increase maximum EITC amount by $100'
                     '\n'
-                    'Tax-Calculator,-2.0,-3.1,-4.2,-4.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-1.9,-3.0,-4.1,-4.2')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r48(puf_fullsample):
+def test_r48(puf_subsample):
     """
     Comparison test 48
     """
@@ -1156,13 +1156,13 @@ def test_r48(puf_fullsample):
     """
     expected_res = ('Increase additional child tax credit rate by 2 pts'
                     '\n'
-                    'Tax-Calculator,-0.7,-0.7,-0.7,-0.6')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-0.9,-0.8,-0.8,-0.8')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r49(puf_fullsample):
+def test_r49(puf_subsample):
     """
     Comparison test 49
     """
@@ -1178,12 +1178,12 @@ def test_r49(puf_fullsample):
     expected_res = ('Lower additional CTC minimum number of children to two'
                     '\n'
                     'Tax-Calculator,0.0,0.0,0.0,0.0')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r50(puf_fullsample):
+def test_r50(puf_subsample):
     """
     Comparison test 50
     """
@@ -1198,13 +1198,13 @@ def test_r50(puf_fullsample):
     """
     expected_res = ('Eliminate Net Investment Income Tax'
                     '\n'
-                    'Tax-Calculator,-36.8,-39.8,-40.4,-41.1')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-36.4,-39.7,-40.6,-41.6')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r51(puf_fullsample):
+def test_r51(puf_subsample):
     """
     Comparison test 51
     """
@@ -1219,13 +1219,13 @@ def test_r51(puf_fullsample):
     """
     expected_res = ('Increase Net Investment Income Tax threshold by $10,000'
                     '\n'
-                    'Tax-Calculator,-0.4,-0.4,-0.4,-0.4')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-0.4,-0.5,-0.5,-0.5')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r52(puf_fullsample):
+def test_r52(puf_subsample):
     """
     Comparison test 52
     """
@@ -1241,12 +1241,12 @@ def test_r52(puf_fullsample):
     expected_res = ('New $1000 personal refundable credit, no phaseout'
                     '\n'
                     'Tax-Calculator,-164.4,-170.2,-177.1,-184.0')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r53(puf_fullsample):
+def test_r53(puf_subsample):
     """
     Comparison test 53
     """
@@ -1264,13 +1264,13 @@ def test_r53(puf_fullsample):
     expected_res = ('New $1000 personal refundable credit, 0.01 po '
                     'above $10K AGI'
                     '\n'
-                    'Tax-Calculator,-108.7,-112.0,-116.5,-120.9')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,-107.7,-110.9,-115.3,-119.9')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res
 
 
 @pytest.mark.requires_pufcsv
-def test_r54(puf_fullsample):
+def test_r54(puf_subsample):
     """
     Comparison test 54
     """
@@ -1288,6 +1288,6 @@ def test_r54(puf_fullsample):
     """
     expected_res = ('Increase FST rate from zero to 0.30 beginning in 2017'
                     '\n'
-                    'Tax-Calculator,41.5,41.9,42.0,42.8')
-    actual_res = reform_results(json.loads(reform_json), puf_fullsample)
+                    'Tax-Calculator,42.2,43.3,42.7,43.5')
+    actual_res = reform_results(json.loads(reform_json), puf_subsample)
     assert actual_res == expected_res


### PR DESCRIPTION
Convert the 54 reform comparison tests so that instead of using the full `puf.csv` sample they use a five percent subsample.  This change reduces the execution time for the command
```
py.test -m "not notebook" -n4
```
from about 237 seconds to about 143 seconds, which is a reduction of about a minute and a half, or in relative terms, a reduction of about 40 percent in execution time.  Many of the reform test results change, but not by large amounts.

@Amy-Xu @andersonfrailey @hdoupe @GoFroggyRun @yuying27 @codykallen 