### PR TITLE
Relax parameter value warning logic when min or max value is "default"

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -29,7 +29,9 @@ Release 0.12.0 on 2017-??-??
   by Martin Holmer]
 
 **Bug Fixes**
-- None
+- Relax _STD and _STD_Dep minimum value warning logic
+  [[#1578](https://github.com/open-source-economics/Tax-Calculator/pull/1578)
+  by Martin Holmer]
 
 Release 0.11.0 on 2017-09-21
 ----------------------------

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -376,6 +376,8 @@ class Policy(ParametersBase):
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-branches
         # pylint: disable=too-many-nested-blocks
+        rounding_error = 100.0
+        # above handles non-rounding of inflation-indexed parameter values
         clp = self.current_law_version()
         parameters = sorted(parameters_set)
         syr = Policy.JSON_START_YEAR
@@ -387,6 +389,10 @@ class Policy(ParametersBase):
                 if isinstance(vval, six.string_types):
                     if vval == 'default':
                         vvalue = getattr(clp, pname)
+                        if vop == 'min':
+                            vvalue -= rounding_error
+                        elif vop == 'max':
+                            vvalue += rounding_error
                     else:
                         vvalue = getattr(self, vval)
                 else:

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -391,8 +391,11 @@ class Policy(ParametersBase):
                         vvalue = getattr(clp, pname)
                         if vop == 'min':
                             vvalue -= rounding_error
-                        elif vop == 'max':
-                            vvalue += rounding_error
+                        # the follow branch can never be reached, so it
+                        # is commented out because it can never be tested
+                        # (see test_range_infomation in test_policy.py)
+                        # --> elif vop == 'max':
+                        # -->    vvalue += rounding_error
                     else:
                         vvalue = getattr(self, vval)
                 else:

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -798,13 +798,17 @@ def test_range_infomation(tests_path):
         range = param.get('range', None)
         if range:
             json_range_params.add(pname)
-            assert param['out_of_range_action'] in warn_stop_list
+            oor_action = param['out_of_range_action']
+            assert oor_action in warn_stop_list
             range_items = range.items()
             assert len(range_items) == 2
             for vop, vval in range_items:
                 assert vop in min_max_list
                 if isinstance(vval, six.string_types):
                     if vval == 'default':
+                        if vop != 'min' or oor_action != 'warn':
+                            msg = 'USES DEFAULT FOR min OR FOR error'
+                            assert pname == msg
                         continue
                     elif vval in clpdict:
                         if vop == 'min':
@@ -880,6 +884,14 @@ def test_validate_param_values_warnings_errors():
     ref6 = {2026: {'_ID_BenefitSurtax_Switch': [[False, True, 0, 2, 0, 1, 0]]}}
     pol6.implement_reform(ref6)
     assert len(pol6.reform_errors) > 0
+    # raise stdded for everybody but widows, leaving widow value unchanged,
+    # which is the logic TaxBrain has been using at least until 2017-10-05
+    # when this "7" test was added
+    pol7 = Policy()
+    ref7 = {2013: {'_STD': [[20000, 20000, 20000, 20000, 12200]]}}
+    pol7.implement_reform(ref7)
+    assert pol7.reform_errors == ''
+    assert pol7.reform_warnings == ''
 
 
 def test_indexing_rates_for_update():


### PR DESCRIPTION
This pull request fixes a bug that was revealed in the discussion of PolicyBrain issue 638 beginning with [this recent comment](https://github.com/OpenSourcePolicyCenter/PolicyBrain/issues/638#issuecomment-333980937).  That discussion describes the bug, which arises only when a TaxBrain user implements a reform before 2017 using either the `_STD` and `_STD_Dep` parameters.

This Tax-Calculator "bug" is caused by the fact that TaxBrain does not allow users to specify the value of either of these two parameters for widow filing units, and then makes a poor guess about what the TaxBrain user would want the reformed widow value to be.  TaxBrain's guessing is poor because it guesses that the user wants to leave the widow value unchanged even though the user is changing the parameter values for other filing unit types.  A much better guess would be to set the widow value to the joint value, which is the case in most filing-unit-indexed parameters under current-law.  There are only a few cases where the widow value is not equal to the joint value, and in all of those case, the widow value is equal to the single value under current law.

Another pull request could  add for the 49 filing-unit-indexed parameters in the `current_law_policy.json` file a new field that would look like this in most cases:
```
        "widow_value": "joint_value",
```
and look like this in the other cases:
```
        "widow_value": "single_value",
```
This additional information would allow TaxBrain to make a much better guess than it is now making about what value a TaxBrain user wants for widows.

Of course, the most logical approach would be to add widow boxes to the TaxBrain input GUI so that users could actually specify what parameter value widows should have.  And this approach would actually simplify both TaxBrain and Tax-Calculator logic, in comparison to the making-a-better-guess approach outlined above.

@MattHJensen @feenberg @Amy-Xu @andersonfrailey @hdoupe @GoFroggyRun 