### PR TITLE
[WIP] Add After-Tax Income Percent Change column to dropq results

### DIFF
--- a/taxcalc/dropq/dropq.py
+++ b/taxcalc/dropq/dropq.py
@@ -19,7 +19,7 @@ from taxcalc import results, TABLE_LABELS, proportional_change_gdp
 # specify constants
 PLAN_COLUMN_TYPES = [float] * len(TABLE_LABELS)
 
-DIFF_COLUMN_TYPES = [int, int, int, float, float, str, str, str]
+DIFF_COLUMN_TYPES = [int, int, int, float, float, str, str, str, str]
 
 DECILE_ROW_NAMES = ['perc0-10', 'perc10-20', 'perc20-30', 'perc30-40',
                     'perc40-50', 'perc50-60', 'perc60-70', 'perc70-80',

--- a/taxcalc/dropq/dropq_utils.py
+++ b/taxcalc/dropq/dropq_utils.py
@@ -435,6 +435,9 @@ def dropq_diff_table(df1, df2, groupby, res_col, diff_col, suffix, wsum):
     srs_change = ["{0:.2f}%".format(val * 100) for val in
                   diffs['share_of_change']]
     diffs['share_of_change'] = pd.Series(srs_change, index=diffs.index)
+    srs_aftertax_perc = ['{0:.2f}%'.format(val * 100)
+                         for val in diffs['aftertax_perc']]
+    diffs['aftertax_perc'] = pd.Series(srs_aftertax_perc, index=diffs.index)
     # columns containing weighted values relative to the binning mechanism
     non_sum_cols = [x for x in diffs.columns if 'mean' in x or 'perc' in x]
     for col in non_sum_cols:


### PR DESCRIPTION
In PR #1375, I added a feature to include the percent change in after tax income in the difference table. @hdoupe and I are trying to add it to TaxBrain as well and the purpose of this PR is primarily to solicit help. We believe that one of the first steps is to modify `dropq.py` and `dropq_utils.py`, as shown in this PR. Any help progressing from this point would be appreciated.