### PR TITLE
Fix PT mtr issue

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -719,6 +719,7 @@ def SchXYZ(taxable_income, MARS, e00900, e26270, e02000, e00200,
     if (pt_active_gross > 0) and PT_wages_active_income:
         pt_active_gross = pt_active_gross + e00200
     pt_active = PT_EligibleRate_active * pt_active_gross
+    pt_active = min(pt_active, e00900 + e26270)
     pt_taxinc = max(0., pt_passive + pt_active)
     if pt_taxinc >= taxable_income:
         pt_taxinc = taxable_income

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -235,6 +235,59 @@ def test_mtr(tests_path, puf_path):
 
 
 @pytest.mark.requires_pufcsv
+def test_mtr_pt_active(puf_subsample):
+    """
+    Test whether including wages in active income causes
+    MTRs on e00900p and e26270 to be less than -1
+    """
+    rec = Records(data=puf_subsample)
+    reform_year = 2018
+    # create current-law Calculator object, calc1
+    pol1 = Policy()
+    calc1 = Calculator(policy=pol1, records=rec)
+    calc1.advance_to_year(reform_year)
+    calc1.calc_all()
+    mtr1_e00900p = calc1.mtr('e00900p')[2]
+    mtr1_e26270 = calc1.mtr('e26270')[2]
+    assert min(mtr1_e00900p) > -1
+    assert min(mtr1_e26270) > -1
+    # change PT rates, calc2
+    reform2 = {reform_year: {'_PT_rt7': [0.35]}}
+    pol2 = Policy()
+    pol2.implement_reform(reform2)
+    calc2 = Calculator(policy=pol2, records=rec)
+    calc2.advance_to_year(reform_year)
+    calc2.calc_all()
+    mtr2_e00900p = calc2.mtr('e00900p')[2]
+    mtr2_e26270 = calc2.mtr('e26270')[2]
+    assert min(mtr2_e00900p) > -1
+    assert min(mtr2_e26270) > -1
+    # change PT_wages_active_income
+    reform3 = {reform_year: {'_PT_wages_active_income': [True]}}
+    pol3 = Policy()
+    pol3.implement_reform(reform3)
+    calc3 = Calculator(policy=pol3, records=rec)
+    calc3.advance_to_year(reform_year)
+    calc3.calc_all()
+    mtr3_e00900p = calc3.mtr('e00900p')[2]
+    mtr3_e26270 = calc3.mtr('e26270')[2]
+    assert min(mtr3_e00900p) > -1
+    assert min(mtr3_e26270) > -1
+    # change PT rates and PT_wages_active_income
+    reform4 = {reform_year: {'_PT_wages_active_income': [True],
+                             '_PT_rt7': [0.35]}}
+    pol4 = Policy()
+    pol4.implement_reform(reform4)
+    calc4 = Calculator(policy=pol4, records=rec)
+    calc4.advance_to_year(reform_year)
+    calc4.calc_all()
+    mtr4_e00900p = calc4.mtr('e00900p')[2]
+    mtr4_e26270 = calc4.mtr('e26270')[2]
+    assert min(mtr4_e00900p) > -1
+    assert min(mtr4_e26270) > -1
+
+
+@pytest.mark.requires_pufcsv
 def test_credit_reforms(puf_subsample):
     """
     Test personal credit reforms using puf.csv subsample


### PR DESCRIPTION
This PR resolves the problem identified in issue #1636. In that issue, @rickecon discovered that the TCJA caused some individuals to have absurdly negative MTRs on `e00900p`. Upon investigtion, I realized that this is due to the `_PT_wages_active_income` parameter, which allows filers with active pass-through income (`e00900` or `e26270`) to include their wages as part of the base to which `_PT_EligibleRate_active` is applied. When we calculate the MTR on `e00900p`, we cause filing units that did not have active pass-through income to have active pass-through income, which made 30% (value of `_PT_EligibleRate_active`) of their wages eligible for the lower PT rates and substantially reduced their tax liability. Note that this phenomenon should also occur when calculating the MTRs on `e26270`, 

This PR eliminates the problem by setting the amount of pass-through income eligible for the PT rates to not exceed `e00900 + e26270`. This resolves the issue. 

I also added a test in test_pufcsv.py with assertion statements that the lowest MTRs on `e00900p` and `e26270` may not be less than -1. I tested this for 4 scenarios: 
- Current law (which should obviously pass)
- Set `'_PT_rt7': [0.35]`. The passage of this shows that the problem is not due to changing the PT rates.
- Set `'_PT_wages_active_income': [True]`. The passage of this shows that this parameter does not produce a problem when PT income and regular income face the same tax schedules.
- Set `'_PT_rt7': [0.35], '_PT_wages_active_income': [True]`. This fails on the master branch, but it passes with my fix. 

@rickecon @martinholmer @MattHJensen @feenberg @jdebacker @andersonfrailey @Amy-Xu 