### PR TITLE
Add business income exclusion in Senate TCJA

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -3093,6 +3093,50 @@
         "out_of_range_action": "stop"
     },
 
+    "_PT_exclusion_rt": {
+        "long_name": "Pass-through income exclusion rate",
+        "description": "Fraction of qualified business income excluded from taxable income.",
+        "section_1": "Personal Income",
+        "section_2": "Pass-Through",
+        "irs_ref": "",
+        "notes": "Applies to e00900 + e26270",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "start_year": 2013,
+        "cpi_inflated": false,
+        "col_var": "",
+        "col_label": "",
+        "boolean_value": false,
+        "integer_value": false,
+        "value": [0.0],
+        "range": {"min": 0.0, "max": 1.0},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
+
+    "_PT_exclusion_limit": {
+        "long_name": "Limit on pass-through income exclusion",
+        "description": "If taxpayer has partnership/ S corporation income, the amount of business income excluded from taxable income may not exceed this fraction of wages.",
+        "section_1": "Personal Income",
+        "section_2": "Pass-Through",
+        "irs_ref": "",
+        "notes": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "start_year": 2013,
+        "cpi_inflated": false,
+        "col_var": "",
+        "col_label": "",
+        "boolean_value": false,
+        "integer_value": false,
+        "value": [9e99],
+        "range": {"min": 0.0, "max": 9e99},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
+
     "_AMT_em": {
         "long_name": "AMT exemption amount",
         "description": "The amount of AMT taxable income exempted from AMT.",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -3115,7 +3115,7 @@
         "out_of_range_action": "stop"
     },
 
-    "_PT_exclusion_limit": {
+    "_PT_exclusion_wage_limit": {
         "long_name": "Limit on pass-through income exclusion",
         "description": "If taxpayer has partnership/ S corporation income, the amount of business income excluded from taxable income may not exceed this fraction of wages.",
         "section_1": "Personal Income",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -689,14 +689,14 @@ def StdDed(DSI, earned, STD, age_head, age_spouse, STD_Aged, STD_Dep,
 
 @iterate_jit(nopython=True)
 def TaxInc(c00100, standard, c04470, c04600, c04800,
-           PT_exclusion_rt, PT_exclusion_limit, e00900,
+           PT_exclusion_rt, PT_exclusion_wage_limit, e00900,
            e26270, e00200):
     """
     TaxInc function: ...
     """
     pt_exclusion = max(0., PT_exclusion_rt * (e00900 + e26270))
     if e26270 > 0.:
-        pt_exclusion = min(pt_exclusion, e00200 * PT_exclusion_limit)
+        pt_exclusion = min(pt_exclusion, e00200 * PT_exclusion_wage_limit)
     c04800 = max(0., c00100 - max(c04470, standard) - c04600 -
                  pt_exclusion)
     return c04800

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -688,11 +688,17 @@ def StdDed(DSI, earned, STD, age_head, age_spouse, STD_Aged, STD_Dep,
 
 
 @iterate_jit(nopython=True)
-def TaxInc(c00100, standard, c04470, c04600, c04800):
+def TaxInc(c00100, standard, c04470, c04600, c04800,
+           PT_exclusion_rt, PT_exclusion_limit, e00900,
+           e26270, e00200):
     """
     TaxInc function: ...
     """
-    c04800 = max(0., c00100 - max(c04470, standard) - c04600)
+    pt_exclusion = max(0., PT_exclusion_rt * (e00900 + e26270))
+    if e26270 > 0.:
+        pt_exclusion = min(pt_exclusion, e00200 * PT_exclusion_limit)
+    c04800 = max(0., c00100 - max(c04470, standard) - c04600 -
+                 pt_exclusion)
     return c04800
 
 


### PR DESCRIPTION
This PR models two parts of the rules related to the exclusion of 17.4 percent of qualified business income, from the Senate's [Tax Cuts and Jobs Act](https://www.finance.senate.gov/imo/media/doc/11.9.17%20Chairman's%20Mark.pdf), pages 17-18. The proposal would allow 17.4% of qualified business income to be excluded from taxable income. The exclusion would phase out for personal services business income for taxable income over $75000 ($150k for married filing jointly). Since we cannot distinguish personal services business income from other business income, I have not modeled the phase-out. I also discuss this aspect in #1650. 

The exclusion rate for qualified business income is modeled by `_PT_exclusion_rt`. 
I also model an unusual rule from the bill:

> In the case of a taxpayer who has qualified business income from a partnership or S corporation, the amount of the deduction is limited to 50 percent of the W-2 wages of the taxpayer. 

This is modeled by `_PT_exclusion_limit`. 

@MattHJensen @martinholmer @jdebacker @feenberg @andersonfrailey @hdoupe @Amy-Xu @GoFroggyRun 