### PR TITLE
Show tc --table count statistic as x.xx million

### DIFF
--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -469,7 +469,7 @@ class TaxCalcIO(object):
                             '      ($b)',
                             '      ($b)')
         tfile.write(row)
-        rowfmt = '{:9.1f}{:10.1f}{:10.1f}{:10.1f}{:10.1f}{:10.1f}\n'
+        rowfmt = '{:9.2f}{:10.1f}{:10.1f}{:10.1f}{:10.1f}{:10.1f}\n'
         for decile in range(0, 10):
             row = '{:2d}'.format(decile)
             row += rowfmt.format(rtns_series[decile] * 1e-6,


### PR DESCRIPTION
This pull request increases the display precision of the count statistic in the CLI `tc` --tables output.
This change was made in light of the statistical precision findings in the `test_diff_count_precision` added in pull request $1550.