### PR TITLE
[WIP] Add functionality to save XTR plots as .png files

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,9 @@ Release 0.9.3 on 2017-??-??
 - Add validation checking of policy parameters involved in a reform
   [[#1502](https://github.com/open-source-economics/Tax-Calculator/pull/1502)
   by Martin Holmer]
+- Add capability to save XTR graphs as .PNG files
+  [[#1504](https://github.com/open-source-economics/Tax-Calculator/pull/1504)
+  by Anderson Frailey]
 
 **Bug Fixes**
 - None

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
 - coverage
 - pytest-pep8
 - pytest-xdist
+- phantomjs

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - numba
 - toolz
 - six
-- bokeh >=0.12.3
+- bokeh >=0.12.6
 - mock
 - pep8
 - pylint

--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,5 @@ dependencies:
 - pytest-pep8
 - pytest-xdist
 - phantomjs
+- pillow
+- selenium

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1038,7 +1038,7 @@ def write_graph_file(figure, filename, title):
     figure : bokeh.plotting figure object
 
     filename : string
-        name of HTML file to which figure is written;
+        name of file to which figure is written;
         should end in .html or .png
 
     title : string

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1038,7 +1038,8 @@ def write_graph_file(figure, filename, title):
     figure : bokeh.plotting figure object
 
     filename : string
-        name of HTML file to which figure is written; should end in .html
+        name of HTML file to which figure is written;
+        should end in .html or .png
 
     title : string
         text displayed in browser tab when HTML file is displayed in browser
@@ -1048,8 +1049,12 @@ def write_graph_file(figure, filename, title):
     Nothing
     """
     delete_file(filename)    # work around annoying 'already exists' bokeh msg
-    bio.output_file(filename=filename, title=title)
-    bio.save(figure)
+    # Save file as either PNG or HTML file
+    if filename[-4:].lower() == '.png':
+        bio.export_png(figure, filename)
+    else:
+        bio.output_file(filename=filename, title=title)
+        bio.save(figure)
 
 
 def isoelastic_utility_function(consumption, crra, cmin):


### PR DESCRIPTION
In release 0.12.6, Bokeh added the ability to save plots as .PNG files, rather than just .HTML. This PR modifies the `write_graph_file` function in `utils.py` to take advantage of this new capability and updates `environment.yml` to include `phantomjs` and Bokeh 0.12.6.

There is no change to the arguments accepted by `write_graph_file`, I have just added a few lines to check if the file ends in `.PNG` and, if so, use `export_png` rather than the usual save feature.