### PR TITLE
Break up DependentCredit

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -3404,7 +3404,7 @@
 
     "_DependentCredit_c": {
         "long_name": "Nonrefundable credit for dependents",
-        "description": "This nonrefundable credit is applied to dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
+        "description": "This nonrefundable credit is applied to (child and non-child) dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
         "section_1": "Nonrefundable Credits",
         "section_2": "Child Tax Credit",
         "irs_ref": "",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -3401,6 +3401,29 @@
         "out_of_range_action": "stop"
     },
 
+
+    "_DependentCredit_c": {
+        "long_name": "Nonrefundable credit for dependents",
+        "description": "This nonrefundable credit is applied to dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
+        "section_1": "Nonrefundable Credits",
+        "section_2": "Child Tax Credit",
+        "irs_ref": "",
+        "notes": "The Ryan-Brady tax proposal sets this at $500",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "start_year": 2013,
+        "cpi_inflated": false,
+        "col_var": "",
+        "col_label": "",
+        "boolean_value": false,
+        "integer_value": false,
+        "value": [0.0],
+        "range": {"min": 0, "max": 9e99},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
+
     "_DependentCredit_Child_c": {
         "long_name": "Nonrefundable credit for children, on top of the child tax credit",
         "description": "This nonrefundable credit is applied to children and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -3401,13 +3401,35 @@
         "out_of_range_action": "stop"
     },
 
-    "_DependentCredit_c": {
-        "long_name": "Nonrefundable credit for dependents",
-        "description": "This nonrefundable credit is applied to dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
+    "_DependentCredit_Child_c": {
+        "long_name": "Nonrefundable credit for children, on top of the child tax credit",
+        "description": "This nonrefundable credit is applied to children and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
         "section_1": "Nonrefundable Credits",
         "section_2": "Child Tax Credit",
         "irs_ref": "",
-        "notes": "The Ryan-Brady tax plan sets this at $500",
+        "notes": "The November 2017 tax framework sets this at $600",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "start_year": 2013,
+        "cpi_inflated": false,
+        "col_var": "",
+        "col_label": "",
+        "boolean_value": false,
+        "integer_value": false,
+        "value": [0.0],
+        "range": {"min": 0, "max": 9e99},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
+
+    "_DependentCredit_Nonchild_c": {
+        "long_name": "Nonrefundable credit for non-child dependents",
+        "description": "This nonrefundable credit is applied to non-child dependents and phases out with the Child Tax Credit. The dependent credit's phaseout begins when the CTC's phaseout ends.",
+        "section_1": "Nonrefundable Credits",
+        "section_2": "Child Tax Credit",
+        "irs_ref": "",
+        "notes": "The November 2017 tax framework sets this at $300",
         "row_var": "FLPDYR",
         "row_label": ["2013"],
         "start_year": 2013,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1100,7 +1100,7 @@ def ChildTaxCredit(n24, MARS, c00100, exact,
                    CTC_c, CTC_ps, CTC_prt, prectc, nu05,
                    CTC_c_under5_bonus, XTOT, num,
                    DependentCredit_Child_c, DependentCredit_Nonchild_c,
-                   dep_credit):
+                   DependentCredit_c, dep_credit):
     """
     ChildTaxCredit function computes prectc amount and dependent credit
     """
@@ -1113,7 +1113,8 @@ def ChildTaxCredit(n24, MARS, c00100, exact,
             excess = 1000. * math.ceil(excess / 1000.)
         prectc = max(0., prectc - CTC_prt * excess)
     # calculate and phase-out dependent credit
-    dep_credit = (DependentCredit_Child_c * n24 +
+    dep_credit = (DependentCredit_c * max(0, XTOT - num) +
+                  DependentCredit_Child_c * n24 +
                   DependentCredit_Nonchild_c * max(0, XTOT - n24 - num))
     if CTC_prt > 0. and c00100 > CTC_ps[MARS - 1]:
         thresh = CTC_ps[MARS - 1] + n24 * CTC_c / CTC_prt

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1099,7 +1099,8 @@ def EITC(MARS, DSI, EIC, c00100, e00300, e00400, e00600, c01000,
 def ChildTaxCredit(n24, MARS, c00100, exact,
                    CTC_c, CTC_ps, CTC_prt, prectc, nu05,
                    CTC_c_under5_bonus, XTOT, num,
-                   DependentCredit_c, dep_credit):
+                   DependentCredit_Child_c, DependentCredit_Nonchild_c,
+                   dep_credit):
     """
     ChildTaxCredit function computes prectc amount and dependent credit
     """
@@ -1112,7 +1113,8 @@ def ChildTaxCredit(n24, MARS, c00100, exact,
             excess = 1000. * math.ceil(excess / 1000.)
         prectc = max(0., prectc - CTC_prt * excess)
     # calculate and phase-out dependent credit
-    dep_credit = DependentCredit_c * max(0, XTOT - num)
+    dep_credit = (DependentCredit_Child_c * n24 +
+                  DependentCredit_Nonchild_c * max(0, XTOT - n24 - num))
     if CTC_prt > 0. and c00100 > CTC_ps[MARS - 1]:
         thresh = CTC_ps[MARS - 1] + n24 * CTC_c / CTC_prt
         excess = c00100 - thresh

--- a/taxcalc/reforms/RyanBrady.json
+++ b/taxcalc/reforms/RyanBrady.json
@@ -72,9 +72,7 @@
             {"2017": [[0, 0, 0, 0, 0]]},
         "_II_em":
             {"2017": [0]},
-        "_DependentCredit_Child_c":
-            {"2017": [500]},
-        "_DependentCredit_Nonchild_c":
+        "_DependentCredit_c":
             {"2017": [500]},
         "_CTC_ps":
             {"2017": [[75000, 150000, 75000, 75000, 75000]]},

--- a/taxcalc/reforms/RyanBrady.json
+++ b/taxcalc/reforms/RyanBrady.json
@@ -72,7 +72,9 @@
             {"2017": [[0, 0, 0, 0, 0]]},
         "_II_em":
             {"2017": [0]},
-        "_DependentCredit_c":
+        "_DependentCredit_Child_c":
+            {"2017": [500]},
+        "_DependentCredit_Nonchild_c":
             {"2017": [500]},
         "_CTC_ps":
             {"2017": [[75000, 150000, 75000, 75000, 75000]]},


### PR DESCRIPTION
This splits the non-refundable dependent credit into two parts, one for children and one for non-child dependents. The original version was intended to implement the Brady-Ryan proposal from 2016, which increased the  CTC cap by $500 (with the new portion non-refundable) and created a $500 non-refundable credit for non-child dependents. 

The new GOP tax plan appears to expand the CTC by $600 and create a $300 non-refundable credit for non-child dependents. If the CTC expansion is non-refundable then it should be implemented with the _DependentCredit_Child_c variable. Otherwise, it should be done by changing the CTC cap. 