### PR TITLE
Add ability to use array suffixes in JSON reform files

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,9 @@ Release 0.9.3 on 2017-??-??
 - Add validation checking of policy parameters involved in a reform
   [[#1502](https://github.com/open-source-economics/Tax-Calculator/pull/1502)
   by Martin Holmer]
+- Add option to use policy parameter suffixes in JSON reform files
+  [[#1505](https://github.com/open-source-economics/Tax-Calculator/pull/1505)
+  by Martin Holmer]
 
 **Bug Fixes**
 - None

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -512,9 +512,9 @@ class Calculator(object):
         an extended example of a commented JSON policy reform text
         that can be read by this method.
 
-        Returned dictionary rpol_dict has integer years as primary keys and
+        Returned dictionary prdict has integer years as primary keys and
         string parameters as secondary keys.  This returned dictionary is
-        suitable as the argument to the Policy implement_reform(rpol_dict)
+        suitable as the argument to the Policy implement_reform(prdict)
         method ONLY if the function argument arrays_not_lists is True.
         """
         # strip out //-comments without changing line numbers
@@ -546,10 +546,10 @@ class Calculator(object):
             if rkey in Calculator.REQUIRED_ASSUMP_KEYS:
                 msg = 'key "{}" should be in economic assumption file'
                 raise ValueError(msg.format(rkey))
-        # convert the policy dictionary in raw_dict
-        rpol_dict = Calculator._convert_parameter_dict(raw_dict['policy'],
-                                                       arrays_not_lists)
-        return rpol_dict
+        # convert raw_dict['policy'] dictionary into prdict
+        tdict = Policy.translate_json_reform_suffixes(raw_dict['policy'])
+        prdict = Calculator._convert_parameter_dict(tdict, arrays_not_lists)
+        return prdict
 
     @staticmethod
     def _read_json_econ_assump_text(text_string, arrays_not_lists):

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -5,6 +5,7 @@ Tax-Calculator federal tax policy Policy class.
 # pep8 --ignore=E402 policy.py
 # pylint --disable=locally-disabled policy.py
 
+import json
 import six
 import numpy as np
 from taxcalc.parameters import ParametersBase
@@ -229,10 +230,83 @@ class Policy(ParametersBase):
     @staticmethod
     def translate_json_reform_suffixes(jsonstr):
         """
-        Replace any parameters with suffixes with array parameters
-        and return the consolidated JSON string
+        Replace any array parameters with suffixes in the specified
+        JSON string, jsonstr, and
+        return a JSON string containing constructed array parameters
+        without containing any parameters with suffixes.
         """
-        return jsonstr  # TODO temporary code
+
+        # define group_dict function used only in this method
+        def group_dict(idict):
+            """
+            Return param_base:year:suffix dictionary with each idict value.
+            """
+            gdict = dict()
+            suffixes = Policy.JSON_REFORM_SUFFIXES.keys()
+            for param in idict.keys():
+                param_pieces = param.split('_')
+                suffix = param_pieces[-1]
+                if suffix in suffixes:
+                    del param_pieces[-1]
+                    param_base = '_'.join(param_pieces)
+                    if param_base not in gdict:
+                        gdict[param_base] = dict()
+                    for year in sorted(idict[param].keys()):
+                        if year not in gdict[param_base]:
+                            gdict[param_base][year] = dict()
+                        gdict[param_base][year][suffix] = idict[param][year][0]
+            return gdict
+
+        # define no_suffix function used only in this method
+        def no_suffix(idict):
+            """
+            Return param_base:year dictionary having only no-suffix parameters.
+            """
+            odict = dict()
+            suffixes = Policy.JSON_REFORM_SUFFIXES.keys()
+            for param in idict.keys():
+                param_pieces = param.split('_')
+                suffix = param_pieces[-1]
+                if suffix not in suffixes:
+                    odict[param] = idict[param]
+            return odict
+
+        # define with_suffix function used only in this method
+        def with_suffix(gdict):
+            """
+            Return param_base:year dictionary having only suffix parameters.
+            """
+            pol = Policy()
+            odict = dict()
+            for param in gdict.keys():
+                odict[param] = dict()
+                for year in sorted(gdict[param].keys()):
+                    odict[param][year] = dict()
+                    for suffix in gdict[param][year].keys():
+                        plist = getattr(pol, param).tolist()
+                        dvals = plist[int(year) - Policy.JSON_START_YEAR]
+                        odict[param][year] = [dvals]
+                        idx = Policy.JSON_REFORM_SUFFIXES[suffix]
+                        odict[param][year][0][idx] = gdict[param][year][suffix]
+                    udict = {int(year): {param: odict[param][year]}}
+                    print udict
+                    pol.implement_reform(udict)
+            return odict
+
+        # begin high-level logic of translate_json_reform_suffixes method
+        # ... Strategy is to build a dictionary containing constructed
+        # ... array parameters, and then converting that dictionary into
+        # ... a JSON string, which is returned by this method.
+        # group params with suffix into param_base:year:suffix dictionary
+        idict = json.loads(jsonstr)['policy']
+        gdict = group_dict(idict)
+        # construct odict containing just parameters without a suffix
+        odict = no_suffix(idict)
+        # add to odict consolidated values for parameters with a suffix
+        if len(gdict) > 0:
+            odict.update(with_suffix(gdict))
+        # convert odict into a JSON string and return the string
+        return json.dumps({'policy': odict})
 
     # ----- begin private methods of Policy class -----
 

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -288,7 +288,6 @@ class Policy(ParametersBase):
                         idx = Policy.JSON_REFORM_SUFFIXES[suffix]
                         odict[param][year][0][idx] = gdict[param][year][suffix]
                     udict = {int(year): {param: odict[param][year]}}
-                    print udict
                     pol.implement_reform(udict)
             return odict
 

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -287,8 +287,8 @@ class Policy(ParametersBase):
                         odict[param][year] = [dvals]
                         idx = Policy.JSON_REFORM_SUFFIXES[suffix]
                         odict[param][year][0][idx] = gdict[param][year][suffix]
-                    udict = {int(year): {param: odict[param][year]}}
-                    pol.implement_reform(udict)
+                        udict = {int(year): {param: odict[param][year]}}
+                        pol.implement_reform(udict)
             return odict
 
         # high-level logic of translate_json_reform_suffixes method:

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -204,12 +204,27 @@ class Policy(ParametersBase):
         clv.set_year(self.current_year)
         return clv
 
-    JSON_REFORM_SUFFIXES = set([
-        'single', 'joint', 'separate', 'headhousehold', 'widow',  # MARS
-        '0kids', '1kid', '2kids', '3+kids',  # EIC
-        'medical', 'statelocal', 'realestate', 'casualty',  # idedtype
-        'misc', 'interest', 'charity'  # idedtype
-    ])
+    JSON_REFORM_SUFFIXES = {
+        # MARS-indexed suffixes and list index numbers
+        'single': 0,
+        'joint': 1,
+        'separate': 2,
+        'headhousehold': 3,
+        'widow': 4,
+        # EIC-indexed suffixes and list index numbers
+        '0kids': 0,
+        '1kid': 1,
+        '2kids': 2,
+        '3+kids': 3,
+        # idedtype-indexed suffixes and list index numbers
+        'medical': 0,
+        'statelocal': 1,
+        'realestate': 2,
+        'casualty': 3,
+        'misc': 4,
+        'interest': 5,
+        'charity': 6
+    }
 
     @staticmethod
     def translate_json_reform_suffixes(jsonstr):

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -688,3 +688,37 @@ def test_calc_all(reform_file, rawinputfile):
                       sync_years=False)  # keeps raw data unchanged
     assert calc.current_year == cyr
     calc.calc_all()
+
+
+def test_translate_json_reform_suffixes():
+    # test read_json_param_files(...) using parameter suffixes
+    json1 = """{"policy": {
+      "_II_em": {"2020": [20000], "2015": [15000]},
+      "_STD_single": {"2018": [18000], "2016": [16000]},
+      "_STD_widow": {"2017": [17000], "2019": [19000]}
+    }}"""
+    pdict1 = Calculator.read_json_param_files(reform_filename=json1,
+                                              assump_filename=None,
+                                              arrays_not_lists=True)
+    rdict1 = pdict1['policy']
+    json2 = """{"policy": {
+      "_STD": {"2016": [[16000.00, 12600.00, 6300.00, 9300.00, 12600.00]],
+               "2017": [[16364.80, 12887.28, 6443.64, 9512.04, 17000.00]],
+               "2018": [[18000.00, 13173.38, 6586.69, 9723.21, 17377.40]],
+               "2019": [[18412.20, 13475.05, 6737.52, 9945.87, 19000.00]]},
+      "_II_em": {"2020": [20000], "2015": [15000]}
+    }}"""
+    pdict2 = Calculator.read_json_param_files(reform_filename=json2,
+                                              assump_filename=None,
+                                              arrays_not_lists=True)
+    rdict2 = pdict2['policy']
+    assert len(rdict2) == len(rdict1)
+    for year in rdict2.keys():
+        if '_II_em' in rdict2[year].keys():
+            assert np.allclose(rdict1[year]['_II_em'],
+                               rdict2[year]['_II_em'],
+                               atol=0.01, rtol=0.0)
+        if '_STD' in rdict2[year].keys():
+            assert np.allclose(rdict1[year]['_STD'],
+                               rdict2[year]['_STD'],
+                               atol=0.01, rtol=0.0)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -757,7 +757,7 @@ def test_translate_json_reform_suffixes_eic():
                                rdict2[year]['_EITC_c'],
                                atol=0.01, rtol=0.0)
 
-@pytest.mark.one
+
 def test_translate_json_reform_suffixes_idedtype():
     # test read_json_param_files(...) using idedtype-indexed parameter suffixes
     json1 = """{"policy": {

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -690,8 +690,8 @@ def test_calc_all(reform_file, rawinputfile):
     calc.calc_all()
 
 
-def test_translate_json_reform_suffixes():
-    # test read_json_param_files(...) using parameter suffixes
+def test_translate_json_reform_suffixes_mars():
+    # test read_json_param_files(...) using MARS-indexed parameter suffixes
     json1 = """{"policy": {
       "_II_em": {"2020": [20000], "2015": [15000]},
       "_STD_single": {"2018": [18000], "2016": [16000]},
@@ -721,4 +721,80 @@ def test_translate_json_reform_suffixes():
         if '_STD' in rdict2[year].keys():
             assert np.allclose(rdict1[year]['_STD'],
                                rdict2[year]['_STD'],
+                               atol=0.01, rtol=0.0)
+
+
+def test_translate_json_reform_suffixes_eic():
+    # test read_json_param_files(...) using EIC-indexed parameter suffixes
+    json1 = """{"policy": {
+      "_II_em": {"2020": [20000], "2015": [15000]},
+      "_EITC_c_0kids": {"2018": [510], "2019": [510]},
+      "_EITC_c_1kid": {"2019": [3400], "2018": [3400]},
+      "_EITC_c_2kids": {"2018": [5616], "2019": [5616]},
+      "_EITC_c_3+kids": {"2019": [6318], "2018": [6318]}
+    }}"""
+    pdict1 = Calculator.read_json_param_files(reform_filename=json1,
+                                              assump_filename=None,
+                                              arrays_not_lists=True)
+    rdict1 = pdict1['policy']
+    json2 = """{"policy": {
+      "_EITC_c": {"2019": [[510, 3400, 5616, 6318]],
+                  "2018": [[510, 3400, 5616, 6318]]},
+      "_II_em": {"2020": [20000], "2015": [15000]}
+    }}"""
+    pdict2 = Calculator.read_json_param_files(reform_filename=json2,
+                                              assump_filename=None,
+                                              arrays_not_lists=True)
+    rdict2 = pdict2['policy']
+    assert len(rdict2) == len(rdict1)
+    for year in rdict2.keys():
+        if '_II_em' in rdict2[year].keys():
+            assert np.allclose(rdict1[year]['_II_em'],
+                               rdict2[year]['_II_em'],
+                               atol=0.01, rtol=0.0)
+        if '_EITC_c' in rdict2[year].keys():
+            assert np.allclose(rdict1[year]['_EITC_c'],
+                               rdict2[year]['_EITC_c'],
+                               atol=0.01, rtol=0.0)
+
+@pytest.mark.one
+def test_translate_json_reform_suffixes_idedtype():
+    # test read_json_param_files(...) using idedtype-indexed parameter suffixes
+    json1 = """{"policy": {
+      "_ID_BenefitCap_rt": {"2019": [0.2]},
+      "_ID_BenefitCap_Switch_medical": {"2019": [false]},
+      "_ID_BenefitCap_Switch_casualty": {"2019": [false]},
+      "_ID_BenefitCap_Switch_misc": {"2019": [false]},
+      "_ID_BenefitCap_Switch_interest": {"2019": [false]},
+      "_ID_BenefitCap_Switch_charity": {"2019": [false]},
+      "_II_em": {"2020": [20000], "2015": [15000]}
+    }}"""
+    pdict1 = Calculator.read_json_param_files(reform_filename=json1,
+                                              assump_filename=None,
+                                              arrays_not_lists=True)
+    rdict1 = pdict1['policy']
+    json2 = """{"policy": {
+      "_II_em": {"2020": [20000], "2015": [15000]},
+      "_ID_BenefitCap_Switch": {
+        "2019": [[false, true, true, false, false, false, false]]
+      },
+      "_ID_BenefitCap_rt": {"2019": [0.2]}
+    }}"""
+    pdict2 = Calculator.read_json_param_files(reform_filename=json2,
+                                              assump_filename=None,
+                                              arrays_not_lists=True)
+    rdict2 = pdict2['policy']
+    assert len(rdict2) == len(rdict1)
+    for year in rdict2.keys():
+        if '_II_em' in rdict2[year].keys():
+            assert np.allclose(rdict1[year]['_II_em'],
+                               rdict2[year]['_II_em'],
+                               atol=0.01, rtol=0.0)
+        if '_ID_BenefitCap_rt' in rdict2[year].keys():
+            assert np.allclose(rdict1[year]['_ID_BenefitCap_rt'],
+                               rdict2[year]['_ID_BenefitCap_rt'],
+                               atol=0.01, rtol=0.0)
+        if '_ID_BenefitCap_Switch' in rdict2[year].keys():
+            assert np.allclose(rdict1[year]['_ID_BenefitCap_Switch'],
+                               rdict2[year]['_ID_BenefitCap_Switch'],
                                atol=0.01, rtol=0.0)

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -753,23 +753,6 @@ def test_json_reform_suffixes(tests_path):
         assert unmatched == 'UNMATCHED SUFFIXES'
 
 
-@pytest.mark.one
-def test_translate_json_reform_suffixes():
-    """
-    Test Policy.translate_json_reform_suffixes method.
-    """
-    rawjson = """{"policy": {
-      "_II_em": {"2017": [12000], "2020": [14000]},
-      "_STD_single": {"2016": [18000]},
-      "_STD_widow": {"2018": [22000]}
-    }}"""
-    """
-    rawdict = json.loads(rawjson)
-    refjson = Policy.translate_json_reform_suffixes(rawjson)
-    refdict = json.loads(refjson)
-    """
-
-
 def test_validated_parameters_set(tests_path):
     """
     Check Policy.VALIDATED_PARAMETERS against current_law_policy.json info.

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -735,17 +735,20 @@ def test_json_reform_suffixes(tests_path):
     clpdict = json.load(clpfile)
     clpfile.close()
     # create set of suffixes in the clpdict "col_label" lists
-    suffixes = set()
+    json_suffixes = Policy.JSON_REFORM_SUFFIXES.keys()
+    clp_suffixes = set()
     for param in clpdict:
+        suffix = param.split('_')[-1]
+        assert suffix not in json_suffixes
         col_var = clpdict[param]['col_var']
         col_label = clpdict[param]['col_label']
         if col_var == '':
             assert col_label == ''
             continue
         assert isinstance(col_label, list)
-        suffixes.update(col_label)
+        clp_suffixes.update(col_label)
     # check that suffixes set is same as Policy.JSON_REFORM_SUFFIXES set
-    unmatched = suffixes ^ Policy.JSON_REFORM_SUFFIXES
+    unmatched = clp_suffixes ^ set(json_suffixes)
     if len(unmatched) != 0:
         assert unmatched == 'UNMATCHED SUFFIXES'
 

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -752,6 +752,21 @@ def test_json_reform_suffixes(tests_path):
     if len(unmatched) != 0:
         assert unmatched == 'UNMATCHED SUFFIXES'
 
+@pytest.mark.one
+def test_translate_json_reform_suffixes():
+    """
+    Test Policy.translate_json_reform_suffixes method.
+    """
+    rawjson = """{"policy": {
+      "_II_em": {"2017": [12000], "2020": [14000]},
+      "_STD_single": {"2016": [18000]},
+      "_STD_widow": {"2018": [22000]}
+    }}"""
+    rawdict = json.loads(rawjson)
+    refjson = Policy.translate_json_reform_suffixes(rawjson)
+    refdict = json.loads(refjson)
+    # assert refdict == rawdict
+
 
 def test_validated_parameters_set(tests_path):
     """

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -752,6 +752,7 @@ def test_json_reform_suffixes(tests_path):
     if len(unmatched) != 0:
         assert unmatched == 'UNMATCHED SUFFIXES'
 
+
 @pytest.mark.one
 def test_translate_json_reform_suffixes():
     """
@@ -762,10 +763,11 @@ def test_translate_json_reform_suffixes():
       "_STD_single": {"2016": [18000]},
       "_STD_widow": {"2018": [22000]}
     }}"""
+    """
     rawdict = json.loads(rawjson)
     refjson = Policy.translate_json_reform_suffixes(rawjson)
     refdict = json.loads(refjson)
-    # assert refdict == rawdict
+    """
 
 
 def test_validated_parameters_set(tests_path):


### PR DESCRIPTION
This pull request, which follows up #1503, implements the idea suggested by @talumbau in [TaxBrain issue 596](https://github.com/OpenSourcePolicyCenter/webapp-public/issues/596#issuecomment-320993715).  This Tax-Calculator enhancement should enable a major simplification in TaxBrain logic and the elimination of at least one TaxBrain bug (the one discussed in issue 596).

See the three new `test_translate_json_reform_suffixes_*` test in the `test_calculate.py` file for details on how this enhancement can be used.  The new capability is optional in the sense that all old JSON reform files continue to work as they did before.  The new optional capability is meant primarily for TaxBrain, but could be used in hand-written JSON reform files.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @hdoupe @GoFroggyRun @codykallen
@talumbau @PeterDSteinberg @brittainhard 
