### PR TITLE
INCORRECT reform file for 2017 (Brown-Khanna) GAIN Act that expands EITC

### DIFF
--- a/taxcalc/reforms/BrownKhanna.json
+++ b/taxcalc/reforms/BrownKhanna.json
@@ -1,4 +1,4 @@
-// Title: 2017 Brown-Khanna Grow American Incomes Now (GAIN) Act (EITC reform)
+// Title: 2017 Brown-Khanna Grow American Incomes Now (GAIN) Act EITC expansion
 // Reform_File_Author: Martin Holmer
 // Reform_Reference: https://khanna.house.gov/media/press-releases/release-sen-sherrod-brown-and-rep-ro-khanna-introduce-landmark-legislation
 // Reform_Description:

--- a/taxcalc/reforms/BrownKhanna.json
+++ b/taxcalc/reforms/BrownKhanna.json
@@ -1,0 +1,17 @@
+// Title: 2017 Brown-Khanna Grow American Incomes Now (GAIN) Act (EITC reform)
+// Reform_File_Author: Martin Holmer
+// Reform_Reference: https://khanna.house.gov/media/press-releases/release-sen-sherrod-brown-and-rep-ro-khanna-introduce-landmark-legislation
+// Reform_Description:
+// - Raise maximum EITC amounts (1) 
+// - Reduce minimim age for childless EITC eligibility from 25 to 21 (2) 
+// Reform_Parameter_Map:
+// - 1: _EITC_c
+// - 2: _EITC_MinEligAge
+{
+  "policy": {
+        "_EITC_c":
+            {"2017": [[3000, 6528, 10783, 12131]]},
+        "_EITC_MinEligAge":
+            {"2017": [21]}
+    }
+}


### PR DESCRIPTION
**NOTE: this pull request incorrectly specifies the GAIN Act as pointed out below by @MattHJensen.
Therefore, this pull request is being closed without being merged and is replaced by pull request #1555.**

This pull request adds the `taxcalc/reforms/BrownKhanna.json` reform file that implements the EITC reform described in issue #1552.

Using `tc puf.csv YEAR --reform taxcalc/reforms/BrownKhanna.json --tables` produces the following change-in-tax-liability results for calendar YEAR = 2017 . . . 2026:
```
2017 -80.5
2018 -82.8
2019 -85.1
2020 -87.4
2021 -89.9
2022 -92.5
2023 -95.3
2024 -98.1
2025 -101.0
2026 -104.0
```
These **static results** imply a ten-year total cost (that is, reduction in income tax revenue) of about $917 billion.  When leaving the minimum eligibility age for the childless unchanged in the GAIN Act, the ten-year total cost is about $868 billion, which implies that this reform provision (reducing the minimum age from 25 to 21) costs about $49 billion.

These cost estimates are noticeably smaller than the [TPC estimates](http://www.taxpolicycenter.org/taxvox/plan-radically-expand-earned-income-tax-credit) which have the ten-year cost of the GAIN Act at about $1400 billion and the cost of reducing the minimum age at about $100 billion.  TPC provides no details on these two estimates; the only detailed model estimates pointed to in their report are for [other kinds of EITC reforms that were analyzed in June 2017](http://www.taxpolicycenter.org/model-estimates/earned-income-tax-credit-eitc-expansion-options-march-2017/options-expand-earned).   Footnote 2 in that June 2017 analysis says "Revenue estimates include the effects of microdynamic responses."  There is no further explanation of what those "microdynamic responses" to EITC reforms are, but presumably the Brown-Khanna GAIN Act is simulated with the same assumptions about "microdynamic responses".  So, it is possible that the TPC revenue estimates of the GAIN Act are computed assuming reductions in earnings caused by the EITC expansion.  But again, there is no way to be certain about this because TPC does not reveal anything about how they estimated the revenue effects of the GAIN Act.

Here are some details for calendar year 2017 of the Tax-Calculator **static analysis** of the GAIN Act.
```
Weighted Tax Reform Totals by Baseline Expanded-Income Decile
    Returns    ExpInc    IncTax    PayTax     LSTax    AllTax
       (#m)      ($b)      ($b)      ($b)      ($b)      ($b)
 0    17.00    -119.4      -3.0       6.4       0.0       3.5
 1    17.00     152.4     -13.6      14.4       0.0       0.8
 2    17.01     273.9     -33.6      24.5       0.0      -9.1
 3    17.00     400.6     -37.8      35.8       0.0      -2.0
 4    17.01     558.3     -25.6      52.6       0.0      27.0
 5    17.01     754.0       7.5      72.0       0.0      79.5
 6    17.01    1008.8      55.3      97.0       0.0     152.3
 7    17.00    1379.3     116.0     143.2       0.0     259.1
 8    17.01    2054.4     215.0     233.3       0.0     448.3
 9    17.01    6272.4    1339.3     413.3       0.0    1752.7
 A   170.05   12734.6    1619.5    1092.6       0.0    2712.1

Weighted Tax Differences by Baseline Expanded-Income Decile
    Returns    ExpInc    IncTax    PayTax     LSTax    AllTax
       (#m)      ($b)      ($b)      ($b)      ($b)      ($b)
 0    17.00    -119.4      -0.4       0.0       0.0      -0.4
 1    17.00     152.4      -1.5       0.0       0.0      -1.5
 2    17.01     273.9      -8.7       0.0       0.0      -8.7
 3    17.00     400.6     -20.5       0.0       0.0     -20.5
 4    17.01     558.3     -24.7       0.0       0.0     -24.7
 5    17.01     754.0     -18.9       0.0       0.0     -18.9
 6    17.01    1008.8      -5.6       0.0       0.0      -5.6
 7    17.00    1379.3      -0.1       0.0       0.0      -0.1
 8    17.01    2054.4      -0.0       0.0       0.0      -0.0
 9    17.01    6272.4      -0.0       0.0       0.0      -0.0
 A   170.05   12734.6     -80.5       0.0       0.0     -80.5
```

![screen shot 2017-09-16 at 9 16 09 am](https://user-images.githubusercontent.com/12170745/30512545-d9836a40-9abf-11e7-8714-f0a81722e440.png)

![screen shot 2017-09-16 at 9 17 56 am](https://user-images.githubusercontent.com/12170745/30512555-119beb64-9ac0-11e7-85f9-065a0391e36e.png)
