### PR TITLE
pandas 0.21.0 compatibility part 2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,6 +24,9 @@ for a complete commit history.
 - Resolve compatibility issues with Pandas 0.21.0
   [[#1629](https://github.com/open-source-economics/Tax-Calculator/pull/1629)
   by Hank Doupe]
+- Cleaner solution to compatibility issues with Pandas 0.21.0
+  [[#1634](https://github.com/open-source-economics/Tax-Calculator/pull/1634)
+  by Hank Doupe]
 
 
 2017-10-20 Release 0.12.0

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -11,7 +11,11 @@ from taxcalc.utils import *
 from taxcalc.macro_elasticity import *
 from taxcalc.tbi import *
 from taxcalc.cli import *
+import pandas as pd
 
 from taxcalc._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+# zsum is defined in utils.py
+pd.Series.zsum = zsum

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -126,6 +126,16 @@ SMALL_INCOME_BINS = [-9e99, 0, 4999, 9999, 14999, 19999, 24999, 29999, 39999,
                      1999999, 4999999, 9999999, 9e99]
 
 
+def zsum(self):
+    """
+    pandas 0.21.0 changes sum() behavior so that the result of applying sum
+    over an empty DataFrame is NaN. Since we apply the sum function over
+    grouped DataFrames that may or not be empty, it makes more sense for us
+    to have a sum() function that returns 0 instead of NaN.
+    """
+    return self.sum() if len(self) > 0 else 0
+
+
 def unweighted_sum(pdf, col_name):
     """
     Return unweighted sum of Pandas DataFrame col_name items.

--- a/taxcalc/utilsprvt.py
+++ b/taxcalc/utilsprvt.py
@@ -17,8 +17,7 @@ def weighted_count_lt_zero(pdf, col_name, tolerance=-0.001):
     If condition is not met by any items, the result of applying sum to an
     empty dataframe is NaN.  This is undesirable and 0 is returned instead.
     """
-    res = pdf[pdf[col_name] < tolerance]['s006'].sum()
-    return res if not np.isnan(res) else 0
+    return pdf[pdf[col_name] < tolerance]['s006'].zsum()
 
 
 def weighted_count_gt_zero(pdf, col_name, tolerance=0.001):
@@ -27,15 +26,14 @@ def weighted_count_gt_zero(pdf, col_name, tolerance=0.001):
     If condition is not met by any items, the result of applying sum to an
     empty dataframe is NaN.  This is undesirable and 0 is returned instead.
     """
-    res = pdf[pdf[col_name] > tolerance]['s006'].sum()
-    return res if not np.isnan(res) else 0
+    return pdf[pdf[col_name] > tolerance]['s006'].zsum()
 
 
 def weighted_count(pdf):
     """
     Return weighted count of items in Pandas DataFrame.
     """
-    return pdf['s006'].sum()
+    return pdf['s006'].zsum()
 
 
 def weighted_mean(pdf, col_name):
@@ -43,8 +41,8 @@ def weighted_mean(pdf, col_name):
     Return weighted mean of Pandas DataFrame col_name items.
     """
     if len(pdf) > 0:
-        return ((pdf[col_name] * pdf['s006']).sum() /
-                (pdf['s006'].sum() + EPSILON))
+        return ((pdf[col_name] * pdf['s006']).zsum() /
+                (pdf['s006'].zsum() + EPSILON))
     else:
         return 0
 
@@ -55,8 +53,8 @@ def wage_weighted(pdf, col_name):
     """
     swght = 's006'
     wage = 'e00200'
-    return (((pdf[col_name] * pdf[swght] * pdf[wage]).sum()) /
-            ((pdf[swght] * pdf[wage]).sum() + EPSILON))
+    return (((pdf[col_name] * pdf[swght] * pdf[wage]).zsum()) /
+            ((pdf[swght] * pdf[wage]).zsum() + EPSILON))
 
 
 def agi_weighted(pdf, col_name):
@@ -65,8 +63,8 @@ def agi_weighted(pdf, col_name):
     """
     swght = 's006'
     agi = 'c00100'
-    return ((pdf[col_name] * pdf[swght] * pdf[agi]).sum() /
-            ((pdf[swght] * pdf[agi]).sum() + EPSILON))
+    return ((pdf[col_name] * pdf[swght] * pdf[agi]).zsum() /
+            ((pdf[swght] * pdf[agi]).zsum() + EPSILON))
 
 
 def expanded_income_weighted(pdf, col_name):
@@ -75,8 +73,8 @@ def expanded_income_weighted(pdf, col_name):
     """
     swght = 's006'
     expinc = 'expanded_income'
-    return ((pdf[col_name] * pdf[swght] * pdf[expinc]).sum() /
-            ((pdf[swght] * pdf[expinc]).sum() + EPSILON))
+    return ((pdf[col_name] * pdf[swght] * pdf[expinc]).zsum() /
+            ((pdf[swght] * pdf[expinc]).zsum() + EPSILON))
 
 
 def weighted_perc_inc(pdf, col_name):

--- a/taxcalc/utilsprvt.py
+++ b/taxcalc/utilsprvt.py
@@ -40,11 +40,8 @@ def weighted_mean(pdf, col_name):
     """
     Return weighted mean of Pandas DataFrame col_name items.
     """
-    if len(pdf) > 0:
-        return ((pdf[col_name] * pdf['s006']).zsum() /
-                (pdf['s006'].zsum() + EPSILON))
-    else:
-        return 0
+    return ((pdf[col_name] * pdf['s006']).zsum() /
+            (pdf['s006'].zsum() + EPSILON))
 
 
 def wage_weighted(pdf, col_name):


### PR DESCRIPTION
This implements a cleaner solution to pandas 0.21.0 compatibility issue #1628 that was initially addressed by PR #1629. The approach here was advocated in this [comment](https://github.com/pandas-dev/pandas/issues/9422#issuecomment-342515489).  See pandas-dev/pandas#9422 for context.