### PR TITLE
Add test that computes precision of difference table count statistics

### DIFF
--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -331,6 +331,19 @@ def test_diff_count_precision():
                        data_estimate, bs_samples, alpha, stderr, cilo, cihi)
         )
     assert abs((stderr / 1.90) - 1) < 0.0008
+    # NOTE: a se of 1.90 thousand implies that when comparing the difference
+    #       in the weighted number of filing units in WEBAPP bin 10 with a
+    #       tax increase, the difference statistic has a bigger se (because
+    #       the variance of the difference is the sum of the variances of the
+    #       two point estimates).  So, in WEBAPP bin 10 if the point estimates
+    #       both had se = 1.90, then the difference in the point estimates has
+    #       has a se = 2.687.  This means that the difference would have to be
+    #       over 5 thousand in order for there to be high confidence that the
+    #       difference was different from zero in a statistically significant
+    #       manner.
+    #       Or put a different way, a difference of 1 thousand cannot be
+    #       accurately detected while a difference of 10 thousand can be
+    #       accurately detected.
     assert abs((cilo / 28.33) - 1) < 0.0012
     assert abs((cihi / 35.81) - 1) < 0.0012
     # compute stderr and confidence interval for WEBAPP bin 11 increase count
@@ -351,6 +364,19 @@ def test_diff_count_precision():
                        data_estimate, bs_samples, alpha, stderr, cilo, cihi)
         )
     assert abs((stderr / 0.85) - 1) < 0.0040
+    # NOTE: a se of 0.85 thousand implies that when comparing the difference
+    #       in the weighted number of filing units in WEBAPP bin 11 with a
+    #       tax increase, the difference statistic has a bigger se (because
+    #       the variance of the difference is the sum of the variances of the
+    #       two point estimates).  So, in WEBAPP bin 11 if the point estimates
+    #       both had se = 0.85, then the difference in the point estimates has
+    #       has a se = 1.20.  This means that the difference would have to be
+    #       over 2.5 thousand in order for there to be high confidence that the
+    #       difference was different from zero in a statistically significant
+    #       manner.
+    #       Or put a different way, a difference of 1 thousand cannot be
+    #       accurately detected while a difference of 10 thousand can be
+    #       accurately detected.
     assert abs((cilo / 25.37) - 1) < 0.0012
     assert abs((cihi / 28.65) - 1) < 0.0012
     # fail if doing dump

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -788,9 +788,9 @@ def test_bootstrap_se_ci():
     # "An Introduction to the Bootstrap"
     # (Chapman & Hall, 1993).
     data = np.array([94, 197, 16, 38, 99, 141, 23], dtype=np.float64)
-    assert abs(np.mean(data) - 86.86) < 0.005  # just rounding error
+    assert abs(np.mean(data) - 86.86) < 0.005  # diff is just rounding error
     bsd = bootstrap_se_ci(data, 123456789, 1000, np.mean, alpha=0.025)
-    # following comparisons less precise because of rn seed differences
+    # following comparisons are less precise because of r.n. stream differences
     assert abs(bsd['se'] / 23.02 - 1) < 0.02
     assert abs(bsd['cilo'] / 45.9 - 1) < 0.02
     assert abs(bsd['cihi'] / 135.4 - 1) < 0.03

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -251,6 +251,62 @@ def test_create_tables(cps_subsample):
                                   result_type='weighted_sum')
 
 
+def test_diff_count_precision():
+    """
+    Estimate bootstrap standard error and confidence interval for count
+    statistics ('tax_cut' and 'tax_inc') in difference table generated
+    using puf.csv input data without any fuzzing by the dropq algorithm.
+
+    Background information on unweighted number of filing units by bin:
+
+    DECILE BINS:
+    0   16268
+    1   14897
+    2   13620
+    3   15760
+    4   16426
+    5   18070
+    6   18348
+    7   19352
+    8   21051
+    9   61733
+    A  215525
+
+    WEBAPP BINS:
+    0    7081 <--- negative income bin is dropped in TaxBrain display
+    1   19355
+    2   22722
+    3   20098
+    4   17088
+    5   14515
+    6   24760
+    7   15875
+    8   25225
+    9   15123
+    10  10570 <--- smallest unweighted bin count
+    11  23113
+    A  215525
+
+    Background information on Trump2017.json reform used in TaxBrain run 16649:
+
+    WEBAPP bin 10 (500-1000 thousands of dollars) has weighted count 1,179,000
+                  and weighted count of units with tax increase of 32,000.
+
+    So, the mean weight for all units in WEBAPP bin 10 is 111.5421 and the
+    unweighted number with a tax increase is 287 assuming all units in that
+    bin have the same weight.  (Note that 287 * 111.5421 is about 32,012.58,
+    which rounds to the 32 thousand shown in the TaxBrain difference table.)
+
+    This test estimates the standard error of and the confidence interval
+    around this 32 thousand estimate.
+    """
+    data_list = [111.5421] * 287 + [0.0] * (10570 - 287)
+    assert len(data_list) == 10570
+    data = np.array(data_list)
+    assert (data > 0).sum() == 287
+    assert abs((np.sum(data) / 32000) - 1) < 0.0005
+
+
 def test_weighted_count_lt_zero():
     df1 = pd.DataFrame(data=DATA, columns=['tax_diff', 's006', 'label'])
     grped = df1.groupby('label')

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -290,8 +290,8 @@ def test_diff_count_precision():
 
     Background information on Trump2017.json reform used in TaxBrain run 16649:
 
-    WEBAPP bin 10 (500-1000 thousands of dollars) has weighted count 1,179,000
-                  and weighted count of units with tax increase of 32,000.
+    WEBAPP bin 10 (500-1000 thousand dollars) has weighted count 1,179,000
+                   and weighted count of units with tax increase is 32,000.
 
     So, the mean weight for all units in WEBAPP bin 10 is 111.5421 and the
     unweighted number with a tax increase is 287 assuming all units in that
@@ -305,7 +305,25 @@ def test_diff_count_precision():
     assert len(data_list) == 10570
     data = np.array(data_list)
     assert (data > 0).sum() == 287
-    assert abs((np.sum(data) / 32000) - 1) < 0.0005
+    data_estimate = np.sum(data) * 1e-3
+    assert abs((data_estimate / 32) - 1) < 0.0005
+    seed = 123456789
+    bs_samples = 1000
+    alpha = 0.025  # implies 95% confidence interval
+    bsd = bootstrap_se_ci(data, seed, bs_samples, np.sum, alpha)
+    stderr = bsd['se'] * 1e-3
+    cilo = bsd['cilo'] * 1e-3
+    cihi = bsd['cihi'] * 1e-3
+    dump = False  # setting to True implies results printed and test fails
+    if dump:
+        res = 'EST={:.1f} B={} alpha={:.3f} se={:.1f} ci=[ {:.1f} , {:.1f} ]'
+        print(
+            res.format(data_estimate, bs_samples, alpha, stderr, cilo, cihi)
+        )
+    assert abs((stderr / 1.9) - 1) < 0.0008
+    assert abs((cilo / 28.3) - 1) < 0.0012
+    assert abs((cihi / 35.8) - 1) < 0.0012
+    assert not dump
 
 
 def test_weighted_count_lt_zero():

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -433,6 +433,7 @@ def create_difference_table(res1, res2, groupby, income_measure, tax_to_diff):
             raise ValueError(msg)
         # create grouped Pandas DataFrame
         gpdf = pdf.groupby('bins', as_index=False)
+        # print gpdf.count()  # show unweighted number of filing units per bin
         # create difference table statistics from gpdf in a new DataFrame
         diffs = pd.DataFrame()
         diffs['tax_cut'] = gpdf.apply(weighted_count_lt_zero, 'tax_diff')

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1298,7 +1298,7 @@ def bootstrap_se_ci(data, seed, num_samples, statistic, alpha):
     """
     Return bootstrap estimate of standard error of statistic and
     bootstrap estimate of 100*(1-2*alpha)% confidence interval for statistic
-    in a dictionary along with seed and nun_samples (B) and alpha.
+    in a dictionary along with specified seed and nun_samples (B) and alpha.
     """
     assert isinstance(data, np.ndarray)
     assert isinstance(seed, int)
@@ -1309,8 +1309,8 @@ def bootstrap_se_ci(data, seed, num_samples, statistic, alpha):
     bsest['seed'] = seed
     np.random.seed(seed)  # pylint: disable=no-member
     dlen = len(data)
-    idx = np.random.randint(0, dlen,   # pylint: disable=no-member
-                            (num_samples, dlen))
+    idx = np.random.randint(low=0, high=dlen,   # pylint: disable=no-member
+                            size=(num_samples, dlen))
     samples = data[idx]
     stat = statistic(samples, axis=1)
     bsest['B'] = num_samples


### PR DESCRIPTION
The difference table contains two statistics that are weighted counts of filing units that experience a reform-induced change in tax liability (either an increase or a decrease).  Recently there was a discussion in [TaxBrain issue 647](https://github.com/OpenSourcePolicyCenter/webapp-public/issues/647) about the display precision of these weighted count statistics, which are currently displayed in whole thousands of weighted units.  The problem with that discussion was that nobody had any statistical estimates of the precision of the count statistics.  The new test added in this pull request provides some statistical estimates of the precision of the count statistics, and therefore, provides some factual information for that discussion.

These results show that displaying the count statistics as whole thousands is highly misleading in the sense that differences of one thousand are not significantly different from zero.  But the results show that differences of ten thousand are significantly different from zero.  So, it would seem more responsible to display a count statistic in millions rounded to the nearest two decimal places (rather than in thousands).  So, for example, a count statistic of 49 thousand would be displayed as 0.05 million and a count statistic of 44 thousand would be displayed as 0.04 million.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @hdoupe @GoFroggyRun 