### PR TITLE
add cpi_offset reform to reforms.json

### DIFF
--- a/taxcalc/tests/reforms.json
+++ b/taxcalc/tests/reforms.json
@@ -560,27 +560,27 @@
 
   "56": {
       "start_year": 2017,
-      "value": {"_DependentCredit_before_CTC": [true],
-                "_DependentCredit_Child_c": [500]},
-      "name": "Stack dependent credit before CTC",
-      "output_type": "iitax",
-      "compare_with": {},
-      "expected": "Tax-Calculator,-13.2,-12.9,-12.3,-12.1"
-  },
-
-    "57": {
-      "start_year": 2017,
       "value": {"_DependentCredit_Child_c": [500]},
-      "name": "Stack dependent credit before CTC",
+      "name": "Set Dependend Credit for Children at $500",
       "output_type": "iitax",
       "compare_with": {},
       "expected": "Tax-Calculator,-7.9,-7.7,-7.3,-7.2"
   },
 
+    "57": {
+      "start_year": 2017,
+      "value": {"_DependentCredit_before_CTC": [true],
+                "_DependentCredit_Child_c": [500]},
+      "name": "Set Dependend Credit for Children at $500 AND stack dependent credit before CTC",
+      "output_type": "iitax",
+      "compare_with": {},
+      "expected": "Tax-Calculator,-13.2,-12.9,-12.3,-12.1"
+  },
+
       "58": {
       "start_year": 2017,
       "value": {"_cpi_offset": [-0.0025]},
-      "name": "Stack dependent credit before CTC",
+      "name": "Adopt cpi_offset similar to chained CPI",
       "output_type": "iitax",
       "compare_with": {},
       "expected": "Tax-Calculator,0.0,2.2,4.6,7.2"

--- a/taxcalc/tests/reforms.json
+++ b/taxcalc/tests/reforms.json
@@ -575,6 +575,14 @@
       "output_type": "iitax",
       "compare_with": {},
       "expected": "Tax-Calculator,-7.9,-7.7,-7.3,-7.2"
-  }
+  },
 
+      "58": {
+      "start_year": 2017,
+      "value": {"_cpi_offset": [-0.0025]},
+      "name": "Stack dependent credit before CTC",
+      "output_type": "iitax",
+      "compare_with": {},
+      "expected": "Tax-Calculator,0.0,2.2,4.6,7.2"
+  }
 }

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -100,7 +100,7 @@ def fixture_reforms_dict(tests_path):
     return json.loads(rjson)
 
 
-NUM_REFORMS = 57
+NUM_REFORMS = 58
 
 
 @pytest.mark.requires_pufcsv


### PR DESCRIPTION
Just checking the magnitude and pattern of cpi_offset reforms. Does not change results. 

