### PR TITLE
Fix docstring typo in parameters.py

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -317,7 +317,7 @@ class ParametersBase(object):
         To model a change in behavior substitution effect, a year_mods dict
         example would be::
 
-            {2014: {'_BE_inc': [0.2, 0.3]}}
+            {2014: {'_BE_sub': [0.2, 0.3]}}
         """
         # check YEAR value in the single YEAR:MODS dictionary parameter
         if not isinstance(year_mods, dict):


### PR DESCRIPTION
No change in logic or results; just fixing a documentation typo.