### PR TITLE
Add chained CPI indexing to TCJA reform files

### DIFF
--- a/taxcalc/reforms/TCJA_House.json
+++ b/taxcalc/reforms/TCJA_House.json
@@ -12,6 +12,7 @@
 // -  Changes to above-the-line deductions (8)
 // -  Changes to itemized deductions (9)
 // -  Repeal of certain credits (10)
+// -  Adopt Chained CPI for parameter indexing (11)
 // Reform_Parameter_Map:
 // - 1: _II_rt*
 // - 2: _PT_rt*
@@ -23,6 +24,7 @@
 // - 8: _ALD_*
 // - 9: _ID_*
 // - 10: _CR_SchR_hc, _LLC_Ecpense_c
+// - 11: _cpi_offset
 {
   "policy": {
         "_II_rt1":
@@ -132,6 +134,8 @@
         "_CR_SchR_hc":
             {"2018": [1]},
         "_LLC_Expense_c":
-            {"2018": [0]}
+            {"2018": [0]},
+        "_cpi_offset":
+            {"2018": [-0.0025]}
   }
 }

--- a/taxcalc/reforms/TCJA_House_Amended.json
+++ b/taxcalc/reforms/TCJA_House_Amended.json
@@ -12,6 +12,7 @@
 // -  Changes to above-the-line deductions (8)
 // -  Changes to itemized deductions (9)
 // -  Repeal of certain credits (10)
+// -  Adopt Chained CPI for parameter indexing (11)
 // Reform_Parameter_Map:
 // - 1: _II_rt*
 // - 2: _PT_rt*
@@ -23,6 +24,7 @@
 // - 8: _ALD_*
 // - 9: _ID_*
 // - 10: _CR_SchR_hc, _LLC_Ecpense_c
+// - 11: _cpi_offset
 {
   "policy": {
         "_II_rt1":
@@ -140,6 +142,8 @@
         "_CR_SchR_hc":
             {"2018": [1]},
         "_LLC_Expense_c":
-            {"2018": [0]}
+            {"2018": [0]},
+        "_cpi_offset":
+            {"2018": [-0.0025]}
   }
 }

--- a/taxcalc/reforms/TCJA_Senate.json
+++ b/taxcalc/reforms/TCJA_Senate.json
@@ -10,6 +10,7 @@
 // -  Repeal Alternative Minimum Tax (6)
 // -  Repeal of domestic production deduction
 // -  Changes to itemized deductions (8)
+// -  Adopt Chained CPI for parameter indexing (9)
 // Reform_Parameter_Map:
 // - 1: _II_rt*
 // - 2: _PT_rt*
@@ -19,6 +20,7 @@
 // - 6: _AMT_rt*
 // - 7: _ALD_DomesticProduction_hc
 // - 8: _ID_*
+// - 9: _cpi_offset
 {
   "policy": {
         "_II_rt1":
@@ -104,6 +106,8 @@
         "_ID_RealEstate_hc":
             {"2018": [1]},
         "_ID_Miscellaneous_hc":
-            {"2018": [1]}
+            {"2018": [1]},
+        "_cpi_offset":
+            {"2018": [-0.0025]}
   }
 }


### PR DESCRIPTION
Use the new `_cpi_offset` policy parameter to characterize the chained CPI indexing reform provision in several of TCJA JSON reform files.