### PR TITLE
Provide more specific information in error/warning messages

### DIFF
--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -366,6 +366,7 @@ class Policy(ParametersBase):
         range information from the current_law_policy.json file.
         """
         # pylint: disable=too-many-locals,too-many-branches
+        # pylint: disable=too-many-nested-blocks
         clp = self.current_law_version()
         parameters = sorted(parameters_set)
         syr = Policy.JSON_START_YEAR
@@ -407,6 +408,8 @@ class Policy(ParametersBase):
                             name = pname
                         else:
                             name = '{}_{}'.format(pname, idx[1])
+                            if len(extra) > 0:
+                                msg += '_{}'.format(idx[1])
                         if action == 'warn':
                             self.reform_warnings += (
                                 'WARNING: ' + msg.format(idx[0] + syr, name,

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -365,7 +365,7 @@ class Policy(ParametersBase):
         Check values of parameters in specified parameter_set using
         range information from the current_law_policy.json file.
         """
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-locals,too-many-branches
         clp = self.current_law_version()
         parameters = sorted(parameters_set)
         syr = Policy.JSON_START_YEAR
@@ -382,6 +382,11 @@ class Policy(ParametersBase):
                 else:
                     vvalue = np.full(pvalue.shape, vval)
                 assert pvalue.shape == vvalue.shape
+                assert len(pvalue.shape) <= 2
+                if len(pvalue.shape) == 2:
+                    scalar = False  # parameter value is a list
+                else:
+                    scalar = True  # parameter value is a scalar
                 for idx in np.ndindex(pvalue.shape):
                     out_of_range = False
                     if vop == 'min' and pvalue[idx] < vvalue[idx]:
@@ -397,16 +402,21 @@ class Policy(ParametersBase):
                         if len(extra) > 0:
                             msg += ' {}'.format(extra)
                     if out_of_range:
+
                         action = self._vals[pname]['out_of_range_action']
+                        if scalar:
+                            name = pname
+                        else:
+                            name = '{}_{}'.format(pname, idx[1])
                         if action == 'warn':
                             self.reform_warnings += (
-                                'WARNING: ' + msg.format(idx[0] + syr, pname,
+                                'WARNING: ' + msg.format(idx[0] + syr, name,
                                                          pvalue[idx],
                                                          vvalue[idx]) + '\n'
                             )
                         if action == 'stop':
                             self.reform_errors += (
-                                'ERROR: ' + msg.format(idx[0] + syr, pname,
+                                'ERROR: ' + msg.format(idx[0] + syr, name,
                                                        pvalue[idx],
                                                        vvalue[idx]) + '\n'
                             )

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -402,7 +402,6 @@ class Policy(ParametersBase):
                         if len(extra) > 0:
                             msg += ' {}'.format(extra)
                     if out_of_range:
-
                         action = self._vals[pname]['out_of_range_action']
                         if scalar:
                             name = pname

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -200,6 +200,7 @@ class TaxCalcIO(object):
             try:
                 pol.implement_reform(param_dict['policy'])
                 self.errmsg += pol.reform_errors
+                self.errmsg += pol.reform_warnings
             except ValueError as valerr_msg:
                 self.errmsg += valerr_msg.__str__()
         else:

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -200,7 +200,6 @@ class TaxCalcIO(object):
             try:
                 pol.implement_reform(param_dict['policy'])
                 self.errmsg += pol.reform_errors
-                self.errmsg += pol.reform_warnings
             except ValueError as valerr_msg:
                 self.errmsg += valerr_msg.__str__()
         else:


### PR DESCRIPTION
This pull request is an attempt to provide more information about which element of a non-scalar policy parameter is being discussed in an error or warning message.  There are three kinds of non-scalar parameters: some are indexed by MARS, others are indexed by EIC, and a few are indexed by itemized-deduction-type.  The need for more information in the messages was pointed out by @hdoupe in the discussion of [TaxBrain pull request 641](https://github.com/OpenSourcePolicyCenter/webapp-public/pull/641#issuecomment-327893352).

Using the revised code in this pull request, the error and warning messages look like this:
```
tax-calculator$ cat ref.json
{"policy": {
    "_II_rt2": {"2020": [0.0]},
    "_II_brk2": {"2020": [[10000, 10000, 10000, 10000, 10000]]},
    "_STD_Dep": {"2020": [200]}
}}

tax-calculator$ tc cps.csv 2020 --reform ref.json
ERROR: 2020 _II_brk2_1 value 10000.0 < min value 19954.96 for _II_brk1_1
ERROR: 2020 _II_brk2_3 value 10000.0 < min value 14284.11 for _II_brk1_3
ERROR: 2020 _II_brk2_4 value 10000.0 < min value 19954.96 for _II_brk1_4
ERROR: 2021 _II_brk2_1 value 10233.0 < min value 20419.91 for _II_brk1_1
ERROR: 2021 _II_brk2_3 value 10233.0 < min value 14616.93 for _II_brk1_3
ERROR: 2021 _II_brk2_4 value 10233.0 < min value 20419.91 for _II_brk1_4
ERROR: 2022 _II_brk2_1 value 10470.41 < min value 20893.65 for _II_brk1_1
ERROR: 2022 _II_brk2_3 value 10470.41 < min value 14956.04 for _II_brk1_3
ERROR: 2022 _II_brk2_4 value 10470.41 < min value 20893.65 for _II_brk1_4
ERROR: 2023 _II_brk2_1 value 10714.37 < min value 21380.47 for _II_brk1_1
ERROR: 2023 _II_brk2_3 value 10714.37 < min value 15304.52 for _II_brk1_3
ERROR: 2023 _II_brk2_4 value 10714.37 < min value 21380.47 for _II_brk1_4
ERROR: 2024 _II_brk2_1 value 10964.01 < min value 21878.63 for _II_brk1_1
ERROR: 2024 _II_brk2_3 value 10964.01 < min value 15661.12 for _II_brk1_3
ERROR: 2024 _II_brk2_4 value 10964.01 < min value 21878.63 for _II_brk1_4
ERROR: 2025 _II_brk2_1 value 11220.57 < min value 22390.59 for _II_brk1_1
ERROR: 2025 _II_brk2_3 value 11220.57 < min value 16027.59 for _II_brk1_3
ERROR: 2025 _II_brk2_4 value 11220.57 < min value 22390.59 for _II_brk1_4
ERROR: 2026 _II_brk2_1 value 11484.25 < min value 22916.77 for _II_brk1_1
ERROR: 2026 _II_brk2_3 value 11484.25 < min value 16404.24 for _II_brk1_3
ERROR: 2026 _II_brk2_4 value 11484.25 < min value 22916.77 for _II_brk1_4
WARNING: 2020 _STD_Dep value 200.0 < min value 1123.47
WARNING: 2021 _STD_Dep value 204.66 < min value 1149.65
WARNING: 2022 _STD_Dep value 209.41 < min value 1176.32
WARNING: 2023 _STD_Dep value 214.29 < min value 1203.73
WARNING: 2024 _STD_Dep value 219.28 < min value 1231.78
WARNING: 2025 _STD_Dep value 224.41 < min value 1260.6
WARNING: 2026 _STD_Dep value 229.68 < min value 1290.22
USAGE: tc --help
```
