### PR TITLE
Rename function as read_json_param_objects()

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,13 +4,15 @@ Go
 [here](https://github.com/open-source-economics/Tax-Calculator/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
-Release 0.Y.Z on 2017-??-??
+Release 0.12.0 on 2017-??-??
 ----------------------------
 (last merged pull request is
 [#XXXX](https://github.com/open-source-economics/Tax-Calculator/pull/XXXX))
 
 **API Changes**
-- None
+- Rename read_json_param_files as read_json_param_objects
+  [[#1563](https://github.com/open-source-economics/Tax-Calculator/pull/1563)
+  by Martin Holmer]
 
 **New Features**
 - None

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -358,33 +358,35 @@ class Calculator(object):
         return calc
 
     @staticmethod
-    def read_json_param_files(reform_filename, assump_filename,
-                              arrays_not_lists=True):
+    def read_json_param_objects(reform, assump, arrays_not_lists=True):
         """
-        Read JSON files and call Calculator.read_json_*_text methods
-        returning a single dictionary containing five key:dict pairs:
+        Read JSON reform and assump objects and
+        return a single dictionary containing five key:dict pairs:
         'policy':dict, 'consumption':dict, 'behavior':dict,
         'growdiff_baseline':dict and 'growdiff_response':dict.
 
-        Note that either of the first two parameters may be None, in which
-        case an empty dictionary or empty dictionaries will be returned.
+        Note that either of the first two parameters may be None.
+        If reform is None, the dict in the 'policy':dict pair is empty.
+        If assump is None, the dict in the 'consumption':dict pair,
+        in the 'behavior':dict pair, in the 'growdiff_baseline':dict pair,
+        and in the 'growdiff_response':dict pair, are all empty.
 
         Also note that either of the first two parameters can be strings
-        containing the JSON parameter file contents (rather than filename),
-        in which case the file reading is skipped and the read_json_*_text
-        method is called.
+        containing a valid JSON string (rather than a filename),
+        in which case the file reading is skipped and the appropriate
+        read_json_*_text method is called.
         """
         # first process second assump parameter
-        if assump_filename is None:
+        if assump is None:
             cons_dict = dict()
             behv_dict = dict()
             gdiff_base_dict = dict()
             gdiff_resp_dict = dict()
-        elif isinstance(assump_filename, str):
-            if os.path.isfile(assump_filename):
-                txt = open(assump_filename, 'r').read()
+        elif isinstance(assump, six.string_types):
+            if os.path.isfile(assump):
+                txt = open(assump, 'r').read()
             else:
-                txt = assump_filename
+                txt = assump
             (cons_dict,
              behv_dict,
              gdiff_base_dict,
@@ -392,22 +394,22 @@ class Calculator(object):
                  Calculator._read_json_econ_assump_text(txt,
                                                         arrays_not_lists))
         else:
-            raise ValueError('assump_filename is neither None nor str')
+            raise ValueError('assump is neither None nor string')
         # next process first reform parameter
-        if reform_filename is None:
+        if reform is None:
             rpol_dict = dict()
-        elif isinstance(reform_filename, str):
-            if os.path.isfile(reform_filename):
-                txt = open(reform_filename, 'r').read()
+        elif isinstance(reform, six.string_types):
+            if os.path.isfile(reform):
+                txt = open(reform, 'r').read()
             else:
-                txt = reform_filename
+                txt = reform
             rpol_dict = (
                 Calculator._read_json_policy_reform_text(txt,
                                                          arrays_not_lists,
                                                          gdiff_base_dict,
                                                          gdiff_resp_dict))
         else:
-            raise ValueError('reform_filename is neither None nor str')
+            raise ValueError('reform is neither None nor string')
         # finally construct and return single composite dictionary
         param_dict = dict()
         param_dict['policy'] = rpol_dict

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -161,7 +161,7 @@ class TaxCalcIO(object):
         # pylint: disable=too-many-statements,too-many-branches
         self.errmsg = ''
         # get parameter dictionaries from --reform and --assump files
-        param_dict = Calculator.read_json_param_files(reform, assump)
+        param_dict = Calculator.read_json_param_objects(reform, assump)
         # create Behavior object
         beh = Behavior()
         beh.update_behavior(param_dict['behavior'])

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -367,7 +367,7 @@ def test_Calculator_using_nonstd_input(rawinputfile):
 
 
 REFORM_CONTENTS = """
-// Example of a reform file suitable for read_json_param_files() function.
+// Example of a reform file suitable for read_json_param_objects().
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
 // Within each "policy" object, the primary keys are parameters and
@@ -412,7 +412,7 @@ REFORM_CONTENTS = """
 @pytest.fixture(scope='module', name='reform_file')
 def fixture_reform_file():
     """
-    Temporary reform file for read_json_param_files() function.
+    Temporary reform file for read_json_param_objects() function.
     """
     rfile = tempfile.NamedTemporaryFile(mode='a', delete=False)
     rfile.write(REFORM_CONTENTS)
@@ -427,7 +427,7 @@ def fixture_reform_file():
 
 
 ASSUMP_CONTENTS = """
-// Example of an assump file suitable for the read_json_param_files() function.
+// Example of assump file suitable for the read_json_param_objects().
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
 // Within each "behavior", "consumption" and "growth" object, the
@@ -462,12 +462,14 @@ def fixture_assump_file():
 
 def test_read_json_reform_file_two_ways(reform_file, assump_file):
     """
-    Test when using file name and file contents in read_json_param_files
+    Test when using filename/contents in read_json_param_objects()
     """
-    pd1 = Calculator.read_json_param_files(reform_file.name, assump_file.name,
-                                           arrays_not_lists=False)
-    pd2 = Calculator.read_json_param_files(REFORM_CONTENTS, ASSUMP_CONTENTS,
-                                           arrays_not_lists=False)
+    pd1 = Calculator.read_json_param_objects(reform_file.name,
+                                             assump_file.name,
+                                             arrays_not_lists=False)
+    pd2 = Calculator.read_json_param_objects(REFORM_CONTENTS,
+                                             ASSUMP_CONTENTS,
+                                             arrays_not_lists=False)
     assert pd1 == pd2
 
 
@@ -483,8 +485,8 @@ def test_read_json_reform_file_and_implement_reform(reform_file,
     policy = Policy()
     if set_year:
         policy.set_year(2015)
-    param_dict = Calculator.read_json_param_files(reform_file.name,
-                                                  assump_file.name)
+    param_dict = Calculator.read_json_param_objects(reform_file.name,
+                                                    assump_file.name)
     policy.implement_reform(param_dict['policy'])
     syr = policy.start_year
     amt_brk1 = policy._AMT_brk1
@@ -575,13 +577,13 @@ def fixture_bad3reformfile():
 def test_read_bad_json_reform_file(bad1reformfile, bad2reformfile,
                                    bad3reformfile):
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(bad1reformfile.name, None)
+        Calculator.read_json_param_objects(bad1reformfile.name, None)
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(bad2reformfile.name, None)
+        Calculator.read_json_param_objects(bad2reformfile.name, None)
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(bad3reformfile.name, None)
+        Calculator.read_json_param_objects(bad3reformfile.name, None)
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(list(), None)
+        Calculator.read_json_param_objects(list(), None)
 
 
 @pytest.fixture(scope='module', name='bad1assumpfile')
@@ -649,15 +651,15 @@ def fixture_bad3assumpfile():
 def test_read_bad_json_assump_file(bad1assumpfile, bad2assumpfile,
                                    bad3assumpfile):
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(None, bad1assumpfile.name)
+        Calculator.read_json_param_objects(None, bad1assumpfile.name)
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(None, bad2assumpfile.name)
+        Calculator.read_json_param_objects(None, bad2assumpfile.name)
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(None, bad3assumpfile.name)
+        Calculator.read_json_param_objects(None, bad3assumpfile.name)
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(None, 'unknown_file_name')
+        Calculator.read_json_param_objects(None, 'unknown_file_name')
     with pytest.raises(ValueError):
-        Calculator.read_json_param_files(None, list())
+        Calculator.read_json_param_objects(None, list())
 
 
 def test_convert_parameter_dict():
@@ -681,7 +683,7 @@ def test_convert_parameter_dict():
 def test_calc_all(reform_file, rawinputfile):
     cyr = 2016
     policy = Policy()
-    param_dict = Calculator.read_json_param_files(reform_file.name, None)
+    param_dict = Calculator.read_json_param_objects(reform_file.name, None)
     policy.implement_reform(param_dict['policy'])
     policy.set_year(cyr)
     nonpuf = Records(data=rawinputfile.name, gfactors=None,
@@ -695,7 +697,8 @@ def test_calc_all(reform_file, rawinputfile):
 
 
 def test_translate_json_reform_suffixes_mars_indexed():
-    # test read_json_param_files(...) using MARS-indexed parameter suffixes
+    # test read_json_param_objects()
+    # using MARS-indexed parameter suffixes
     json1 = """{"policy": {
       "_II_em": {"2020": [20000], "2015": [15000]},
       "_STD_single": {"2018": [18000], "2016": [16000]},
@@ -709,9 +712,9 @@ def test_translate_json_reform_suffixes_mars_indexed():
         "_AWAGE": {"2013": [0.01]}},
       "growdiff_response": {}
     }"""
-    pdict1 = Calculator.read_json_param_files(reform_filename=json1,
-                                              assump_filename=assump_json,
-                                              arrays_not_lists=True)
+    pdict1 = Calculator.read_json_param_objects(reform=json1,
+                                                assump=assump_json,
+                                                arrays_not_lists=True)
     rdict1 = pdict1['policy']
     json2 = """{"policy": {
       "_STD": {"2016": [[16000.00, 12600.00, 6300.00,  9300.00, 12600.00]],
@@ -720,9 +723,9 @@ def test_translate_json_reform_suffixes_mars_indexed():
                "2019": [[18592.20, 13874.23, 6937.11, 10240.50, 19000.00]]},
       "_II_em": {"2020": [20000], "2015": [15000]}
     }}"""
-    pdict2 = Calculator.read_json_param_files(reform_filename=json2,
-                                              assump_filename=assump_json,
-                                              arrays_not_lists=True)
+    pdict2 = Calculator.read_json_param_objects(reform=json2,
+                                                assump=assump_json,
+                                                arrays_not_lists=True)
     rdict2 = pdict2['policy']
     assert len(rdict2) == len(rdict1)
     for year in rdict2.keys():
@@ -737,15 +740,16 @@ def test_translate_json_reform_suffixes_mars_indexed():
 
 
 def test_translate_json_reform_suffixes_mars_non_indexed():
-    # test read_json_param_files(...) using MARS-indexed parameter suffixes
+    # test read_json_param_objects()
+    # using MARS-indexed parameter suffixes
     json1 = """{"policy": {
       "_II_em": {"2020": [20000], "2015": [15000]},
       "_AMEDT_ec_joint": {"2018": [400000], "2016": [300000]},
       "_AMEDT_ec_separate": {"2017": [150000], "2019": [200000]}
     }}"""
-    pdict1 = Calculator.read_json_param_files(reform_filename=json1,
-                                              assump_filename=None,
-                                              arrays_not_lists=True)
+    pdict1 = Calculator.read_json_param_objects(reform=json1,
+                                                assump=None,
+                                                arrays_not_lists=True)
     rdict1 = pdict1['policy']
     json2 = """{"policy": {
       "_AMEDT_ec": {"2016": [[200000, 300000, 125000, 200000, 200000]],
@@ -754,9 +758,9 @@ def test_translate_json_reform_suffixes_mars_non_indexed():
                     "2019": [[200000, 400000, 200000, 200000, 200000]]},
       "_II_em": {"2015": [15000], "2020": [20000]}
     }}"""
-    pdict2 = Calculator.read_json_param_files(reform_filename=json2,
-                                              assump_filename=None,
-                                              arrays_not_lists=True)
+    pdict2 = Calculator.read_json_param_objects(reform=json2,
+                                                assump=None,
+                                                arrays_not_lists=True)
     rdict2 = pdict2['policy']
     assert len(rdict2) == len(rdict1)
     for year in rdict2.keys():
@@ -771,7 +775,8 @@ def test_translate_json_reform_suffixes_mars_non_indexed():
 
 
 def test_translate_json_reform_suffixes_eic():
-    # test read_json_param_files(...) using EIC-indexed parameter suffixes
+    # test read_json_param_objects(...)
+    # using EIC-indexed parameter suffixes
     json1 = """{"policy": {
       "_II_em": {"2020": [20000], "2015": [15000]},
       "_EITC_c_0kids": {"2018": [510], "2019": [510]},
@@ -779,18 +784,18 @@ def test_translate_json_reform_suffixes_eic():
       "_EITC_c_2kids": {"2018": [5616], "2019": [5616]},
       "_EITC_c_3+kids": {"2019": [6318], "2018": [6318]}
     }}"""
-    pdict1 = Calculator.read_json_param_files(reform_filename=json1,
-                                              assump_filename=None,
-                                              arrays_not_lists=True)
+    pdict1 = Calculator.read_json_param_objects(reform=json1,
+                                                assump=None,
+                                                arrays_not_lists=True)
     rdict1 = pdict1['policy']
     json2 = """{"policy": {
       "_EITC_c": {"2019": [[510, 3400, 5616, 6318]],
                   "2018": [[510, 3400, 5616, 6318]]},
       "_II_em": {"2020": [20000], "2015": [15000]}
     }}"""
-    pdict2 = Calculator.read_json_param_files(reform_filename=json2,
-                                              assump_filename=None,
-                                              arrays_not_lists=True)
+    pdict2 = Calculator.read_json_param_objects(reform=json2,
+                                                assump=None,
+                                                arrays_not_lists=True)
     rdict2 = pdict2['policy']
     assert len(rdict2) == len(rdict1)
     for year in rdict2.keys():
@@ -805,7 +810,8 @@ def test_translate_json_reform_suffixes_eic():
 
 
 def test_translate_json_reform_suffixes_idedtype():
-    # test read_json_param_files(...) using idedtype-indexed parameter suffixes
+    # test read_json_param_objects(...)
+    # using idedtype-indexed parameter suffixes
     json1 = """{"policy": {
       "_ID_BenefitCap_rt": {"2019": [0.2]},
       "_ID_BenefitCap_Switch_medical": {"2019": [false]},
@@ -815,9 +821,9 @@ def test_translate_json_reform_suffixes_idedtype():
       "_ID_BenefitCap_Switch_charity": {"2019": [false]},
       "_II_em": {"2020": [20000], "2015": [15000]}
     }}"""
-    pdict1 = Calculator.read_json_param_files(reform_filename=json1,
-                                              assump_filename=None,
-                                              arrays_not_lists=True)
+    pdict1 = Calculator.read_json_param_objects(reform=json1,
+                                                assump=None,
+                                                arrays_not_lists=True)
     rdict1 = pdict1['policy']
     json2 = """{"policy": {
       "_II_em": {"2020": [20000], "2015": [15000]},
@@ -826,9 +832,9 @@ def test_translate_json_reform_suffixes_idedtype():
       },
       "_ID_BenefitCap_rt": {"2019": [0.2]}
     }}"""
-    pdict2 = Calculator.read_json_param_files(reform_filename=json2,
-                                              assump_filename=None,
-                                              arrays_not_lists=True)
+    pdict2 = Calculator.read_json_param_objects(reform=json2,
+                                                assump=None,
+                                                arrays_not_lists=True)
     rdict2 = pdict2['policy']
     assert len(rdict2) == len(rdict1)
     for year in rdict2.keys():
@@ -846,9 +852,9 @@ def test_translate_json_reform_suffixes_idedtype():
                                atol=0.01, rtol=0.0)
 
 
-def test_read_json_param_files_with_suffixes_and_errors():
+def test_read_json_param_with_suffixes_and_errors():
     # test interaction of policy parameter suffixes and reform errors
-    # (fails without 0.10.2 bug fix as reported by Hank Doupe in TB PR#641)
+    # (fails without 0.10.2 bug fix as reported by Hank Doupe in PB PR#641)
     reform = {
         u'policy': {
             u'_II_brk4_separate': {u'2017': [5000.0]},
@@ -868,7 +874,7 @@ def test_read_json_param_files_with_suffixes_and_errors():
         }
     }
     json_reform = json.dumps(reform)
-    params = Calculator.read_json_param_files(json_reform, None)
+    params = Calculator.read_json_param_objects(json_reform, None)
     assert isinstance(params, dict)
     pol = Policy()
     pol.implement_reform(params['policy'])

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -430,7 +430,7 @@ def test_parameters_get_default_start_year():
 
 
 REFORM_CONTENTS = """
-// Example of a reform file suitable for Calculator read_json_param_files().
+// Example of reform file suitable for Calculator read_json_param_objects().
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
 // The primary keys are policy parameters and secondary keys are years.
@@ -474,7 +474,7 @@ REFORM_CONTENTS = """
 @pytest.fixture(scope='module', name='reform_file')
 def fixture_reform_file():
     """
-    Temporary reform file for Calculator read_json_param_files function.
+    Temporary reform file for Calculator read_json_param_objects() function.
     """
     with tempfile.NamedTemporaryFile(mode='a', delete=False) as rfile:
         rfile.write(REFORM_CONTENTS)
@@ -488,7 +488,7 @@ def fixture_reform_file():
 
 
 @pytest.mark.parametrize("set_year", [False, True])
-def test_read_json_param_files_and_implement_reform(reform_file, set_year):
+def test_read_json_param_and_implement_reform(reform_file, set_year):
     """
     Test reading and translation of reform file into a reform dictionary
     that is then used to call implement_reform method.
@@ -497,7 +497,7 @@ def test_read_json_param_files_and_implement_reform(reform_file, set_year):
     policy = Policy()
     if set_year:
         policy.set_year(2015)
-    param_dict = Calculator.read_json_param_files(reform_file.name, None)
+    param_dict = Calculator.read_json_param_objects(reform_file.name, None)
     policy.implement_reform(param_dict['policy'])
     syr = policy.start_year
     amt_brk1 = policy._AMT_brk1

--- a/taxcalc/validation/taxsim/simpletaxio.py
+++ b/taxcalc/validation/taxsim/simpletaxio.py
@@ -104,7 +104,7 @@ class SimpleTaxIO(object):
         # implement reform if reform is specified
         if reform:
             if self._using_reform_file:
-                param_dict = Calculator.read_json_param_files(reform, None)
+                param_dict = Calculator.read_json_param_objects(reform, None)
                 r_pol = param_dict['policy']
             else:
                 r_pol = reform

--- a/taxcalc/validation/taxsim/test_simpletaxio.py
+++ b/taxcalc/validation/taxsim/test_simpletaxio.py
@@ -19,7 +19,7 @@ INPUT_CONTENTS = (
     '4 2015 0 2 0 4039 15000 0    0 0 50000 70000 0 0 0 0 0 0 0 0    0 -3000\n'
 )
 REFORM_CONTENTS = """
-// Example of a reform file suitable for the read_json_param_files function.
+// Example of a reform file suitable for the read_json_param_objects function.
 // This JSON file can contain any number of trailing //-style comments, which
 // will be removed before the contents are converted from JSON to a dictionary.
 // Within the "policy" object, the primary keys are parameters and


### PR DESCRIPTION
This pull request changes the static Calculator method name from `read_json_param_files` to `read_json_param_objects` in order to clarify that the first two arguments (which have also been renamed) can be a string that contains either a filename or valid JSON.

Note that this is an API change because this method is called by code in the PolicyBrain repository.

@MattHJensen @Amy-Xu @andersonfrailey @hdoupe @GoFroggyRun @brittainhard 