### PR TITLE
Ignore Jupyter notebook support files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.ipynb_checkpoints*
 
 # C extensions
 *.so


### PR DESCRIPTION
This PR simply adds the line,
```python
.ipynb_checkpoints*
```
to the Tax-Calculator `.gitignore` file. This is valuable if one wants to put a Jupyter notebook in the Tax-Calculator directory to run analysis because the notebooks currently created these support files, which we do not want to be carrying around in the repo. I think it will be a good idea to include notebooks in the Tax-Calculator repository so that any user can quickly perform analyses.