### PR TITLE
Add reform documentation to standard output of Tax-Calculator CLI, tc

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,9 @@ Release 0.12.0 on 2017-??-??
 - Add Calculator.reform_documentation that generates plain text documentation of a reform
   [[#1564](https://github.com/open-source-economics/Tax-Calculator/pull/1564)
   by Martin Holmer]
+- Enhance stats_summary.py script and its output
+  [[#1566](https://github.com/open-source-economics/Tax-Calculator/pull/1566)
+  by Amy Xu]
 - Add reform documentation as standard output from Tax-Calculator CLI, tc
   [[#1567](https://github.com/open-source-economics/Tax-Calculator/pull/1567)
   by Martin Holmer]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,9 @@ Release 0.12.0 on 2017-??-??
 - Add Calculator.reform_documentation that generates plain text documentation of a reform
   [[#1564](https://github.com/open-source-economics/Tax-Calculator/pull/1564)
   by Martin Holmer]
+- Add reform documentation as standard output from Tax-Calculator CLI, tc
+  [[#1567](https://github.com/open-source-economics/Tax-Calculator/pull/1567)
+  by Martin Holmer]
 
 **Bug Fixes**
 - None

--- a/docs/index.html
+++ b/docs/index.html
@@ -440,6 +440,10 @@ in the minimal output file include:
 <kbd>PAYTAX</kbd> (which is same as <kbd>payroll_tax</kbd>).
 </p>
 
+<p>Also, documentation of the reform is always written to a text file
+ending in <kbd>-doc.text</kbd>, which in this example would be
+named <kbd>test-20-#-#-doc.text</kbd>.</p>
+
 <p><pre>
 (2)$ tc test.csv 2020 --dump
 </pre></p>

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -442,8 +442,9 @@ class Calculator(object):
         Parameters
         ----------
         params: dict
-            compound dictionary structured as dict returned from
-            the static Calculator method read_json_param_objects()
+            compound dictionary structured as dict returned from the
+            static Calculator method read_json_param_objects() when
+            called with the arrays_not_lists=False argument
 
         Returns
         -------

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -105,7 +105,7 @@ def cli_tc_main():
     args = parser.parse_args()
     # write test input and expected output files if --test option specified
     if args.test:
-        _write_test_input_output_files()
+        _write_expected_test_output()
         inputfn = TEST_INPUT_FILENAME
         taxyear = TEST_TAXYEAR
     else:
@@ -148,7 +148,7 @@ EXPECTED_TEST_OUTPUT_FILENAME = 'test-{}-out.csv'.format(str(TEST_TAXYEAR)[2:])
 ACTUAL_TEST_OUTPUT_FILENAME = 'test-{}-#-#.csv'.format(str(TEST_TAXYEAR)[2:])
 
 
-def _write_test_input_output_files():
+def _write_expected_test_output():
     """
     Private function that writes tc --test input and expected output files.
     """

--- a/taxcalc/docs/index.htmx
+++ b/taxcalc/docs/index.htmx
@@ -440,6 +440,10 @@ in the minimal output file include:
 <kbd>PAYTAX</kbd> (which is same as <kbd>payroll_tax</kbd>).
 </p>
 
+<p>Also, documentation of the reform is always written to a text file
+ending in <kbd>-doc.text</kbd>, which in this example would be
+named <kbd>test-20-#-#-doc.text</kbd>.</p>
+
 <p><pre>
 (2)$ tc test.csv 2020 --dump
 </pre></p>

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -55,6 +55,7 @@ class TaxCalcIO(object):
     -------
     class instance: TaxCalcIO
     """
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, input_data, tax_year, reform, assump):
         # pylint: disable=too-many-branches,too-many-statements
@@ -122,9 +123,11 @@ class TaxCalcIO(object):
         else:
             msg = 'TaxCalcIO.ctor: assump is neither None nor str'
             self.errmsg += 'ERROR: {}\n'.format(msg)
-        # create OUTPUT file name and delete any existing output file
+        # create OUTPUT file name and delete any existing output files
         self._output_filename = '{}{}{}.csv'.format(inp, ref, asm)
         delete_file(self._output_filename)
+        delete_file(self._output_filename.replace('.csv', '.db'))
+        delete_file(self._output_filename.replace('.csv', '-doc.text'))
         delete_file(self._output_filename.replace('.csv', '-tab.text'))
         delete_file(self._output_filename.replace('.csv', '-atr.html'))
         delete_file(self._output_filename.replace('.csv', '-mtr.html'))
@@ -132,6 +135,7 @@ class TaxCalcIO(object):
         self.behavior_has_any_response = False
         self.calc = None
         self.calc_clp = None
+        self.param_dict = None
 
     def init(self, input_data, tax_year, reform, assump,
              growdiff_response,
@@ -162,6 +166,7 @@ class TaxCalcIO(object):
         self.errmsg = ''
         # get parameter dictionaries from --reform and --assump files
         param_dict = Calculator.read_json_param_objects(reform, assump)
+        self.param_dict = param_dict
         # create Behavior object
         beh = Behavior()
         beh.update_behavior(param_dict['behavior'])
@@ -358,6 +363,7 @@ class TaxCalcIO(object):
         # extract output if writing_output_file
         if writing_output_file:
             self.write_output_file(output_dump, mtr_paytax, mtr_inctax)
+            self.write_doc_file()
         # optionally write --sqldb output to SQLite3 database
         if output_sqldb:
             self.write_sqldb_file(mtr_paytax, mtr_inctax)
@@ -391,14 +397,23 @@ class TaxCalcIO(object):
         outdf.to_csv(self._output_filename, columns=column_order,
                      index=False, float_format='%.2f')
 
+    def write_doc_file(self):
+        """
+        Write reform documentation to text file.
+        """
+        doc = Calculator.reform_documentation(self.param_dict)
+        doc_fname = self._output_filename.replace('.csv', '-doc.text')
+        with open(doc_fname, 'w') as dfile:
+            dfile.write(doc)
+
     def write_sqldb_file(self, mtr_paytax, mtr_inctax):
         """
         Write dump output to SQLite3 database table dump.
         """
         outdf = self.dump_output(mtr_inctax, mtr_paytax)
         assert len(outdf.index) == self.calc.records.dim
-        dbfilename = '{}.db'.format(self._output_filename[:-4])
-        dbcon = sqlite3.connect(dbfilename)
+        db_fname = self._output_filename.replace('.csv', '.db')
+        dbcon = sqlite3.connect(db_fname)
         outdf.to_sql('dump', dbcon, if_exists='replace', index=False)
         dbcon.close()
 

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -135,7 +135,7 @@ class TaxCalcIO(object):
         self.behavior_has_any_response = False
         self.calc = None
         self.calc_clp = None
-        self.param_dict = None
+        self.param_dict_with_lists = None
 
     def init(self, input_data, tax_year, reform, assump,
              growdiff_response,
@@ -166,7 +166,8 @@ class TaxCalcIO(object):
         self.errmsg = ''
         # get parameter dictionaries from --reform and --assump files
         param_dict = Calculator.read_json_param_objects(reform, assump)
-        self.param_dict = param_dict
+        self.param_dict_with_lists = Calculator.read_json_param_objects(
+            reform, assump, arrays_not_lists=False)
         # create Behavior object
         beh = Behavior()
         beh.update_behavior(param_dict['behavior'])
@@ -401,7 +402,7 @@ class TaxCalcIO(object):
         """
         Write reform documentation to text file.
         """
-        doc = Calculator.reform_documentation(self.param_dict)
+        doc = Calculator.reform_documentation(self.param_dict_with_lists)
         doc_fname = self._output_filename.replace('.csv', '-doc.text')
         with open(doc_fname, 'w') as dfile:
             dfile.write(doc)

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -397,9 +397,12 @@ def test_output_otions(rawinputfile, reformfile1, assumpfile1):
             except OSError:
                 pass  # sometimes we can't remove a generated temporary file
         assert 'TaxCalcIO.analyze(dump)_ok' == 'no'
-    # if tries were successful, remove the output file
+    # if tries were successful, remove output file and doc file
     if os.path.isfile(outfilepath):
         os.remove(outfilepath)
+    docfilepath = outfilepath.replace('.csv', '-doc.text')
+    if os.path.isfile(docfilepath):
+        os.remove(docfilepath)
 
 
 def test_sqldb_option(rawinputfile, reformfile1, assumpfile1):


### PR DESCRIPTION
This pull request uses the capabilities added in pull request #1564 to have `tc`, the command-line interface (CLI) to Tax-Calculator, always output reform documentation in a file ending in `-doc.text`.

Here is an example of the documentation using the Brown-Khanna GAIN Act as the reform.
```
$ cat BK.json
// Title: Brown-Khanna Grow American Incomes Now (GAIN) Act of 2017
// Reform_File_Author: Matt Jensen
// Reform_Reference: https://khanna.house.gov/media/press-releases/release-sen-sherrod-brown-and-rep-ro-khanna-introduce-landmark-legislation
// Reform_Description:
// - Increase EITC maximum amounts (1)
// - Increase EITC phase-in rates (2)
// - Increase EITC phase-out rate for childless filing units (3)
// - Increase EITC phase-out start for childless filing units (4)
// - Lower EITC minimim eligibility age for childless f.units from 25 to 21 (5)
// Reform_Parameter_Map:
// - 1: _EITC_c
// - 2: _EITC_rt
// - 3: _EITC_prt
// - 4: _EITC_ps
// - 5: _EITC_MinEligAge
{
  "policy": {
      "_EITC_c": {"2017": [[3000, 6528, 10783, 12131]]},
      "_EITC_rt": {"2017": [[0.3, 0.6258, 0.768, 0.864]]},
      "_EITC_prt": {"2017": [[0.1598, 0.1598, 0.2106, 0.2106]]},
      "_EITC_ps": {"2017": [[18340, 18340, 18340, 18340]]},
      "_EITC_MinEligAge": {"2017": [21]}
    }
}

$ tc puf.csv 2017 --reform BK.json 
You loaded data for 2009.
Tax-Calculator startup automatically extrapolated your data to 2017.

$ ls -l puf-17-BK*
-rw-r--r--  1 mrh  staff     1533 Sep 25 15:44 puf-17-BK-#-doc.text
-rw-r--r--  1 mrh  staff  8823846 Sep 25 15:44 puf-17-BK-#.csv

$ cat puf-17-BK-#-doc.text
iMac2:tax-calculator mrh$ cat puf-17-BK-#-doc.text 
REFORM DOCUMENTATION
Baseline Growth-Difference Assumption Values by Year:
none: using default baseline growth assumptions
Policy Reform Parameter Values by Year:
2017:
 _EITC_MinEligAge : 21
  name: Minimum Age for Childless EITC Eligibility
  desc: For a childless filling unit, at least one individual's age needs to
        be no less than this age (but no greater than the EITC_MaxEligAge) in
        order to be eligible for an earned income tax credit.
  baseline_value: 25.0
 _EITC_c : [3000, 6528, 10783, 12131]
           ['0kids', '1kid', '2kids', '3+kids']
  name: Maximum earned income credit
  desc: This is the maximum amount of earned income credit taxpayers are
        eligible for; it depends on how many kids they have.
  baseline_value: [510.0, 3400.0, 5616.0, 6318.0]
 _EITC_prt : [0.1598, 0.1598, 0.2106, 0.2106]
             ['0kids', '1kid', '2kids', '3+kids']
  name: Earned income credit phaseout rate
  desc: Earned income credit begins to decrease at the this rate when AGI is
        higher than earned income credit phaseout start AGI.
  baseline_value: [0.0765, 0.1598, 0.2106, 0.2106]
 _EITC_ps : [18340, 18340, 18340, 18340]
            ['0kids', '1kid', '2kids', '3+kids']
  name: Earned income credit phaseout start AGI
  desc: If AGI is higher than this threshold, the amount of EITC will start to
        decrease at the phaseout rate.
  baseline_value: [8340.0, 18340.0, 18340.0, 18340.0]
 _EITC_rt : [0.3, 0.6258, 0.768, 0.864]
            ['0kids', '1kid', '2kids', '3+kids']
  name: Earned income credit phasein rate
  desc: Pre-phaseout credit is minimum of this rate times earnings and the
        maximum earned income credit.
  baseline_value: [0.0765, 0.34, 0.4, 0.45]
```

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @hdoupe @GoFroggyRun @codykallen 
