### PR TITLE
Add/revise comments in four file-upload-tests/*.json files

### DIFF
--- a/file-upload-tests/a0.json
+++ b/file-upload-tests/a0.json
@@ -1,4 +1,4 @@
-// Assume no customized analysis assumptions, which means:
+// a0.json assumes no customized analysis assumptions, which means:
 // - no consumption response when computing marginal tax rates
 // - no behaviorial responses to reform
 // - no differences in baseline growth assumptions

--- a/file-upload-tests/a1.json
+++ b/file-upload-tests/a1.json
@@ -1,3 +1,8 @@
+// a1.json assumes some customized analysis assumptions, which means:
+// - consumption response for e18400, which is state+local income/sales taxes
+// - no behaviorial responses to reform
+// - baseline growth assumptions except slower growth in _ATXPY and _AWAGE
+// - no growth response to reform
 {
     "consumption": {
         "_MPC_e18400": {"2018": [0.05]}

--- a/file-upload-tests/a2.json
+++ b/file-upload-tests/a2.json
@@ -1,3 +1,8 @@
+// a2.json assumes some customized analysis assumptions, which means:
+// - consumption response for e18400, which is state+local income/sales taxes
+// - some behavioral substitution response
+// - no differences in baseline growth assumptions
+// - no growth response to reform
 {
     "consumption": {
         "_MPC_e18400": {"2018": [0.1]}

--- a/file-upload-tests/r1.json
+++ b/file-upload-tests/r1.json
@@ -1,4 +1,4 @@
-// Assume reform with the following provisions:
+// r1.json assumes reform with the following provisions:
 // - adhoc raises in OASDI maximum taxable earnings in 2018, 2019 and 2020,
 //     with _SS_Earnings_c wage indexed in subsequent years
 // - raise personal exemption amount _II_em in 2018, keep it unchanged for


### PR DESCRIPTION
Add name of uploaded file in comments because TaxBrain file-upload capability doesn't remember the name of the uploaded file (it just remembers the content of the uploaded file).