### PR TITLE
Add docs/contributing.md file

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,25 @@
+Guidelines for Contributing to Tax-Calculator
+=============================================
+
+Reporting a bug
+---------------
+In a new issue, provide details on what you think is wrong with
+Tax-Calculator.  Clarify your bug report by giving a concrete example
+in which Tax-Calculator produces a result that you consider incorrect
+and explain what the correct answer is.
+
+Requesting an enhancement
+-------------------------
+In a new issue, provide a description of what you think should be added
+to Tax-Calculator.  Be sure to clarify your request by explaining what
+enhancement would allow users to do that they cannot do without the
+enhancement.
+
+Proposing code changes
+----------------------
+In a new pull request, provide a clear description of the rationale
+and nature of the code changes.  Make sure that your proposed changes
+are consistent with our [coding
+style](https://github.com/open-source-economics/Tax-Calculator/blob/master/CODING.md)
+and our [testing
+procedures](https://github.com/open-source-economics/Tax-Calculator/blob/master/TESTING.md).


### PR DESCRIPTION
This kind of documentation is recommended by GitHub for every repository as can be seen here:

![screen shot 2017-10-18 at 10 20 59 am](https://user-images.githubusercontent.com/12170745/31723912-2b7dda1e-b3ee-11e7-922a-49dd7ac7ecd6.png)

[Here](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) is how it works.