### PR TITLE
Include taxcalc/tbi/*.py files in code coverage calculations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,5 +4,6 @@ omit =
     taxcalc/functions.py
     taxcalc/*.json
     taxcalc/cli/*
+    taxcalc/tbi/*
     taxcalc/tests/*
     taxcalc/validation/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,5 @@ omit =
     taxcalc/functions.py
     taxcalc/*.json
     taxcalc/cli/*
-    taxcalc/tbi/*
     taxcalc/tests/*
     taxcalc/validation/*

--- a/taxcalc/tbi/tbi_utils.py
+++ b/taxcalc/tbi/tbi_utils.py
@@ -115,8 +115,8 @@ def calculate(year_n, start_year,
         # first try Tax-Calculator code path
         input_path = os.path.join(tbi_path, '..', 'cps.csv.gz')
         if not os.path.isfile(input_path):
-            # otherwise try taxcalc package path
-            input_path = None
+            # otherwise read from taxcalc package "egg"
+            input_path = None  # pragma: no cover
             full_sample = read_egg_csv('cps.csv.gz')  # pragma: no cover
         sampling_frac = 0.05  # TODO: using same as for puf for now
         sampling_seed = 180  # TODO: using same as for puf for now

--- a/taxcalc/tests/test_tbi.py
+++ b/taxcalc/tests/test_tbi.py
@@ -108,7 +108,7 @@ def test_run_tax_calc_model(resdict):
 
 @pytest.mark.requires_pufcsv
 @pytest.mark.parametrize('resdict', [True, False])
-def test_run_gdp_elast_model(resdict):
+def test_run_gdp_elast_model_1(resdict):
     usermods = USER_MODS
     usermods['behavior'] = dict()
     res = run_nth_year_gdp_elast_model(2, 2016,
@@ -121,6 +121,18 @@ def test_run_gdp_elast_model(resdict):
         assert isinstance(res, dict)
     else:
         assert isinstance(res, float)
+
+
+def test_run_gdp_elast_model_2():
+    usermods = USER_MODS
+    usermods['behavior'] = dict()
+    res = run_nth_year_gdp_elast_model(0, 2014,  # forces no automatic zero
+                                       use_puf_not_cps=False,
+                                       use_full_sample=False,
+                                       user_mods=usermods,
+                                       gdp_elasticity=0.36,
+                                       return_dict=False)
+    assert res == 0.0
 
 
 def test_random_seed_from_subdict():


### PR DESCRIPTION
This pull request includes, for the first time, the files in the `taxcalc/tbi` directory in the code test coverage calculations.  In order to maintain complete code coverage, another test was added to the `taxcalc/tests/test_tbi.py` file and one statement in the `tbi_utils.py` file was omitted from the coverage calculations because reading from the taxcalc package "egg" is not testable.

This pull request contains no changes in tax-calculating code or in tax results.