### PR TITLE
Add two float casts to avoid integer division in Python 2.7

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -481,7 +481,7 @@ class Records(object):
             msg = 'weights is not None or a string or a Pandas DataFrame'
             raise ValueError(msg)
         assert isinstance(WT, pd.DataFrame)
-        setattr(self, 'WT', WT)
+        setattr(self, 'WT', WT.astype(np.float64))
 
     def _read_ratios(self, ratios):
         """

--- a/taxcalc/tests/test_dropq.py
+++ b/taxcalc/tests/test_dropq.py
@@ -251,7 +251,7 @@ def test_with_pufcsv(puf_fullsample):
     adt = multiyear_diagnostic_table(calc, 1)
     taxes_fullsample = adt.loc["Combined Liability ($b)"]
     assert taxes_fullsample is not None
-    fulls_reform_revenue = taxes_fullsample.loc[analysis_year]
+    fulls_reform_revenue = float(taxes_fullsample.loc[analysis_year])
     # create a Public Use File object
     tax_data = puf_fullsample
     # call run_nth_year_tax_calc_model function
@@ -261,8 +261,8 @@ def test_with_pufcsv(puf_fullsample):
     total = restuple[len(restuple) - 1]  # the last of element of the tuple
     dropq_reform_revenue = float(total['combined_tax_9'])
     dropq_reform_revenue *= 1e-9  # convert to billions of dollars
-    diff = abs(fulls_reform_revenue - dropq_reform_revenue)
     # assert that dropq revenue is similar to the fullsample calculation
+    diff = abs(fulls_reform_revenue - dropq_reform_revenue)
     proportional_diff = diff / fulls_reform_revenue
     frmt = 'f,d,adiff,pdiff=  {:.4f}  {:.4f}  {:.4f}  {}'
     print(frmt.format(fulls_reform_revenue, dropq_reform_revenue,


### PR DESCRIPTION
I tried the experiment (using `from __future__ import division`) @talumbau suggested in #1506, but the unit test results on Python 2.7 did not change.  So, the source of the rounding error differences between test_cpscsv results under 2.7 and 3.x are still not clear.  Perhaps I didn't do the experiment correctly given that I added the `__future__ import` statement in only these files:
```
iMac2:tax-calculator mrh$ grep -r --include="*py" "import division" .
./taxcalc/behavior.py:from __future__ import division
./taxcalc/calculate.py:from __future__ import division
./taxcalc/functions.py:from __future__ import division
./taxcalc/records.py:from __future__ import division
./taxcalc/taxcalcio.py:from __future__ import division
./taxcalc/tests/test_dropq.py:from __future__ import division
```
All other `.py` files did not contain the two character sequence `/ `, and therefore, seemed to not need a `__future__ import` statement.

In the course of conducting the experiment, I found a couple of places that probably needed integer to float casting.  This pull request makes those few changes.  These changes did not change any test results.

@MattHJensen @Amy-Xu @andersonfrailey @hdoupe @GoFroggyRun 
