### PR TITLE
Fix test failures caused by PR#1635 and PR#1653

### DIFF
--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -455,7 +455,7 @@
       "form": {"2013-2016": "6251"},
       "availability": "taxdata_puf"
     },
-    "ffpos":{
+    "ffpos": {
       "type": "int",
       "desc": "Unique family identifier in the CPS",
       "form": {},

--- a/taxcalc/tests/test_puf_var_stats.py
+++ b/taxcalc/tests/test_puf_var_stats.py
@@ -36,6 +36,7 @@ def create_base_table(test_path):
                  'c09600': 'Federal AMT liability'}
     # specify read variable names and descriptions
     unused_var_set = set(['AGIR1', 'DSI', 'EFI', 'EIC', 'ELECT', 'FDED',
+                          'h_seq', 'ffpos', 'fips',
                           'FLPDYR', 'FLPDMO', 'f2441', 'f3800', 'f6251',
                           'f8582', 'f8606', 'f8829', 'f8910', 'f8936', 'n20',
                           'n24', 'n25', 'n30', 'PREP', 'SCHB', 'SCHCF', 'SCHE',

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -238,8 +238,9 @@ def test_mtr(tests_path, puf_path):
 def test_mtr_pt_active(puf_subsample):
     """
     Test whether including wages in active income causes
-    MTRs on e00900p and e26270 to be less than -1
+    MTRs on e00900p and e26270 to be less than -1 (i.e., -100%)
     """
+    # pylint: disable=too-many-locals
     rec = Records(data=puf_subsample)
     reform_year = 2018
     # create current-law Calculator object, calc1


### PR DESCRIPTION
This pull request avoids test failures caused by the addition of the `h_seq` and `ffpos` variables in pull request #1635 and the addition of the `fips` variable in pull request #1653.

The pull request also makes two cosmetic changes to the code to comply with the project coding style.
