### PR TITLE
Test new pt params

### DIFF
--- a/taxcalc/tests/reforms.json
+++ b/taxcalc/tests/reforms.json
@@ -587,19 +587,21 @@
   }, 
       "59": {
       "start_year": 2017,
-      "value": {"_PT_rt7": [0.35]},
-      "name": "Top pass through rate at 0.35",
+      "value": {"_PT_rt7": [0.35],
+                "_PT_EligibleRate_active": [0.7]},
+      "name": "Top pass through rate at 0.35 AND 70% of active business inc eligible for lower rate",
       "output_type": "iitax",
       "compare_with": {},
-      "expected": "Tax-Calculator,-18.2,-18.1,-17.9,-18.0"
+      "expected": "Tax-Calculator,-14.8,-14.7,-14.6,-14.7"
   },
       "60": {
       "start_year": 2017,
       "value": {"_PT_wages_active_income": [true],
+                "_PT_EligibleRate_active": [0.7],
                 "_PT_rt7": [0.35]},
-      "name": "Top pass through rate at 0.35 AND wages included in (positive) active business income eligible for PT rates",
+      "name": "Top pass through rate at 0.35 AND 70% of active business inc eligible for lower rate AND wages included in (positive) active business income eligible for PT rates",
       "output_type": "iitax",
       "compare_with": {},
-      "expected": "Tax-Calculator,-18.2,-18.1,-17.9,-18.0"
+      "expected": "Tax-Calculator,-16.5,-16.5,-16.4,-16.5"
   }
 }

--- a/taxcalc/tests/reforms.json
+++ b/taxcalc/tests/reforms.json
@@ -588,7 +588,7 @@
       "59": {
       "start_year": 2017,
       "value": {"_PT_rt7": [0.35]},
-      "name": "Wages included in (positive) active business income eligible for PT rates",
+      "name": "Top pass through rate at 0.35",
       "output_type": "iitax",
       "compare_with": {},
       "expected": "Tax-Calculator,-18.2,-18.1,-17.9,-18.0"
@@ -597,7 +597,7 @@
       "start_year": 2017,
       "value": {"_PT_wages_active_income": [true],
                 "_PT_rt7": [0.35]},
-      "name": "Wages included in (positive) active business income eligible for PT rates",
+      "name": "Top pass through rate at 0.35 AND wages included in (positive) active business income eligible for PT rates",
       "output_type": "iitax",
       "compare_with": {},
       "expected": "Tax-Calculator,-18.2,-18.1,-17.9,-18.0"

--- a/taxcalc/tests/reforms.json
+++ b/taxcalc/tests/reforms.json
@@ -584,5 +584,22 @@
       "output_type": "iitax",
       "compare_with": {},
       "expected": "Tax-Calculator,0.0,2.2,4.6,7.2"
+  }, 
+      "59": {
+      "start_year": 2017,
+      "value": {"_PT_rt7": [0.35]},
+      "name": "Wages included in (positive) active business income eligible for PT rates",
+      "output_type": "iitax",
+      "compare_with": {},
+      "expected": "Tax-Calculator,-18.2,-18.1,-17.9,-18.0"
+  },
+      "60": {
+      "start_year": 2017,
+      "value": {"_PT_wages_active_income": [true],
+                "_PT_rt7": [0.35]},
+      "name": "Wages included in (positive) active business income eligible for PT rates",
+      "output_type": "iitax",
+      "compare_with": {},
+      "expected": "Tax-Calculator,-18.2,-18.1,-17.9,-18.0"
   }
 }

--- a/taxcalc/tests/reforms.json
+++ b/taxcalc/tests/reforms.json
@@ -575,6 +575,14 @@
       "output_type": "iitax",
       "compare_with": {},
       "expected": "Tax-Calculator,-7.9,-7.7,-7.3,-7.2"
-  }
+  },
 
+      "58": {
+      "start_year": 2017,
+      "value": {"_cpi_offset": [-0.0025]},
+      "name": "Stack dependent credit before CTC",
+      "output_type": "iitax",
+      "compare_with": {},
+      "expected": "Tax-Calculator,0.0,2.2,4.6,7.2"
+  }
 }

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -100,7 +100,7 @@ def fixture_reforms_dict(tests_path):
     return json.loads(rjson)
 
 
-NUM_REFORMS = 58
+NUM_REFORMS = 60
 
 
 @pytest.mark.requires_pufcsv

--- a/taxcalc/tests/test_reforms.py
+++ b/taxcalc/tests/test_reforms.py
@@ -100,7 +100,7 @@ def fixture_reforms_dict(tests_path):
     return json.loads(rjson)
 
 
-NUM_REFORMS = 57
+NUM_REFORMS = 58
 
 
 @pytest.mark.requires_pufcsv


### PR DESCRIPTION
In my work on #1614, I found that `_PT_wages_active_income` does not affect results, even in the presence of a reduced `_PT_rt7` compared to `_II_rt7`. The tests in this PR confirm that finding. 

@codykallen, could you suggest how I can 'activate' the _PT_wages_active_income parameter so that switching it from `false` to `true` has an effect on results? 