### PR TITLE
Resolve issue 304 regarding Calculator constructor logic

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -97,11 +97,11 @@ class Calculator(object):
                  sync_years=True, consumption=None, behavior=None):
         # pylint: disable=too-many-arguments,too-many-branches
         if isinstance(policy, Policy):
-            self.policy = policy
+            self.policy = copy.deepcopy(policy)
         else:
             raise ValueError('must specify policy as a Policy object')
         if isinstance(records, Records):
-            self.records = records
+            self.records = copy.deepcopy(records)
         else:
             raise ValueError('must specify records as a Records object')
         if self.policy.current_year < self.records.data_year:
@@ -109,7 +109,7 @@ class Calculator(object):
         if consumption is None:
             self.consumption = Consumption(start_year=policy.start_year)
         elif isinstance(consumption, Consumption):
-            self.consumption = consumption
+            self.consumption = copy.deepcopy(consumption)
             while self.consumption.current_year < self.policy.current_year:
                 next_year = self.consumption.current_year + 1
                 self.consumption.set_year(next_year)
@@ -118,7 +118,7 @@ class Calculator(object):
         if behavior is None:
             self.behavior = Behavior(start_year=policy.start_year)
         elif isinstance(behavior, Behavior):
-            self.behavior = behavior
+            self.behavior = copy.deepcopy(behavior)
             while self.behavior.current_year < self.policy.current_year:
                 next_year = self.behavior.current_year + 1
                 self.behavior.set_year(next_year)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -41,47 +41,29 @@ class Calculator(object):
     Parameters
     ----------
     policy: Policy class object
-        this argument must be specified
-        IMPORTANT NOTE: never pass the same Policy object to more than one
-        Calculator.  In other words, when specifying more
-        than one Calculator object, do this::
-
-            pol1 = Policy()
-            rec1 = Records()
-            calc1 = Calculator(policy=pol1, records=rec1)
-            pol2 = Policy()
-            rec2 = Records()
-            calc2 = Calculator(policy=pol2, records=rec2)
+        this argument must be specified and object is copied for internal use
 
     records: Records class object
-        this argument must be specified
-        IMPORTANT NOTE: never pass the same Records object to more than one
-        Calculator.  In other words, when specifying more
-        than one Calculator object, do this::
-
-            pol1 = Policy()
-            rec1 = Records()
-            calc1 = Calculator(policy=pol1, records=rec1)
-            pol2 = Policy()
-            rec2 = Records()
-            calc2 = Calculator(policy=pol2, records=rec2)
+        this argument must be specified and object is copied for internal use
 
     verbose: boolean
         specifies whether or not to write to stdout data-loaded and
         data-extrapolated progress reports; default value is true.
 
     sync_years: boolean
-        specifies whether or not to syncronize policy year and records year;
+        specifies whether or not to synchronize policy year and records year;
         default value is true.
 
     consumption: Consumption class object
         specifies consumption response assumptions used to calculate
         "effective" marginal tax rates; default is None, which implies
-        no consumption responses assumed in marginal tax rate calculations.
+        no consumption responses assumed in marginal tax rate calculations;
+        when argument is an object it is copied for internal use
 
     behavior: Behavior class object
-        specifies behaviorial responses used by Calculator; default is None,
-        which implies no behavioral responses to policy reform.
+        specifies behavioral responses used by Calculator; default is None,
+        which implies no behavioral responses to policy reform;
+        when argument is an object it is copied for internal use
 
     Raises
     ------
@@ -91,6 +73,18 @@ class Calculator(object):
     Returns
     -------
     class instance: Calculator
+
+    Notes
+    -----
+    The most efficient way to specify current-law and reform Calculator
+    objects is as follows:
+         pol = Policy()
+         rec = Records()
+         calc1 = Calculator(policy=pol, records=rec)  # current-law
+         pol.implement_reform(...)
+         calc2 = Calculator(policy=pol, records=rec)  # reform
+    All calculations are done on the internal copies of the Policy and
+    Records objects passed to each of the two Calculator constructors.
     """
 
     def __init__(self, policy=None, records=None, verbose=True,

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -5,7 +5,7 @@ import pytest
 from taxcalc import Policy, Records, Calculator, Behavior
 
 
-def test_incorrect_Behavior_instantiation():
+def test_incorrect_behavior_instantiation():
     with pytest.raises(ValueError):
         Behavior(behavior_dict=list())
     bad_behv_dict = {
@@ -37,74 +37,83 @@ def test_incorrect_Behavior_instantiation():
         Behavior(behavior_dict=bad_behv_dict)
 
 
-def test_behavioral_response_Calculator(cps_subsample):
-    # create Records objects
-    records_x = Records.cps_constructor(data=cps_subsample)
-    records_y = Records.cps_constructor(data=cps_subsample)
-    year = records_x.current_year
-    # create Policy objects
-    policy_x = Policy()
-    policy_y = Policy()
-    # implement policy_y reform
+def test_behavioral_response_calculator(cps_subsample):
+    # create Records object
+    rec = Records.cps_constructor(data=cps_subsample)
+    year = rec.current_year
+    # create Policy object
+    pol = Policy()
+    # create current-law Calculator object
+    calc1 = Calculator(policy=pol, records=rec)
+    # implement policy reform
     reform = {year: {'_II_rt7': [0.496],
                      '_PT_rt7': [0.496]}}
-    policy_y.implement_reform(reform)
-    # create two Calculator objects
-    behavior_y = Behavior()
-    calc_x = Calculator(policy=policy_x, records=records_x)
-    calc_y = Calculator(policy=policy_y, records=records_y,
-                        behavior=behavior_y)
+    pol.implement_reform(reform)
+    # create reform Calculator object with no behavioral response
+    behv = Behavior()
+    calc2 = Calculator(policy=pol, records=rec, behavior=behv)
     # test incorrect use of Behavior._mtr_xy method
     with pytest.raises(ValueError):
-        behv = Behavior._mtr_xy(calc_x, calc_y,
-                                mtr_of='e00200p',
-                                tax_type='nonsense')
-    # vary substitution and income effects in calc_y
+        Behavior._mtr_xy(calc1, calc2, mtr_of='e00200p', tax_type='nonsense')
+    # vary substitution and income effects in Behavior object
     behavior0 = {year: {'_BE_sub': [0.0],
                         '_BE_cg': [0.0],
                         '_BE_charity': [[0.0, 0.0, 0.0]]}}
-    behavior_y.update_behavior(behavior0)
-    calc_y_behavior0 = Behavior.response(calc_x, calc_y)
+    behv0 = Behavior()
+    behv0.update_behavior(behavior0)
+    calc2 = Calculator(policy=pol, records=rec, behavior=behv0)
+    assert calc2.behavior.has_response() is False
+    calc2_behv0 = Behavior.response(calc1, calc2)
     behavior1 = {year: {'_BE_sub': [0.3], '_BE_inc': [-0.1], '_BE_cg': [0.0],
                         '_BE_subinc_wrt_earnings': [True]}}
-    behavior_y.update_behavior(behavior1)
-    assert behavior_y.has_response() is True
+    behv1 = Behavior()
+    behv1.update_behavior(behavior1)
+    calc2 = Calculator(policy=pol, records=rec, behavior=behv1)
+    assert calc2.behavior.has_response() is True
     epsilon = 1e-9
-    assert abs(behavior_y.BE_sub - 0.3) < epsilon
-    assert abs(behavior_y.BE_inc - -0.1) < epsilon
-    assert abs(behavior_y.BE_cg - 0.0) < epsilon
-    calc_y_behavior1 = Behavior.response(calc_x, calc_y)
+    assert abs(calc2.behavior.BE_sub - 0.3) < epsilon
+    assert abs(calc2.behavior.BE_inc - -0.1) < epsilon
+    assert abs(calc2.behavior.BE_cg - 0.0) < epsilon
+    calc2_behv1 = Behavior.response(calc1, calc2)
     behavior2 = {year: {'_BE_sub': [0.5], '_BE_cg': [-0.8]}}
-    behavior_y.update_behavior(behavior2)
-    calc_y_behavior2 = Behavior.response(calc_x, calc_y)
+    behv2 = Behavior()
+    behv2.update_behavior(behavior2)
+    calc2 = Calculator(policy=pol, records=rec, behavior=behv2)
+    assert calc2.behavior.has_response() is True
+    calc2_behv2 = Behavior.response(calc1, calc2)
     behavior3 = {year: {'_BE_inc': [-0.2], '_BE_cg': [-0.8]}}
-    behavior_y.update_behavior(behavior3)
-    calc_y_behavior3 = Behavior.response(calc_x, calc_y)
+    behv3 = Behavior()
+    behv3.update_behavior(behavior3)
+    calc2 = Calculator(policy=pol, records=rec, behavior=behv3)
+    assert calc2.behavior.has_response() is True
+    calc2_behv3 = Behavior.response(calc1, calc2)
     behavior4 = {year: {'_BE_cg': [-0.8]}}
-    behavior_y.update_behavior(behavior4)
-    calc_y_behavior4 = Behavior.response(calc_x, calc_y)
+    behv4 = Behavior()
+    behv4.update_behavior(behavior4)
+    calc2 = Calculator(policy=pol, records=rec, behavior=behv4)
+    assert calc2.behavior.has_response() is True
+    calc2_behv4 = Behavior.response(calc1, calc2)
     behavior5 = {year: {'_BE_charity': [[-0.5, -0.5, -0.5]]}}
-    behavior_y.update_behavior(behavior5)
-    calc_y_behavior5 = Behavior.response(calc_x, calc_y)
+    behv5 = Behavior()
+    behv5.update_behavior(behavior5)
+    calc2 = Calculator(policy=pol, records=rec, behavior=behv5)
+    assert calc2.behavior.has_response() is True
+    calc2_behv5 = Behavior.response(calc1, calc2)
     # check that total income tax liability differs across the
     # six sets of behavioral-response elasticities
-    assert (calc_y_behavior0.records.iitax.sum() !=
-            calc_y_behavior1.records.iitax.sum() !=
-            calc_y_behavior2.records.iitax.sum() !=
-            calc_y_behavior3.records.iitax.sum() !=
-            calc_y_behavior4.records.iitax.sum() !=
-            calc_y_behavior5.records.iitax.sum())
-    # test incorrect _mtr_xy() usage
-    with pytest.raises(ValueError):
-        Behavior._mtr_xy(calc_x, calc_y, mtr_of='e00200p', tax_type='?')
+    assert (calc2_behv0.records.iitax.sum() !=
+            calc2_behv1.records.iitax.sum() !=
+            calc2_behv2.records.iitax.sum() !=
+            calc2_behv3.records.iitax.sum() !=
+            calc2_behv4.records.iitax.sum() !=
+            calc2_behv5.records.iitax.sum())
 
 
 def test_correct_update_behavior():
     beh = Behavior(start_year=2013)
     beh.update_behavior({2014: {'_BE_sub': [0.5]},
                          2015: {'_BE_cg': [-1.2]},
-                         2016: {'_BE_charity':
-                         [[-0.5, -0.5, -0.5]]}})
+                         2016: {'_BE_charity': [[-0.5, -0.5, -0.5]]}})
     should_be = np.full((Behavior.DEFAULT_NUM_YEARS,), 0.5)
     should_be[0] = 0.0
     assert np.allclose(beh._BE_sub, should_be, rtol=0.0)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -732,6 +732,9 @@ def test_multiyear_diagnostic_table(cps_subsample):
     adt = multiyear_diagnostic_table(calc, 3)
     assert isinstance(adt, pd.DataFrame)
     behv.update_behavior({2013: {'_BE_sub': [0.3]}})
+    calc = Calculator(policy=Policy(),
+                      records=Records.cps_constructor(data=cps_subsample),
+                      behavior=behv)
     assert calc.behavior.has_response()
     adt = multiyear_diagnostic_table(calc, 3)
     assert isinstance(adt, pd.DataFrame)


### PR DESCRIPTION
This issue resolves issue #304 by revising the Calculator class constructor logic so that deep copies of the specified Policy and Records objects are assigned to the internal class policy and records attributes.  In the same spirit as #304, the Calculator constructor now also makes a deep copy of Behavior objects and Consumption objects specified in the constructor call.

The reason for doing this is the reason highlighted in issue #304: the Calculator object should not cause side effects for the Policy or Records (or Behavior or Consumption) objects passed to the Calculator constructor.

However, there is another significant benefit from making these changes: the new idiom for creating current-law and reform Calculator objects is noticeably faster that the approach used now.  The execution times cited below indicate a 35 percent reduction in execution time for a typical analysis situation.

One implication of these changes is that typical current usage of Behavior objects in Calculator objects may need to change in order to get correct behavior.  One example of a needed change would be the behavioral-effect notebook.  Part of this pull request is to make logically necessary changes in the use of a Behavior object in a Calculator object.

Another implication of these changes is that typical non-Behavior instantiation of current-law and reform Calculator objects is correct by inefficient (that is, does not automatically get the significant execution speed up mentioned above and described in detail below).  A subsequent pull request will change the TaxCalcIO (tc) and TaxBrain Interfact (tbi) code, as well as the pytest unit tests, to use the new more efficient Calculator constructor idiom.

Here is the script used to generate the execution times (OLD_IDIOM was set to True on the master branch and set to False on this development branch).
```
"""
Timings before and after resolve-issue-304 changes.
"""
import time
from taxcalc import Policy, Records, Calculator

REFORM_YEAR = 2018
REFORM = {REFORM_YEAR: {'_SS_Earnings_c': [9e99]}}

OLD_IDIOM = False

EXEC_TIMES = list()
for iteration in range(0, 4):
    start_time = time.time()

    if OLD_IDIOM:
        rec1 = Records.cps_constructor()
        pol1 = Policy()
        calc1 = Calculator(policy=pol1, records=rec1, verbose=False)
        rec2 = Records.cps_constructor()
        pol2 = Policy()
        pol2.implement_reform(REFORM)
        calc2 = Calculator(policy=pol2, records=rec2, verbose=False)
    else:
        rec = Records.cps_constructor()
        pol = Policy()
        calc1 = Calculator(policy=pol, records=rec, verbose=False)
        pol.implement_reform(REFORM)
        calc2 = Calculator(policy=pol, records=rec, verbose=False)

    calc1.advance_to_year(REFORM_YEAR)
    calc2.advance_to_year(REFORM_YEAR)

    calc1.calc_all()
    calc2.calc_all()

    taxrev1 = (calc1.records.combined * calc1.records.s006).sum() * 1e-9
    taxrev2 = (calc2.records.combined * calc2.records.s006).sum() * 1e-9

    print('iter,taxrev1,taxrev2($B)= {} {:.3f} {:.3f}'.format(
        iteration + 1, taxrev1, taxrev2))

    end_time = time.time()
    exec_time = end_time - start_time
    if iteration > 0:
        EXEC_TIMES.append(exec_time)
    print('iter,total_exec_time(secs)= {} {:.2f}'.format(
        iteration + 1, end_time - start_time))

SUM_EXEC_TIMES = 0.0
for etime in EXEC_TIMES:
    SUM_EXEC_TIMES += etime
print('OLD_IDION,average_exec_time(secs)= {} {:.2f}'.format(
    OLD_IDIOM, SUM_EXEC_TIMES/len(EXEC_TIMES)))
```
The results of running this script are as follows:
```
ON MASTER BRANCH:
$ python issue_304_timing.py
iter,taxrev1,taxrev2($B)= 1 2551.551 2682.908
iter,total_exec_time(secs)= 1 29.59
iter,taxrev1,taxrev2($B)= 2 2551.551 2682.908
iter,total_exec_time(secs)= 2 15.49
iter,taxrev1,taxrev2($B)= 3 2551.551 2682.908
iter,total_exec_time(secs)= 3 15.50
iter,taxrev1,taxrev2($B)= 4 2551.551 2682.908
iter,total_exec_time(secs)= 4 15.47
OLD_IDION,average_exec_time(secs)= True 15.49

ON DEVELOPMENT BRANCH:
$ python issue_304_timing.py
iter,taxrev1,taxrev2($B)= 1 2551.551 2682.908
iter,total_exec_time(secs)= 1 23.81
iter,taxrev1,taxrev2($B)= 2 2551.551 2682.908
iter,total_exec_time(secs)= 2 10.00
iter,taxrev1,taxrev2($B)= 3 2551.551 2682.908
iter,total_exec_time(secs)= 3 9.90
iter,taxrev1,taxrev2($B)= 4 2551.551 2682.908
iter,total_exec_time(secs)= 4 9.96
OLD_IDION,average_exec_time(secs)= False 9.95
```



