### PR TITLE
Consistently use baseline income measure for tc CLI distribution/difference table binning

### DIFF
--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -408,30 +408,34 @@ class TaxCalcIO(object):
         """
         # pylint: disable=too-many-locals
         tab_fname = self._output_filename.replace('.csv', '-tab.text')
-        # create DataFrame with weighted tax totals
+        # create list of nontax column results
+        # - weights don't change with reform
+        # - expanded_income may change, but always use baseline expanded income
         nontax_cols = ['s006', 'expanded_income']
+        nontax = [getattr(self.calc_clp.records, col) for col in nontax_cols]
+        # specify column names for taxes
         tax_cols = ['iitax', 'payrolltax', 'lumpsum_tax', 'combined']
         all_cols = nontax_cols + tax_cols
-        non = [getattr(self.calc.records, col) for col in nontax_cols]
-        ref = [getattr(self.calc.records, col) for col in tax_cols]
-        tot = non + ref
-        totdf = pd.DataFrame(data=np.column_stack(tot), columns=all_cols)
+        # create DataFrame with taxes under the reform
+        reform = [getattr(self.calc.records, col) for col in tax_cols]
+        dist = nontax + reform  # using expanded_income under baseline policy
+        distdf = pd.DataFrame(data=np.column_stack(dist), columns=all_cols)
         # skip tables if there are not some positive weights
-        if totdf['s006'].sum() <= 0.:
+        if distdf['s006'].sum() <= 0.:
             with open(tab_fname, 'w') as tfile:
                 msg = 'No tables because sum of weights is not positive\n'
                 tfile.write(msg)
             return
-        # create DataFrame with weighted tax differences
+        # create DataFrame with tax differences (reform - baseline)
         clp = [getattr(self.calc_clp.records, col) for col in tax_cols]
-        chg = [(ref[idx] - clp[idx]) for idx in range(0, len(tax_cols))]
-        dif = non + chg
-        difdf = pd.DataFrame(data=np.column_stack(dif), columns=all_cols)
+        change = [(reform[idx] - clp[idx]) for idx in range(0, len(tax_cols))]
+        diff = nontax + change  # using expanded_income under baseline policy
+        diffdf = pd.DataFrame(data=np.column_stack(diff), columns=all_cols)
         # write each kind of distributional table
         with open(tab_fname, 'w') as tfile:
-            TaxCalcIO.write_decile_table(totdf, tfile, tkind='Totals')
+            TaxCalcIO.write_decile_table(distdf, tfile, tkind='Reform Totals')
             tfile.write('\n')
-            TaxCalcIO.write_decile_table(difdf, tfile, tkind='Differences')
+            TaxCalcIO.write_decile_table(diffdf, tfile, tkind='Differences')
 
     @staticmethod
     def write_decile_table(dfx, tfile, tkind='Totals'):
@@ -449,7 +453,7 @@ class TaxCalcIO(object):
         htax_series = gdfx.apply(weighted_sum, 'lumpsum_tax')
         ctax_series = gdfx.apply(weighted_sum, 'combined')
         # write decile table to text file
-        row = 'Weighted Tax {} by Expanded-Income Decile\n'
+        row = 'Weighted Tax {} by Baseline Expanded-Income Decile\n'
         tfile.write(row.format(tkind))
         rowfmt = '{}{}{}{}{}{}\n'
         row = rowfmt.format('    Returns',

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -427,8 +427,8 @@ class TaxCalcIO(object):
                 tfile.write(msg)
             return
         # create DataFrame with tax differences (reform - baseline)
-        clp = [getattr(self.calc_clp.records, col) for col in tax_cols]
-        change = [(reform[idx] - clp[idx]) for idx in range(0, len(tax_cols))]
+        base = [getattr(self.calc_clp.records, col) for col in tax_cols]
+        change = [(reform[idx] - base[idx]) for idx in range(0, len(tax_cols))]
         diff = nontax + change  # using expanded_income under baseline policy
         diffdf = pd.DataFrame(data=np.column_stack(diff), columns=all_cols)
         # write each kind of distributional table

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -695,7 +695,7 @@ def mtr_graph_data(calc1, calc2,
             weighting_function = agi_weighted
     elif income_measure == 'expanded_income':
         income_var = 'expanded_income'
-        income_str = 'Expanded Income'
+        income_str = 'Expanded-Income'
         if dollar_weighting:
             weighting_function = expanded_income_weighted
     else:
@@ -776,7 +776,7 @@ def mtr_graph_data(calc1, calc2,
         income_str = 'Dollar-weighted {}'.format(income_str)
         mtr_str = 'Dollar-weighted {}'.format(mtr_str)
     data['ylabel'] = '{} MTR'.format(mtr_str)
-    xlabel_str = '{} Percentile'.format(income_str)
+    xlabel_str = 'Baseline {} Percentile'.format(income_str)
     if mars != 'ALL':
         xlabel_str = '{} for MARS={}'.format(xlabel_str, mars)
     data['xlabel'] = xlabel_str
@@ -918,7 +918,7 @@ def atr_graph_data(calc1, calc2,
     data = dict()
     data['lines'] = lines
     data['ylabel'] = '{} Average Tax Rate'.format(atr_str)
-    xlabel_str = 'Expanded Income Percentile'
+    xlabel_str = 'Baseline Expanded-Income Percentile'
     if mars != 'ALL':
         xlabel_str = '{} for MARS={}'.format(xlabel_str, mars)
     data['xlabel'] = xlabel_str
@@ -1002,7 +1002,7 @@ def xtr_graph_plot(data,
     fig = bp.figure(plot_width=width, plot_height=height, title=title)
     fig.title.text_font_size = '12pt'
     lines = data['lines']
-    fig.line(lines.index, lines.base, line_color='blue', legend='Base')
+    fig.line(lines.index, lines.base, line_color='blue', legend='Baseline')
     fig.line(lines.index, lines.reform, line_color='red', legend='Reform')
     fig.circle(0, 0, visible=False)  # force zero to be included on y axis
     if xlabel == '':


### PR DESCRIPTION
Given the discussion in issue #1540, the `tc` CLI logic has been revised to consistently use pre-reform (that is, baseline) expanded-income to assign filing units to an income category in both the `--tables` output and the `--graphs` output.