### PR TITLE
Add file-upload-tests/a3.json and use it in the cli-results.sh script

### DIFF
--- a/file-upload-tests/a3.json
+++ b/file-upload-tests/a3.json
@@ -1,0 +1,17 @@
+// a3.json assumes some customized analysis assumptions, which means:
+// - no consumption response when computing marginal tax rates
+// - some behavioral substitution response
+// - no differences in baseline growth assumptions
+// - no growth response to reform
+{
+    "consumption": {
+    },
+    "behavior": {
+        "_BE_sub": {"2013": [0.3]},
+        "_BE_inc": {"2013": [-0.1]}
+    },
+    "growdiff_baseline": {
+    },
+    "growdiff_response": {
+    }
+}

--- a/file-upload-tests/a3.json
+++ b/file-upload-tests/a3.json
@@ -1,6 +1,6 @@
 // a3.json assumes some customized analysis assumptions, which means:
 // - no consumption response when computing marginal tax rates
-// - some behavioral substitution response
+// - some behavioral substitution and income response
 // - no differences in baseline growth assumptions
 // - no growth response to reform
 {

--- a/file-upload-tests/cli-results.sh
+++ b/file-upload-tests/cli-results.sh
@@ -26,6 +26,10 @@ write_results puf-22-r1-a1.csv
 tc puf.csv 2022 --reform r1.json --assump a2.json > /dev/null
 write_results puf-22-r1-a2.csv
 
+# r1-a3 : reform r1.json and assumptions a3.json
+tc puf.csv 2022 --reform r1.json --assump a3.json > /dev/null
+write_results puf-22-r1-a3.csv
+
 if [ "$1" == "save" ]; then
     echo "Saving output files"
 else


### PR DESCRIPTION
The new `a3.json` assumption file (in combination with the existing `r1.json` reform file) generates results that can be compared with TaxBrain "Partial Equilibrium" dynamic results generated from the Static Results page for the `r1`+`a3` file upload.

No change in tax-calculating logic or results.