### PR TITLE
Improve tc output documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -509,9 +509,9 @@ part of this section.</p>
 formats from a single tc run.</p>
 
 <p>The remaining examples use neither the <kbd>--dump</kbd> nor the
-<kbd>--sqldb</kbd> option, and thus, produce minimal output.  But
-either or both of those options could be used in all the subsequent
-examples.</p>
+<kbd>--sqldb</kbd> option, and thus, produce minimal output for the
+reform.  But either or both of those options could be used in all the
+subsequent examples to generate more complete output for the reform.</p>
 
 <p><pre>
 (5)$ tc test.csv 2021 --reform ref3.json
@@ -651,7 +651,10 @@ developer website</a>.</p>
 files or SQLite3 database files, there is an enormous range of
 software tools that can be used to tabulate the output.  You can use
 SAS or R, Stata or MATLAB, or even import output into a spreadsheet
-(but this would seem to be the least useful option).  The main point
+(but this would seem to be the least useful option).  If you just
+want to compare the contents of two output files, you can use your
+favorite graphical diff program to view the two files <q>side by side</q>
+with highlighting of numbers that are different.  The main point
 is to use a software tool that is available to you and that you have
 experience using.</p>
 

--- a/docs/index.htmx
+++ b/docs/index.htmx
@@ -508,9 +508,9 @@ part of this section.</p>
 formats from a single tc run.</p>
 
 <p>The remaining examples use neither the <kbd>--dump</kbd> nor the
-<kbd>--sqldb</kbd> option, and thus, produce minimal output.  But
-either or both of those options could be used in all the subsequent
-examples.</p>
+<kbd>--sqldb</kbd> option, and thus, produce minimal output for the
+reform.  But either or both of those options could be used in all the
+subsequent examples to generate more complete output for the reform.</p>
 
 <p><pre>
 (5)$ tc test.csv 2021 --reform ref3.json
@@ -650,7 +650,10 @@ developer website</a>.</p>
 files or SQLite3 database files, there is an enormous range of
 software tools that can be used to tabulate the output.  You can use
 SAS or R, Stata or MATLAB, or even import output into a spreadsheet
-(but this would seem to be the least useful option).  The main point
+(but this would seem to be the least useful option).  If you just
+want to compare the contents of two output files, you can use your
+favorite graphical diff program to view the two files <q>side by side</q>
+with highlighting of numbers that are different.  The main point
 is to use a software tool that is available to you and that you have
 experience using.</p>
 

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -33,7 +33,7 @@ def cli_tc_main():
                      'file, with the OUTPUT computed from the INPUT for the '
                      'TAXYEAR using Tax-Calculator. The OUTPUT file is a '
                      'CSV-formatted file that contains tax information for '
-                     'each INPUT filing unit.'))
+                     'each INPUT filing unit under the reform.'))
     parser.add_argument('INPUT', nargs='?',
                         help=('INPUT is name of CSV-formatted file that '
                               'contains for each filing unit variables used '
@@ -48,8 +48,8 @@ def cli_tc_main():
                         default=0)
     parser.add_argument('--reform',
                         help=('REFORM is name of optional JSON reform file. '
-                              'No --reform implies use of current-law '
-                              'policy.'),
+                              'No --reform implies a "null" reform (that is, '
+                              'current-law policy).'),
                         default=None)
     parser.add_argument('--assump',
                         help=('ASSUMP is name of optional JSON economic '
@@ -83,17 +83,17 @@ def cli_tc_main():
                         action="store_true")
     parser.add_argument('--dump',
                         help=('optional flag that causes OUTPUT to contain '
-                              'all INPUT variables (possibly extrapolated '
-                              'to TAXYEAR) and all calculated tax variables, '
-                              'where all the variables are named using their '
-                              'internal Tax-Calculator names.  No --dump '
-                              'option implies OUTPUT contains minimal tax '
-                              'output.'),
+                              'all INPUT variables (extrapolated to TAXYEAR) '
+                              'and all calculated tax variables for the '
+                              'reform, where all the variables are named '
+                              'using their internal Tax-Calculator names.  No '
+                              '--dump option implies OUTPUT contains minimal '
+                              'tax output for the reform.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--sqldb',
-                        help=('optional flag that writes SQLite database with '
-                              'dump table containing same output as '
+                        help=('optional flag that writes SQLite database '
+                              'with dump table containing same output as '
                               'produced by --dump option.'),
                         default=False,
                         action="store_true")


### PR DESCRIPTION
This pull request changes the documentation of the CLI `tc` OUTPUT content to make it clear that the `tc` OUTPUT file contains information about the reform (with `tc` with out the --reform option being the "null" reform).  It also suggests use of graphical diff programs to compare the contents of  two`tc` OUTPUT files.

These changes respond to several points raised in issue #1639.