### PR TITLE
Add test to boost code coverage to 100%

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -397,7 +397,11 @@ class ParametersBase(object):
         If necessary, pad out additional years by increasing the last given
         year using the given inflation_rates list.
         """
-        if isinstance(x, np.ndarray):
+        if not isinstance(x, np.ndarray):
+            return ParametersBase._expand_1D(np.array([x], dtype=np.float64),
+                                             inflate, inflation_rates,
+                                             num_years)
+        else:
             if len(x) >= num_years:
                 return x
             else:
@@ -415,8 +419,6 @@ class ParametersBase(object):
                              range(1, num_years - len(x) + 1)]
                 ans[len(x):] = extra
                 return ans
-        return ParametersBase._expand_1D(np.array([x], dtype=np.float64),
-                                         inflate, inflation_rates, num_years)
 
     @staticmethod
     def _expand_2D(x, inflate, inflation_rates, num_years):
@@ -427,7 +429,11 @@ class ParametersBase(object):
         number of rows. For each expanded row, we inflate using the given
         inflation rates list.
         """
-        if isinstance(x, np.ndarray):
+        if not isinstance(x, np.ndarray):
+            return ParametersBase._expand_2D(np.array(x, dtype=np.float64),
+                                             inflate, inflation_rates,
+                                             num_years)
+        else:
             # Look for -1s and create masks if present
             last_good_row = -1
             keep_user_data_mask = []
@@ -494,8 +500,6 @@ class ParametersBase(object):
                         user_vals = x * keep_user_data_mask
                         ans = ans + user_vals
                 return ans
-        return ParametersBase._expand_2D(np.array(x, dtype=np.float64),
-                                         inflate, inflation_rates, num_years)
 
     @staticmethod
     def _strip_nones(x):

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -485,6 +485,7 @@ def test_expand_2d_accept_none():
                 [38000, 74000, 36900, 49400, 73800],
                 [40000, 74900, 37450, 50200, 74900],
                 [41000, None, None, None, None]]
+    # assume parameter is inflation indexed
     exp1 = 74900 * 1.02
     exp2 = 37450 * 1.02
     exp3 = 50200 * 1.02
@@ -493,15 +494,24 @@ def test_expand_2d_accept_none():
            [38000, 74000, 36900, 49400, 73800],
            [40000, 74900, 37450, 50200, 74900],
            [41000, exp1, exp2, exp3, exp4]]
-    exp = np.array(exp).astype('i4', casting='unsafe')
+    exp = np.array(exp)
     res = ParametersBase._expand_array(_II_brk2, inflate=True,
                                        inflation_rates=[0.02] * 5, num_years=4)
     assert np.allclose(res, exp, atol=0.01, rtol=0.0)
-
+    # assume parameter is not inflation indexed
+    exp = [[36000, 72250, 36500, 48600, 72500],
+           [38000, 74000, 36900, 49400, 73800],
+           [40000, 74900, 37450, 50200, 74900],
+           [41000, 74900, 37450, 50200, 74900]]
+    exp = np.array(exp, dtype='float64')
+    res = ParametersBase._expand_array(_II_brk2, inflate=False,
+                                       inflation_rates=[0.02] * 5, num_years=4)
+    assert np.allclose(res, exp, atol=0.01, rtol=0.0)
+    # assume parameter reform is done via implement_reform Policy method
     syr = 2013
     pol = Policy(start_year=syr)
     irates = pol.inflation_rates()
-    reform = {2016: {u'_II_brk2': _II_brk2}}
+    reform = {2016: {'_II_brk2': _II_brk2}}
     pol.implement_reform(reform)
     pol.set_year(2019)
     # The 2019 policy should be the combination of the user-defined

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -69,8 +69,7 @@ def test_expand_1d_variable_rates():
     res = ParametersBase._expand_1D(ary, inflate=True,
                                     inflation_rates=irates, num_years=5)
     exp = np.array([4, 5, 9, 9 * 1.03, 9 * 1.03 * 1.035])
-    assert np.allclose(exp.astype('f4', casting='unsafe'), res,
-                       atol=0.01, rtol=0.0)
+    assert np.allclose(exp, res, atol=0.01, rtol=0.0)
 
 
 def test_expand_1d_scalar():
@@ -94,8 +93,7 @@ def test_expand_1d_accept_none():
     exp = np.array(exp)
     res = ParametersBase._expand_array(lst, inflate=True,
                                        inflation_rates=irates, num_years=5)
-    assert np.allclose(exp.astype('f4', casting='unsafe'), res,
-                       atol=0.01, rtol=0.0)
+    assert np.allclose(exp, res, atol=0.01, rtol=0.0)
 
 
 def test_expand_2d_short_array():


### PR DESCRIPTION
This pull request adds another test to `test_utils.py` that exercises code used only in unusual cases.  After adding this test Tax-Calculator code coverage is 100 percent.

There are no changes in tax calculating logic or results; just the extra test.