### PR TITLE
Remove array_not_lists argument from several functions

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,9 @@ Release 0.12.0 on 2017-??-??
 - Rename read_json_param_files as read_json_param_objects
   [[#1563](https://github.com/open-source-economics/Tax-Calculator/pull/1563)
   by Martin Holmer]
+- Remove arrays_not_lists argument from read_json_param_objects
+  [[#1568](https://github.com/open-source-economics/Tax-Calculator/pull/1568)
+  by Martin Holmer]
 
 **New Features**
 - Add Calculator.reform_documentation that generates plain text documentation of a reform

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -135,7 +135,7 @@ class TaxCalcIO(object):
         self.behavior_has_any_response = False
         self.calc = None
         self.calc_clp = None
-        self.param_dict_with_lists = None
+        self.paramdict = None
 
     def init(self, input_data, tax_year, reform, assump,
              growdiff_response,
@@ -165,23 +165,21 @@ class TaxCalcIO(object):
         # pylint: disable=too-many-statements,too-many-branches
         self.errmsg = ''
         # get parameter dictionaries from --reform and --assump files
-        param_dict = Calculator.read_json_param_objects(reform, assump)
-        self.param_dict_with_lists = Calculator.read_json_param_objects(
-            reform, assump, arrays_not_lists=False)
+        self.paramdict = Calculator.read_json_param_objects(reform, assump)
         # create Behavior object
         beh = Behavior()
-        beh.update_behavior(param_dict['behavior'])
+        beh.update_behavior(self.paramdict['behavior'])
         self.behavior_has_any_response = beh.has_any_response()
         # create gdiff_baseline object
         gdiff_baseline = Growdiff()
-        gdiff_baseline.update_growdiff(param_dict['growdiff_baseline'])
+        gdiff_baseline.update_growdiff(self.paramdict['growdiff_baseline'])
         # create Growfactors clp object that incorporates gdiff_baseline
         gfactors_clp = Growfactors()
         gdiff_baseline.apply_to(gfactors_clp)
         # specify gdiff_response object
         if growdiff_response is None:
             gdiff_response = Growdiff()
-            gdiff_response.update_growdiff(param_dict['growdiff_response'])
+            gdiff_response.update_growdiff(self.paramdict['growdiff_response'])
         elif isinstance(growdiff_response, Growdiff):
             gdiff_response = growdiff_response
         else:
@@ -204,7 +202,7 @@ class TaxCalcIO(object):
         if self.specified_reform:
             pol = Policy(gfactors=gfactors_ref)
             try:
-                pol.implement_reform(param_dict['policy'])
+                pol.implement_reform(self.paramdict['policy'])
                 self.errmsg += pol.reform_errors
             except ValueError as valerr_msg:
                 self.errmsg += valerr_msg.__str__()
@@ -262,7 +260,7 @@ class TaxCalcIO(object):
             self.errmsg += 'ERROR: {}\n'.format(msg)
         # create Calculator objects
         con = Consumption()
-        con.update_consumption(param_dict['consumption'])
+        con.update_consumption(self.paramdict['consumption'])
         self.calc = Calculator(policy=pol, records=recs,
                                verbose=True,
                                consumption=con,
@@ -402,7 +400,7 @@ class TaxCalcIO(object):
         """
         Write reform documentation to text file.
         """
-        doc = Calculator.reform_documentation(self.param_dict_with_lists)
+        doc = Calculator.reform_documentation(self.paramdict)
         doc_fname = self._output_filename.replace('.csv', '-doc.text')
         with open(doc_fname, 'w') as dfile:
             dfile.write(doc)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -461,19 +461,6 @@ def fixture_assump_file():
             pass  # sometimes we can't remove a generated temporary file
 
 
-def test_read_json_reform_file_two_ways(reform_file, assump_file):
-    """
-    Test when using filename/contents in read_json_param_objects()
-    """
-    pd1 = Calculator.read_json_param_objects(reform_file.name,
-                                             assump_file.name,
-                                             arrays_not_lists=False)
-    pd2 = Calculator.read_json_param_objects(REFORM_CONTENTS,
-                                             ASSUMP_CONTENTS,
-                                             arrays_not_lists=False)
-    assert pd1 == pd2
-
-
 @pytest.mark.parametrize("set_year", [False, True])
 def test_read_json_reform_file_and_implement_reform(reform_file,
                                                     assump_file,
@@ -665,19 +652,14 @@ def test_read_bad_json_assump_file(bad1assumpfile, bad2assumpfile,
 
 def test_convert_parameter_dict():
     with pytest.raises(ValueError):
-        rdict = Calculator._convert_parameter_dict({2013: {'2013': [40000]}},
-                                                   arrays_not_lists=True)
+        rdict = Calculator._convert_parameter_dict({2013: {'2013': [40000]}})
     with pytest.raises(ValueError):
-        rdict = Calculator._convert_parameter_dict({'_II_em': {2013: [40000]}},
-                                                   arrays_not_lists=True)
+        rdict = Calculator._convert_parameter_dict({'_II_em': {2013: [40000]}})
     with pytest.raises(ValueError):
-        rdict = Calculator._convert_parameter_dict({4567: {2013: [40000]}},
-                                                   arrays_not_lists=True)
+        rdict = Calculator._convert_parameter_dict({4567: {2013: [40000]}})
     with pytest.raises(ValueError):
-        rdict = Calculator._convert_parameter_dict({'_II_em': 40000},
-                                                   arrays_not_lists=True)
-    rdict = Calculator._convert_parameter_dict({'_II_em': {'2013': [40000]}},
-                                               arrays_not_lists=False)
+        rdict = Calculator._convert_parameter_dict({'_II_em': 40000})
+    rdict = Calculator._convert_parameter_dict({'_II_em': {'2013': [40000]}})
     assert isinstance(rdict, dict)
 
 
@@ -714,8 +696,7 @@ def test_translate_json_reform_suffixes_mars_indexed():
       "growdiff_response": {}
     }"""
     pdict1 = Calculator.read_json_param_objects(reform=json1,
-                                                assump=assump_json,
-                                                arrays_not_lists=True)
+                                                assump=assump_json)
     rdict1 = pdict1['policy']
     json2 = """{"policy": {
       "_STD": {"2016": [[16000.00, 12600.00, 6300.00,  9300.00, 12600.00]],
@@ -725,8 +706,7 @@ def test_translate_json_reform_suffixes_mars_indexed():
       "_II_em": {"2020": [20000], "2015": [15000]}
     }}"""
     pdict2 = Calculator.read_json_param_objects(reform=json2,
-                                                assump=assump_json,
-                                                arrays_not_lists=True)
+                                                assump=assump_json)
     rdict2 = pdict2['policy']
     assert len(rdict2) == len(rdict1)
     for year in rdict2.keys():
@@ -748,9 +728,7 @@ def test_translate_json_reform_suffixes_mars_non_indexed():
       "_AMEDT_ec_joint": {"2018": [400000], "2016": [300000]},
       "_AMEDT_ec_separate": {"2017": [150000], "2019": [200000]}
     }}"""
-    pdict1 = Calculator.read_json_param_objects(reform=json1,
-                                                assump=None,
-                                                arrays_not_lists=True)
+    pdict1 = Calculator.read_json_param_objects(reform=json1, assump=None)
     rdict1 = pdict1['policy']
     json2 = """{"policy": {
       "_AMEDT_ec": {"2016": [[200000, 300000, 125000, 200000, 200000]],
@@ -759,9 +737,7 @@ def test_translate_json_reform_suffixes_mars_non_indexed():
                     "2019": [[200000, 400000, 200000, 200000, 200000]]},
       "_II_em": {"2015": [15000], "2020": [20000]}
     }}"""
-    pdict2 = Calculator.read_json_param_objects(reform=json2,
-                                                assump=None,
-                                                arrays_not_lists=True)
+    pdict2 = Calculator.read_json_param_objects(reform=json2, assump=None)
     rdict2 = pdict2['policy']
     assert len(rdict2) == len(rdict1)
     for year in rdict2.keys():
@@ -785,18 +761,14 @@ def test_translate_json_reform_suffixes_eic():
       "_EITC_c_2kids": {"2018": [5616], "2019": [5616]},
       "_EITC_c_3+kids": {"2019": [6318], "2018": [6318]}
     }}"""
-    pdict1 = Calculator.read_json_param_objects(reform=json1,
-                                                assump=None,
-                                                arrays_not_lists=True)
+    pdict1 = Calculator.read_json_param_objects(reform=json1, assump=None)
     rdict1 = pdict1['policy']
     json2 = """{"policy": {
       "_EITC_c": {"2019": [[510, 3400, 5616, 6318]],
                   "2018": [[510, 3400, 5616, 6318]]},
       "_II_em": {"2020": [20000], "2015": [15000]}
     }}"""
-    pdict2 = Calculator.read_json_param_objects(reform=json2,
-                                                assump=None,
-                                                arrays_not_lists=True)
+    pdict2 = Calculator.read_json_param_objects(reform=json2, assump=None)
     rdict2 = pdict2['policy']
     assert len(rdict2) == len(rdict1)
     for year in rdict2.keys():
@@ -822,9 +794,7 @@ def test_translate_json_reform_suffixes_idedtype():
       "_ID_BenefitCap_Switch_charity": {"2019": [false]},
       "_II_em": {"2020": [20000], "2015": [15000]}
     }}"""
-    pdict1 = Calculator.read_json_param_objects(reform=json1,
-                                                assump=None,
-                                                arrays_not_lists=True)
+    pdict1 = Calculator.read_json_param_objects(reform=json1, assump=None)
     rdict1 = pdict1['policy']
     json2 = """{"policy": {
       "_II_em": {"2020": [20000], "2015": [15000]},
@@ -833,9 +803,7 @@ def test_translate_json_reform_suffixes_idedtype():
       },
       "_ID_BenefitCap_rt": {"2019": [0.2]}
     }}"""
-    pdict2 = Calculator.read_json_param_objects(reform=json2,
-                                                assump=None,
-                                                arrays_not_lists=True)
+    pdict2 = Calculator.read_json_param_objects(reform=json2, assump=None)
     rdict2 = pdict2['policy']
     assert len(rdict2) == len(rdict1)
     for year in rdict2.keys():
@@ -897,8 +865,7 @@ def test_noreform_documentation():
     "growdiff_response": {}
     }
     """
-    params = Calculator.read_json_param_objects(reform_json, assump_json,
-                                                arrays_not_lists=False)
+    params = Calculator.read_json_param_objects(reform_json, assump_json)
     assert isinstance(params, dict)
     actual_doc = Calculator.reform_documentation(params)
     expected_doc = (
@@ -941,8 +908,7 @@ def test_reform_documentation():
     "growdiff_response": {}
     }
     """
-    params = Calculator.read_json_param_objects(reform_json, assump_json,
-                                                arrays_not_lists=False)
+    params = Calculator.read_json_param_objects(reform_json, assump_json)
     assert isinstance(params, dict)
     doc = Calculator.reform_documentation(params)
     assert isinstance(doc, six.string_types)

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -27,13 +27,11 @@ def test_reform_json(tests_path):
         jpf_text = jfile.read()
         # check that jpf_text has "policy" that can be implemented as a reform
         if '"policy"' in jpf_text:
-            arrays_not_lists = True
             gdiffbase = {}
             gdiffresp = {}
             # pylint: disable=protected-access
             policy_dict = (
                 Calculator._read_json_policy_reform_text(jpf_text,
-                                                         arrays_not_lists,
                                                          gdiffbase, gdiffresp)
             )
             policy = Policy()

--- a/taxcalc/tests/test_responses.py
+++ b/taxcalc/tests/test_responses.py
@@ -29,9 +29,7 @@ def test_response_json(tests_path):
         if response_file:
             # pylint: disable=protected-access
             (con, beh, gdiff_base,
-             gdiff_resp) = (
-                 Calculator._read_json_econ_assump_text(jpf_text,
-                                                        arrays_not_lists=True))
+             gdiff_resp) = Calculator._read_json_econ_assump_text(jpf_text)
             cons = Consumption()
             cons.update_consumption(con)
             behv = Behavior()


### PR DESCRIPTION
This pull request eliminates an unnecessary argument from the static Calculator `read_json_param_objects()` method and from related functions.
The new logic is identical to always setting `arrays_not_lists` to `False`, which means that the returned dictionary contains lists (not numpy arrays) of parameter values.

This code change did not cause any test results changes.

@MattHJensen @Amy-Xu @andersonfrailey @hdoupe @GoFroggyRun 