### PR TITLE
Add validations for _SS_thd50 and _SS_thd85 policy parameters

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -101,7 +101,8 @@
         "cpi_inflated": false,
         "col_var": "MARS",
         "col_label": ["single", "joint", "separate", "headhousehold", "widow"],
-        "value": [[25000, 32000, 25000, 25000, 25000]]
+        "value": [[25000, 32000, 25000, 25000, 25000]],
+        "validations": {"min": 0, "max": "_SS_thd85"}
     },
 
     "_SS_percentage1": {
@@ -133,7 +134,8 @@
         "cpi_inflated": false,
         "col_var": "MARS",
         "col_label": ["single", "joint", "separate", "headhousehold", "widow"],
-        "value": [[34000, 44000, 34000, 34000, 34000]]
+        "value": [[34000, 44000, 34000, 34000, 34000]],
+        "validations": {"min": "_SS_thd50"}
     },
 
     "_SS_percentage2": {

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -305,6 +305,8 @@ class Policy(ParametersBase):
     # ----- begin private methods of Policy class -----
 
     VALIDATED_PARAMETERS = set([
+        '_SS_thd50',
+        '_SS_thd85',
         '_II_credit_prt',
         '_II_credit_nr_prt',
         '_ID_Medical_frt_add4aged',


### PR DESCRIPTION
No change in tax-calculating logic or results; just add valid-value checking for the `_SS_thd50` and `_SS_thd85` parameters.