### PR TITLE
Fix logic of the run_nth_year_gdp_elast_model function

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,34 @@ Go [here](https://github.com/open-source-economics/Tax-Calculator/pulls?q=is%3Ap
 for a complete commit history.
 
 
+2017-11-?? Release 0.13.2
+-------------------------
+(last merged pull request is
+[#xxxx](https://github.com/open-source-economics/Tax-Calculator/pull/xxxx))
+
+**API Changes**
+- None
+
+**New Features**
+- Add TCJA_House_Amended JSON policy reform file
+  [[#1664](https://github.com/open-source-economics/Tax-Calculator/pull/1664)
+  by Cody Kallen and Matt Jensen]
+- Add `_cpi_offset` policy parameter that can be used to specify chained CPI indexing reforms
+  [[#1667](https://github.com/open-source-economics/Tax-Calculator/pull/1667)
+  by Martin Holmer]
+
+**Bug Fixes**
+- Fix `_ACTC_ChildNum` policy parameter documentation and logic
+  [[#1666](https://github.com/open-source-economics/Tax-Calculator/pull/1666)
+  by Martin Holmer, reported by Ernie Tedeschi]
+- Fix documentation for mis-named `n1821` input variable
+  [[#1672](https://github.com/open-source-economics/Tax-Calculator/pull/1672)
+  by Martin Holmer, reported by Max Ghenis]
+- Fix logic of run_nth_year_gdp_elast_model function in the TaxBrainInterface
+  [[#1677](https://github.com/open-source-economics/Tax-Calculator/pull/1677)
+  by Martin Holmer, reported by Hank Doupe]
+
+
 2017-11-10 Release 0.13.1
 -------------------------
 (last merged pull request is

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,7 @@ for a complete commit history.
 2017-11-17 Release 0.13.2
 -------------------------
 (last merged pull request is
-[#1677](https://github.com/open-source-economics/Tax-Calculator/pull/1677))
+[#1680](https://github.com/open-source-economics/Tax-Calculator/pull/1680))
 
 **API Changes**
 - None
@@ -22,6 +22,9 @@ for a complete commit history.
 - Add new policy parameter that changes the stacking order of child/dependent credits
   [[#1676](https://github.com/open-source-economics/Tax-Calculator/pull/1676)
   by Matt Jensen as suggested by Cody Kallen with need identified by Joint Economic Committee staff]
+- Add to several TCJA reform files the provision for chained CPI indexing
+  [[#1680](https://github.com/open-source-economics/Tax-Calculator/pull/1680)
+  by Matt Jensen]
 
 **Bug Fixes**
 - Fix `_ACTC_ChildNum` policy parameter documentation and logic

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,10 +4,10 @@ Go [here](https://github.com/open-source-economics/Tax-Calculator/pulls?q=is%3Ap
 for a complete commit history.
 
 
-2017-11-?? Release 0.13.2
+2017-11-17 Release 0.13.2
 -------------------------
 (last merged pull request is
-[#xxxx](https://github.com/open-source-economics/Tax-Calculator/pull/xxxx))
+[#1677](https://github.com/open-source-economics/Tax-Calculator/pull/1677))
 
 **API Changes**
 - None
@@ -22,9 +22,6 @@ for a complete commit history.
 - Add new policy parameter that changes the stacking order of child/dependent credits
   [[#1676](https://github.com/open-source-economics/Tax-Calculator/pull/1676)
   by Matt Jensen as suggested by Cody Kallen]
-- Add TCJA_Senate_Chairman_Modified_Mark JSON policy reform file
-  [[#1678](https://github.com/open-source-economics/Tax-Calculator/pull/1678)
-  by Cody Kallen and Sean Wang]
 
 **Bug Fixes**
 - Fix `_ACTC_ChildNum` policy parameter documentation and logic

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,7 +21,7 @@ for a complete commit history.
   by Martin Holmer]
 - Add new policy parameter that changes the stacking order of child/dependent credits
   [[#1676](https://github.com/open-source-economics/Tax-Calculator/pull/1676)
-  by Matt Jensen as suggested by Cody Kallen]
+  by Matt Jensen as suggested by Cody Kallen with need identified by Joint Economic Committee staff]
 
 **Bug Fixes**
 - Fix `_ACTC_ChildNum` policy parameter documentation and logic

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,6 +19,12 @@ for a complete commit history.
 - Add `_cpi_offset` policy parameter that can be used to specify chained CPI indexing reforms
   [[#1667](https://github.com/open-source-economics/Tax-Calculator/pull/1667)
   by Martin Holmer]
+- Add new policy parameter that changes the stacking order of child/dependent credits
+  [[#1676](https://github.com/open-source-economics/Tax-Calculator/pull/1676)
+  by Matt Jensen as suggested by Cody Kallen]
+- Add TCJA_Senate_Chairman_Modified_Mark JSON policy reform file
+  [[#1678](https://github.com/open-source-economics/Tax-Calculator/pull/1678)
+  by Cody Kallen and Sean Wang]
 
 **Bug Fixes**
 - Fix `_ACTC_ChildNum` policy parameter documentation and logic

--- a/taxcalc/tbi/tbi.py
+++ b/taxcalc/tbi/tbi.py
@@ -177,7 +177,7 @@ def run_nth_year_gdp_elast_model(year_n, start_year,
 
     # calculate gdp_effect
     fyear = check_years_return_first_year(year_n, start_year, use_puf_not_cps)
-    if (start_year + year_n) > fyear:
+    if year_n > 0 and (start_year + year_n) > fyear:
         # create calc1 and calc2 calculated for year_n - 1
         (calc1, calc2, _) = calculate((year_n - 1), start_year,
                                       use_puf_not_cps,

--- a/taxcalc/tests/test_tbi.py
+++ b/taxcalc/tests/test_tbi.py
@@ -126,7 +126,19 @@ def test_run_gdp_elast_model_1(resdict):
 def test_run_gdp_elast_model_2():
     usermods = USER_MODS
     usermods['behavior'] = dict()
-    res = run_nth_year_gdp_elast_model(0, 2014,  # forces no automatic zero
+    res = run_nth_year_gdp_elast_model(0, 2014,  # forces automatic zero
+                                       use_puf_not_cps=False,
+                                       use_full_sample=False,
+                                       user_mods=usermods,
+                                       gdp_elasticity=0.36,
+                                       return_dict=False)
+    assert res == 0.0
+
+
+def test_run_gdp_qelast_model_3():
+    usermods = USER_MODS
+    usermods['behavior'] = dict()
+    res = run_nth_year_gdp_elast_model(0, 2017,  # forces automatic zero
                                        use_puf_not_cps=False,
                                        use_full_sample=False,
                                        user_mods=usermods,


### PR DESCRIPTION
This pull request fixes a bug identified by @hdoupe in [PolicyBrain 738](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/738#issuecomment-345350458).

This pull request adds a test to `test_tbi.py` that fails on the master branch (recreating the error reported by @hdoupe) and passes on this branch, which includes a one-line change to the`run_nth_year_gdp_elast_model` function.

Thanks, @hdoupe, for the concise bug report.

@MattHJensen @Amy-Xu @andersonfrailey @GoFroggyRun 