### PR TITLE
Add Calculator array method and test

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -199,6 +199,12 @@ class Calculator(object):
         pdf = pd.DataFrame(data=np.column_stack(arrays), columns=variable_list)
         return pdf
 
+    def array(self, variable_name):
+        """
+        Return numpy ndarray containing the named Records variable.
+        """
+        return getattr(self.records, variable_name)
+
     def add_records_variable(self, dst_name, src_calc, src_name):
         """
         Add new variable with name dst_name to this Calculator object's

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -301,7 +301,11 @@ def test_calculator_using_nonstd_input(rawinputfile):
     assert calc.total_weight() == 0
     varlist = ['RECID', 'MARS']
     pdf = calc.dataframe(varlist)
+    assert isinstance(pdf, pd.DataFrame)
     assert pdf.shape == (RAWINPUTFILE_FUNITS, len(varlist))
+    mars = calc.array('MARS')
+    assert isinstance(mars, np.ndarray)
+    assert mars.shape == (RAWINPUTFILE_FUNITS,)
     exp_iitax = np.zeros((nonstd.dim,))
     assert np.allclose(calc.records.iitax, exp_iitax)
     mtr_ptax, _, _ = calc.mtr(wrt_full_compensation=False)


### PR DESCRIPTION
This pull request adds another Calculator class access method that retrieves information from the Records object embedded in a Calculator object.  There already exists the `dataframe` method that retrieves a pandas DataFrame containing one or more Records variables.  Here we add the `array` method that retrieves a numpy ndarray containing just one Records variable.  Obviously, this is pure convenience because the following expression is true:
```
calc.array('varname') == calc.dataframe(['varname'])['varname']
```
But it is a significant convenience.