### PR TITLE
Add two public Calculator class methods

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -13,6 +13,7 @@ import re
 import copy
 import six
 import numpy as np
+import pandas as pd
 from taxcalc.functions import (TaxInc, SchXYZTax, GainsTax, AGIsurtax,
                                NetInvIncTax, AMT, EI_PayrollTax, Adj,
                                DependentCare, ALD_InvInc_ec_base, CapGains,
@@ -136,23 +137,9 @@ class Calculator(object):
                       str(self.records.current_year) + '.')
         assert self.policy.current_year == self.records.current_year
 
-    def calc_all(self, zero_out_calc_vars=False):
-        """
-        Call all tax-calculation functions.
-        """
-        # conducts static analysis of Calculator object for current_year
-        assert self.records.current_year == self.policy.current_year
-        self._calc_one_year(zero_out_calc_vars)
-        BenefitSurtax(self)
-        BenefitLimitation(self)
-        FairShareTax(self.policy, self.records)
-        LumpSumTax(self.policy, self.records)
-        ExpandIncome(self.policy, self.records)
-        AfterTaxIncome(self.policy, self.records)
-
     def increment_year(self):
         """
-        Advance all objects to next year.
+        Advance all embedded objects to next year.
         """
         next_year = self.policy.current_year + 1
         self.records.increment_year()
@@ -173,6 +160,37 @@ class Calculator(object):
         for _ in range(iteration):
             self.increment_year()
         assert self.records.current_year == year
+
+    def calc_all(self, zero_out_calc_vars=False):
+        """
+        Call all tax-calculation functions for the current_year.
+        """
+        # conducts static analysis of Calculator object for current_year
+        assert self.records.current_year == self.policy.current_year
+        self._calc_one_year(zero_out_calc_vars)
+        BenefitSurtax(self)
+        BenefitLimitation(self)
+        FairShareTax(self.policy, self.records)
+        LumpSumTax(self.policy, self.records)
+        ExpandIncome(self.policy, self.records)
+        AfterTaxIncome(self.policy, self.records)
+
+    def weighted_total(self, variable_name):
+        """
+        Return all-filing-unit weighted total of named Records variable.
+        """
+        variable = getattr(self.records, variable_name)
+        weight = getattr(self.records, 's006')
+        return (variable * weight).sum()
+
+    def dataframe(self, variable_list):
+        """
+        Return pandas DataFrame containing the listed Records variables.
+        """
+        pdf = pd.DataFrame()
+        for varname in variable_list:
+            pdf[varname] = getattr(self.records, varname)
+        return pdf
 
     @property
     def current_year(self):

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -297,6 +297,10 @@ def test_calculator_using_nonstd_input(rawinputfile):
                       sync_years=False)  # keeps raw data unchanged
     assert calc.current_year == RAWINPUTFILE_YEAR
     calc.calc_all()
+    assert calc.weighted_total('e00200') == 0
+    varlist = ['RECID', 'MARS']
+    pdf = calc.dataframe(varlist)
+    assert pdf.shape == (RAWINPUTFILE_FUNITS, len(varlist))
     exp_iitax = np.zeros((nonstd.dim,))
     assert np.allclose(calc.records.iitax, exp_iitax)
     mtr_ptax, _, _ = calc.mtr(wrt_full_compensation=False)


### PR DESCRIPTION
Add a `weighted_total(variable_name)` method and a `dataframe(variable_list)` method to the Calculator class.

These methods make it easier to get information out of the private Records object embedded in a Calculator object.

There is no change in tax logic or results.