### PR TITLE
Revise code to eliminate pylint 1.7.4 warnings

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -122,7 +122,7 @@ class Calculator(object):
             if verbose:
                 print('You loaded data for ' +
                       str(self.records.data_year) + '.')
-                if len(self.records.IGNORED_VARS) > 0:
+                if self.records.IGNORED_VARS:
                     print('Your data include the following unused ' +
                           'variables that will be ignored:')
                     for var in self.records.IGNORED_VARS:
@@ -482,13 +482,13 @@ class Calculator(object):
                 first_line = True
                 line_list = list()
                 words = text.split()
-                while len(words) > 0:
+                while words:
                     if first_line:
                         line = ''
                         first_line = False
                     else:
                         line = ' ' * num_indent_spaces
-                    while (len(words) > 0 and
+                    while (words and
                            (len(words[0]) + len(line)) < max_line_length):
                         line += words.pop(0) + ' '
                     line = line[:-1] + '\n'
@@ -572,16 +572,16 @@ class Calculator(object):
         doc = 'REFORM DOCUMENTATION\n'
         doc += 'Baseline Growth-Difference Assumption Values by Year:\n'
         years = sorted(params['growdiff_baseline'].keys())
-        if len(years) == 0:
-            doc += 'none: using default baseline growth assumptions\n'
-        else:
+        if years:
             doc += param_doc(years, params['growdiff_baseline'], gdb)
+        else:
+            doc += 'none: using default baseline growth assumptions\n'
         doc += 'Policy Reform Parameter Values by Year:\n'
         years = sorted(params['policy'].keys())
-        if len(years) == 0:
-            doc += 'none: using current-law policy parameters\n'
-        else:
+        if years:
             doc += param_doc(years, params['policy'], clp)
+        else:
+            doc += 'none: using current-law policy parameters\n'
         return doc
 
     # ----- begin private methods of Calculator class -----

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -114,7 +114,7 @@ def cli_tc_main():
     # instantiate taxcalcio object and do tax analysis
     tcio = TaxCalcIO(input_data=inputfn, tax_year=taxyear,
                      reform=args.reform, assump=args.assump)
-    if len(tcio.errmsg) > 0:
+    if tcio.errmsg:
         sys.stderr.write(tcio.errmsg)
         sys.stderr.write('USAGE: tc --help\n')
         return 1
@@ -124,7 +124,7 @@ def cli_tc_main():
               growdiff_response=None,
               aging_input_data=aging,
               exact_calculations=args.exact)
-    if len(tcio.errmsg) > 0:
+    if tcio.errmsg:
         sys.stderr.write(tcio.errmsg)
         sys.stderr.write('USAGE: tc --help\n')
         return 1

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -54,8 +54,7 @@ class GetReturnNode(ast.NodeVisitor):
         """
         if isinstance(node.value, ast.Tuple):
             return [e.id for e in node.value.elts]
-        else:
-            return [node.value.id]
+        return [node.value.id]
 
 
 def create_apply_function_string(sigout, sigin, parameters):
@@ -192,8 +191,7 @@ def make_apply_function(func, out_args, in_args, parameters,
          {"jitted_f": jitted_f}, fakeglobals)
     if do_jit:
         return jit(**kwargs)(fakeglobals['ap_func'])
-    else:
-        return fakeglobals['ap_func']
+    return fakeglobals['ap_func']
 
 
 def apply_jit(dtype_sig_out, dtype_sig_in, parameters=None, **kwargs):

--- a/taxcalc/docs/make.py
+++ b/taxcalc/docs/make.py
@@ -56,7 +56,7 @@ def policy_param_text(pname, param):
     """
     Extract info from param for pname and return as HTML string.
     """
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,len-as-condition
     sec1 = param['section_1']
     if len(sec1) > 0:
         txt = '<p><b>{} &mdash; {}</b>'.format(sec1, param['section_2'])
@@ -197,6 +197,7 @@ def response_param_text(pname, ptype, param):
     """
     Extract info from param for pname of ptype and return as HTML string.
     """
+    # pylint: disable=len-as-condition
     sec1 = param['section_1']
     if len(sec1) > 0:
         txt = '<p><b>{} &mdash; {}</b>'.format(sec1, param['section_2'])

--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -50,8 +50,6 @@ class Growfactors(object):
         # read grow factors from specified growfactors_filename
         gfdf = pd.DataFrame()
         if isinstance(growfactors_filename, six.string_types):
-            # pylint: disable=redefined-variable-type
-            # (above because pylint mistakenly thinks gfdf is not a DataFrame)
             if os.path.isfile(growfactors_filename):
                 gfdf = pd.read_csv(growfactors_filename,
                                    index_col='YEAR')

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -173,7 +173,7 @@ class Policy(ParametersBase):
         # check that all reform dictionary keys are integers
         if not isinstance(reform, dict):
             raise ValueError('ERROR: reform is not a dictionary')
-        if len(reform) == 0:
+        if not reform:
             return  # no reform to implement
         reform_years = sorted(list(reform.keys()))
         for year in reform_years:
@@ -194,7 +194,7 @@ class Policy(ParametersBase):
             raise ValueError(msg.format(last_reform_year, self.end_year))
         # validate reform parameter names and types
         self._validate_parameter_names_types(reform)
-        if not self._ignore_errors and len(self.reform_errors) > 0:
+        if not self._ignore_errors and self.reform_errors:
             raise ValueError(self.reform_errors)
         # implement the reform year by year
         precall_current_year = self.current_year
@@ -326,7 +326,7 @@ class Policy(ParametersBase):
         # - group params with suffix into param_base:year:suffix dictionary
         gdict = suffix_group_dict(indict)
         # - add to odict the consolidated values for parameters with a suffix
-        if len(gdict) > 0:
+        if gdict:
             odict.update(with_suffix(gdict,
                                      growdiff_baseline_dict,
                                      growdiff_response_dict))
@@ -406,8 +406,7 @@ class Policy(ParametersBase):
                                         '\n'
                                     )
                             else:  # param is neither bool_type nor int_type
-                                if not (isinstance(pvalue[idx], float) or
-                                        isinstance(pvalue[idx], int)):
+                                if not isinstance(pvalue[idx], (float, int)):
                                     msg = '{} {} value {} is not a number'
                                     self.reform_errors += (
                                         'ERROR: ' +
@@ -459,13 +458,13 @@ class Policy(ParametersBase):
                         out_of_range = True
                         msg = '{} {} value {} < min value {}'
                         extra = self._vals[pname]['out_of_range_minmsg']
-                        if len(extra) > 0:
+                        if extra:
                             msg += ' {}'.format(extra)
                     if vop == 'max' and pvalue[idx] > vvalue[idx]:
                         out_of_range = True
                         msg = '{} {} value {} > max value {}'
                         extra = self._vals[pname]['out_of_range_maxmsg']
-                        if len(extra) > 0:
+                        if extra:
                             msg += ' {}'.format(extra)
                     if out_of_range:
                         action = self._vals[pname]['out_of_range_action']
@@ -473,7 +472,7 @@ class Policy(ParametersBase):
                             name = pname
                         else:
                             name = '{}_{}'.format(pname, idx[1])
-                            if len(extra) > 0:
+                            if extra:
                                 msg += '_{}'.format(idx[1])
                         if action == 'warn':
                             self.reform_warnings += (

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -381,7 +381,7 @@ class Records(object):
         Adjust value of income variables to match SOI distributions
         Note: adjustment must leave variables as numpy.ndarray type
         """
-        if len(self.ADJ) != 0:
+        if self.ADJ.size > 0:
             # Interest income
             adj_array = self.ADJ['INT{}'.format(year)][self.agi_bin].values
             self.e00300 *= adj_array
@@ -469,8 +469,6 @@ class Records(object):
         elif isinstance(weights, six.string_types):
             weights_path = os.path.join(Records.CUR_PATH, weights)
             if os.path.isfile(weights_path):
-                # pylint: disable=redefined-variable-type
-                # (above because pylint mistakenly thinks WT not a DataFrame)
                 WT = pd.read_csv(weights_path)
             else:
                 # cannot call read_egg_ function in unit tests
@@ -496,8 +494,6 @@ class Records(object):
         elif isinstance(ratios, six.string_types):
             ratios_path = os.path.join(Records.CUR_PATH, ratios)
             if os.path.isfile(ratios_path):
-                # pylint: disable=redefined-variable-type
-                # (above because pylint mistakenly thinks ADJ not a DataFrame)
                 ADJ = pd.read_csv(ratios_path,
                                   index_col=0)
             else:

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -219,7 +219,7 @@ class TaxCalcIO(object):
             msg = msg.format(tax_year, pol.end_year)
             self.errmsg += 'ERROR: {}\n'.format(msg)
         # any errors imply cannot proceed with calculations
-        if len(self.errmsg) > 0:
+        if self.errmsg:
             return
         # set policy to tax_year
         pol.set_year(tax_year)
@@ -326,7 +326,7 @@ class TaxCalcIO(object):
         """
         # pylint: disable=too-many-arguments,too-many-branches
         # in order to use print(), pylint: disable=superfluous-parens
-        if len(self.calc.policy.reform_warnings) > 0:
+        if self.calc.policy.reform_warnings:
             warn = 'PARAMETER VALUE WARNING(S):   (read documentation)\n{}{}'
             print(warn.format(self.calc.policy.reform_warnings,
                               'CONTINUING WITH CALCULATIONS...'))

--- a/taxcalc/tbi/tbi.py
+++ b/taxcalc/tbi/tbi.py
@@ -200,5 +200,4 @@ def run_nth_year_gdp_elast_model(year_n, start_year,
                                             num_decimals=5)
         gdp_elast_total = dict((k, v[0]) for k, v in gdp_elast_total.items())
         return gdp_elast_total
-    else:
-        return gdp_effect
+    return gdp_effect

--- a/taxcalc/tests/test_cpscsv.py
+++ b/taxcalc/tests/test_cpscsv.py
@@ -96,10 +96,10 @@ def test_agg(tests_path):
         if actline == expline:
             continue
         diffs = line_diff_list(actline, expline, small)
-        if len(diffs) > 0:
+        if diffs:
             diff_lines.extend(diffs)
     # test failure if there are any diff_lines
-    if len(diff_lines) > 0:
+    if diff_lines:
         new_filename = '{}{}'.format(aggres_path[:-10], 'actual.txt')
         with open(new_filename, 'w') as new_file:
             new_file.write(actual_results)

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -82,10 +82,10 @@ def test_json_file_contents(tests_path, fname):
             assert key in param
         # check for non-empty long_name and description strings
         assert isinstance(param['long_name'], six.string_types)
-        if len(param['long_name']) == 0:
+        if not param['long_name']:
             assert '{} long_name'.format(pname) == 'empty string'
         assert isinstance(param['description'], six.string_types)
-        if len(param['description']) == 0:
+        if not param['description']:
             assert '{} description'.format(pname) == 'empty string'
         # check that row_var is FLPDYR
         assert param['row_var'] == 'FLPDYR'

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -59,7 +59,7 @@ def test_agg(tests_path, puf_fullsample):
     for line in diff:
         diff_lines.append(line)
     # test failure if there are any diff_lines
-    if len(diff_lines) > 0:
+    if diff_lines:
         new_filename = '{}{}'.format(aggres_path[:-10], 'actual.txt')
         with open(new_filename, 'w') as new_file:
             new_file.write(adtstr)
@@ -220,7 +220,7 @@ def test_mtr(tests_path, puf_path):
     for line in diff:
         diff_lines.append(line)
     # test failure if there are any diff_lines
-    if len(diff_lines) > 0:
+    if diff_lines:
         new_filename = '{}{}'.format(mtrres_path[:-10], 'actual.txt')
         with open(new_filename, 'w') as new_file:
             new_file.write(res)

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -248,7 +248,7 @@ def test_ctor_errors(input_data, reform, assump):
     """
     tcio = TaxCalcIO(input_data=input_data, tax_year=2013,
                      reform=reform, assump=assump)
-    assert len(tcio.errmsg) > 0
+    assert tcio.errmsg
 
 
 @pytest.mark.parametrize("year, ref, asm, gdr", [
@@ -288,7 +288,7 @@ def test_init_errors(reformfile0, reformfilex1, reformfilex2,
                      tax_year=year,
                      reform=reform,
                      assump=assump)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=recdf,
               tax_year=year,
               reform=reform,
@@ -296,7 +296,7 @@ def test_init_errors(reformfile0, reformfilex1, reformfilex2,
               growdiff_response=gdiff_response,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) > 0
+    assert tcio.errmsg
 
 
 def test_creation_with_aging(rawinputfile, reformfile0):
@@ -308,7 +308,7 @@ def test_creation_with_aging(rawinputfile, reformfile0):
                      tax_year=taxyear,
                      reform=reformfile0.name,
                      assump=None)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=rawinputfile.name,
               tax_year=taxyear,
               reform=reformfile0.name,
@@ -316,14 +316,14 @@ def test_creation_with_aging(rawinputfile, reformfile0):
               growdiff_response=Growdiff(),
               aging_input_data=True,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     assert tcio.tax_year() == taxyear
     taxyear = 2016
     tcio = TaxCalcIO(input_data=rawinputfile.name,
                      tax_year=taxyear,
                      reform=None,
                      assump=None)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=rawinputfile.name,
               tax_year=taxyear,
               reform=None,
@@ -331,7 +331,7 @@ def test_creation_with_aging(rawinputfile, reformfile0):
               growdiff_response=None,
               aging_input_data=True,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     assert tcio.tax_year() == taxyear
 
 
@@ -346,7 +346,7 @@ def test_ctor_init_with_cps_files():
               growdiff_response=None,
               aging_input_data=True,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     assert tcio.tax_year() == txyr
     # specify invalid tax_year for cps.csv input data
     txyr = 2013
@@ -355,7 +355,7 @@ def test_ctor_init_with_cps_files():
               growdiff_response=None,
               aging_input_data=True,
               exact_calculations=False)
-    assert len(tcio.errmsg) > 0
+    assert tcio.errmsg
 
 
 def test_output_otions(rawinputfile, reformfile1, assumpfile1):
@@ -367,7 +367,7 @@ def test_output_otions(rawinputfile, reformfile1, assumpfile1):
                      tax_year=taxyear,
                      reform=reformfile1.name,
                      assump=assumpfile1.name)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=rawinputfile.name,
               tax_year=taxyear,
               reform=reformfile1.name,
@@ -375,7 +375,7 @@ def test_output_otions(rawinputfile, reformfile1, assumpfile1):
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     outfilepath = tcio.output_filepath()
     # --ceeu output and standard output
     try:
@@ -414,7 +414,7 @@ def test_sqldb_option(rawinputfile, reformfile1, assumpfile1):
                      tax_year=taxyear,
                      reform=reformfile1.name,
                      assump=assumpfile1.name)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=rawinputfile.name,
               tax_year=taxyear,
               reform=reformfile1.name,
@@ -422,7 +422,7 @@ def test_sqldb_option(rawinputfile, reformfile1, assumpfile1):
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     outfilepath = tcio.output_filepath()
     dbfilepath = outfilepath.replace('.csv', '.db')
     # --sqldb output
@@ -459,7 +459,7 @@ def test_no_tables_or_graphs(reformfile1):
                      tax_year=2020,
                      reform=reformfile1.name,
                      assump=None)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=idf,
               tax_year=2020,
               reform=reformfile1.name,
@@ -467,7 +467,7 @@ def test_no_tables_or_graphs(reformfile1):
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     # create TaxCalcIO tables file
     tcio.analyze(writing_output_file=False,
                  output_tables=True,
@@ -503,7 +503,7 @@ def test_tables(reformfile1):
                      tax_year=2020,
                      reform=reformfile1.name,
                      assump=None)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=idf,
               tax_year=2020,
               reform=reformfile1.name,
@@ -511,7 +511,7 @@ def test_tables(reformfile1):
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     # create TaxCalcIO tables file
     tcio.analyze(writing_output_file=False, output_tables=True)
     # delete tables file
@@ -539,7 +539,7 @@ def test_graphs(reformfile1):
                      tax_year=2020,
                      reform=reformfile1.name,
                      assump=None)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=idf,
               tax_year=2020,
               reform=reformfile1.name,
@@ -547,7 +547,7 @@ def test_graphs(reformfile1):
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.analyze(writing_output_file=False, output_graphs=True)
     # delete graph files
     output_filename = tcio.output_filepath()
@@ -570,7 +570,7 @@ def test_ceeu_output1(lumpsumreformfile):
                      tax_year=taxyear,
                      reform=lumpsumreformfile.name,
                      assump=None)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=recdf,
               tax_year=taxyear,
               reform=lumpsumreformfile.name,
@@ -578,7 +578,7 @@ def test_ceeu_output1(lumpsumreformfile):
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.analyze(writing_output_file=False, output_ceeu=True)
     assert tcio.tax_year() == taxyear
 
@@ -594,7 +594,7 @@ def test_ceeu_output2():
                      tax_year=taxyear,
                      reform=None,
                      assump=None)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=recdf,
               tax_year=taxyear,
               reform=None,
@@ -602,7 +602,7 @@ def test_ceeu_output2():
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.analyze(writing_output_file=False, output_ceeu=True)
     assert tcio.tax_year() == taxyear
 
@@ -618,7 +618,7 @@ def test_ceeu_with_behavior(lumpsumreformfile, assumpfile2):
                      tax_year=taxyear,
                      reform=lumpsumreformfile.name,
                      assump=assumpfile2.name)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=recdf,
               tax_year=taxyear,
               reform=lumpsumreformfile.name,
@@ -626,7 +626,7 @@ def test_ceeu_with_behavior(lumpsumreformfile, assumpfile2):
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.analyze(writing_output_file=False, output_ceeu=True)
     assert tcio.tax_year() == taxyear
 
@@ -660,7 +660,7 @@ def test_analyze_warnings_print(warnreformfile):
                      tax_year=taxyear,
                      reform=warnreformfile.name,
                      assump=None)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.init(input_data=recdf,
               tax_year=taxyear,
               reform=warnreformfile.name,
@@ -668,7 +668,7 @@ def test_analyze_warnings_print(warnreformfile):
               growdiff_response=None,
               aging_input_data=False,
               exact_calculations=False)
-    assert len(tcio.errmsg) == 0
+    assert not tcio.errmsg
     tcio.analyze(writing_output_file=False, output_ceeu=False)
     assert tcio.tax_year() == taxyear
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -129,11 +129,11 @@ SMALL_INCOME_BINS = [-9e99, 0, 4999, 9999, 14999, 19999, 24999, 29999, 39999,
 def zsum(self):
     """
     pandas 0.21.0 changes sum() behavior so that the result of applying sum
-    over an empty DataFrame is NaN. Since we apply the sum function over
-    grouped DataFrames that may or not be empty, it makes more sense for us
-    to have a sum() function that returns 0 instead of NaN.
+    over an empty Series is NaN.  Since we apply the sum() function over
+    grouped DataFrames that may contain an empty Series, it makes more sense
+    for us to have a sum() function that returns zero instead of NaN.
     """
-    return self.sum() if len(self) > 0 else 0
+    return self.sum() if self.size > 0 else 0
 
 
 def unweighted_sum(pdf, col_name):
@@ -1164,8 +1164,7 @@ def isoelastic_utility_function(consumption, crra, cmin):
     if consumption >= cmin:
         if crra == 1.0:
             return math.log(consumption)
-        else:
-            return math.pow(consumption, (1.0 - crra)) / (1.0 - crra)
+        return math.pow(consumption, (1.0 - crra)) / (1.0 - crra)
     else:  # if consumption < cmin
         if crra == 1.0:
             tu_at_cmin = math.log(cmin)
@@ -1230,11 +1229,9 @@ def certainty_equivalent(exputil, crra, cmin):
     if exputil >= tu_at_cmin:
         if crra == 1.0:
             return math.exp(exputil)
-        else:
-            return math.pow((exputil * (1.0 - crra)), (1.0 / (1.0 - crra)))
-    else:
-        mu_at_cmin = math.pow(cmin, -crra)
-        return ((exputil - tu_at_cmin) / mu_at_cmin) + cmin
+        return math.pow((exputil * (1.0 - crra)), (1.0 / (1.0 - crra)))
+    mu_at_cmin = math.pow(cmin, -crra)
+    return ((exputil - tu_at_cmin) / mu_at_cmin) + cmin
 
 
 def ce_aftertax_income(calc1, calc2,

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -140,14 +140,14 @@ def unweighted_sum(pdf, col_name):
     """
     Return unweighted sum of Pandas DataFrame col_name items.
     """
-    return pdf[col_name].sum()
+    return pdf[col_name].zsum()
 
 
 def weighted_sum(pdf, col_name):
     """
     Return weighted sum of Pandas DataFrame col_name items.
     """
-    return (pdf[col_name] * pdf['s006']).sum()
+    return (pdf[col_name] * pdf['s006']).zsum()
 
 
 def add_quantile_bins(pdf, income_measure, num_bins,
@@ -249,7 +249,7 @@ def get_sums(pdf):
     sums = dict()
     for col in pdf.columns.values.tolist():
         if col != 'bins':
-            sums[col] = pdf[col].sum()
+            sums[col] = pdf[col].zsum()
     return pd.Series(sums, name='sums')
 
 
@@ -478,7 +478,7 @@ def create_difference_table(res1, res2, groupby, income_measure, tax_to_diff):
             sdf['perc_inc'] = gpdf.apply(weighted_perc_inc, 'tax_diff')
             sdf['mean'] = gpdf.apply(weighted_mean, 'tax_diff')
             sdf['tot_change'] = gpdf.apply(weighted_sum, 'tax_diff')
-            wtotal = (res2['tax_diff'] * res2['s006']).sum()
+            wtotal = (res2['tax_diff'] * res2['s006']).zsum()
             sdf['share_of_change'] = gpdf.apply(weighted_share_of_total,
                                                 'tax_diff', wtotal)
             sdf['perc_aftertax'] = gpdf.apply(weighted_mean, 'perc_aftertax')

--- a/taxcalc/utilsprvt.py
+++ b/taxcalc/utilsprvt.py
@@ -5,8 +5,6 @@ PRIVATE utility functions for Tax-Calculator PUBLIC utility functions.
 # pep8 --ignore=E402 utilsprvt.py
 # pylint --disable=locally-disabled utilsprvt.py
 
-import numpy as np
-
 
 EPSILON = 1e-9
 


### PR DESCRIPTION
The code has been slightly revised so that it does not generate warnings that are new to pylint 1.7.4 version.
There is no change in logic or in test results.

This pull request also uses the new `zsum()` functions in several places in the `utils.py` file per the conversation between @hdoupe and @martinholmer at the end of the [1634 conversation](https://github.com/open-source-economics/Tax-Calculator/pull/1634#issuecomment-343224010).