### PR TITLE
Add CPS with h_seq and ffpos Variables

### DIFF
--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -455,11 +455,23 @@
       "form": {"2013-2016": "6251"},
       "availability": "taxdata_puf"
     },
+    "ffpos":{
+      "type": "int",
+      "desc": "Unique family identifier in the CPS",
+      "form": {},
+      "availability": "taxdata_cps"
+    },
     "filer": {
       "type": "int",
       "desc": "1 if unit files an income tax return; 0 if not (not used in tax-calculation logic)",
       "form": {"2013-2016": "sample construction info"},
       "availability": "taxdata_puf, taxdata_cps"
+    },
+    "h_seq": {
+      "type": "int",
+      "desc": "Household sequence number in the CPS",
+      "form": {},
+      "availability": "taxdata_cps"
     },
     "k1bx14p": {
       "type": "float",


### PR DESCRIPTION
This PR corresponds with TaxData PR [#123](https://github.com/open-source-economics/taxdata/pull/123). I've added the new variables to `records_variables.json` and replaced the CPS file.

cc @MattHJensen 