### PR TITLE
Add optional speed-up argument to Calculator mtr method

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -243,10 +243,12 @@ class Calculator(object):
     def mtr(self, variable_str='e00200p',
             negative_finite_diff=False,
             zero_out_calculated_vars=False,
+            calc_all_already_called=False,
             wrt_full_compensation=True):
         """
         Calculates the marginal payroll, individual income, and combined
-        tax rates for every tax filing unit.
+        tax rates for every tax filing unit, leaving the Calculator object
+        in exactly the same state as it would be in after a calc_all() call.
 
         The marginal tax rates are approximated as the change in tax
         liability caused by a small increase (the finite_diff) in the variable
@@ -280,6 +282,12 @@ class Calculator(object):
             specifies value of zero_out_calc_vars parameter used in calls
             of Calculator.calc_all() method.
 
+        calc_all_already_called: boolean
+            specifies whether self has already had its Calculor.calc_all()
+            method called, in which case this method will not do a final
+            calc_all() call but use the incoming embedded Records object
+            as the outgoing Records object embedding in self.
+
         wrt_full_compensation: boolean
             specifies whether or not marginal tax rates on earned income
             are computed with respect to (wrt) changes in total compensation
@@ -287,13 +295,17 @@ class Calculator(object):
 
         Returns
         -------
-        mtr_payrolltax: a numpy array of marginal payroll tax rates.
-        mtr_incometax: a numpy array of marginal individual income tax rates.
-        mtr_combined: a numpy array of marginal combined tax rates, which is
+        A tuple of numpy arrays in the following order:
+        mtr_payrolltax: an array of marginal payroll tax rates.
+        mtr_incometax: an array of marginal individual income tax rates.
+        mtr_combined: an array of marginal combined tax rates, which is
                       the sum of mtr_payrolltax and mtr_incometax.
 
         Notes
         -----
+        The arguments zero_out_calculated_vars and calc_all_already_called
+        cannot both be true.
+
         Valid variable_str values are:
         'e00200p', taxpayer wage/salary earnings (also included in e00200);
         'e00200s', spouse wage/salary earnings (also included in e00200);
@@ -314,7 +326,9 @@ class Calculator(object):
         'e19800',  Charity cash contributions;
         'e20100',  Charity non-cash contributions.
         """
-        # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+        # pylint: disable=too-many-arguments,too-many-statements
+        # pylint: disable=too-many-locals,too-many-branches
+        assert not zero_out_calculated_vars or not calc_all_already_called
         # check validity of variable_str parameter
         if variable_str not in Calculator.MTR_VALID_VARIABLES:
             msg = 'mtr variable_str="{}" is not valid'
@@ -357,7 +371,8 @@ class Calculator(object):
         combined_taxes_chng = incometax_chng + payrolltax_chng
         # calculate base level of taxes after restoring records object
         setattr(self, 'records', recs0)
-        self.calc_all(zero_out_calc_vars=zero_out_calculated_vars)
+        if not calc_all_already_called or zero_out_calculated_vars:
+            self.calc_all(zero_out_calc_vars=zero_out_calculated_vars)
         payrolltax_base = copy.deepcopy(self.records.payrolltax)
         incometax_base = copy.deepcopy(self.records.iitax)
         combined_taxes_base = incometax_base + payrolltax_base

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -169,14 +169,22 @@ def test_calculator_current_law_version(cps_subsample):
 
 def test_calculator_mtr(cps_subsample):
     rec = Records.cps_constructor(data=cps_subsample)
+    calcx = Calculator(policy=Policy(), records=rec)
+    calcx.calc_all()
+    combinedx = calcx.array('combined')
+    c00100x = calcx.array('c00100')
     calc = Calculator(policy=Policy(), records=rec)
     recs_pre_e00200p = copy.deepcopy(calc.array('e00200p'))
     (mtr_ptx, mtr_itx, mtr_cmb) = calc.mtr(variable_str='e00200p',
                                            zero_out_calculated_vars=True)
-    recs_post_e00200p = copy.deepcopy(calc.array('e00200p'))
+    combined = calc.array('combined')
+    c00100 = calc.array('c00100')
+    recs_post_e00200p = calc.array('e00200p')
     assert np.allclose(recs_post_e00200p, recs_pre_e00200p)
     assert np.array_equal(mtr_cmb, mtr_ptx) is False
     assert np.array_equal(mtr_ptx, mtr_itx) is False
+    assert np.allclose(combined, combinedx)
+    assert np.allclose(c00100, c00100x)
     with pytest.raises(ValueError):
         calc.mtr(variable_str='bad_income_type')
     (_, _, mtr_combined) = calc.mtr(variable_str='e00200s')

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -170,27 +170,28 @@ def test_calculator_current_law_version(cps_subsample):
 def test_calculator_mtr(cps_subsample):
     rec = Records.cps_constructor(data=cps_subsample)
     calc = Calculator(policy=Policy(), records=rec)
-    recs_pre_e00200p = copy.deepcopy(calc.records.e00200p)
-    (mtr_ptx, mtr_itx, mtr_combined) = calc.mtr(variable_str='e00200p',
-                                                zero_out_calculated_vars=True)
-    recs_post_e00200p = copy.deepcopy(calc.records.e00200p)
+    recs_pre_e00200p = copy.deepcopy(calc.array('e00200p'))
+    (mtr_ptx, mtr_itx, mtr_cmb) = calc.mtr(variable_str='e00200p',
+                                           zero_out_calculated_vars=True)
+    recs_post_e00200p = copy.deepcopy(calc.array('e00200p'))
     assert np.allclose(recs_post_e00200p, recs_pre_e00200p)
-    assert type(mtr_combined) == np.ndarray
-    assert np.array_equal(mtr_combined, mtr_ptx) is False
+    assert np.array_equal(mtr_cmb, mtr_ptx) is False
     assert np.array_equal(mtr_ptx, mtr_itx) is False
     with pytest.raises(ValueError):
         calc.mtr(variable_str='bad_income_type')
     (_, _, mtr_combined) = calc.mtr(variable_str='e00200s')
-    assert type(mtr_combined) == np.ndarray
+    assert isinstance(mtr_combined, np.ndarray)
     (_, _, mtr_combined) = calc.mtr(variable_str='e00650',
                                     negative_finite_diff=True)
-    assert type(mtr_combined) == np.ndarray
+    assert isinstance(mtr_combined, np.ndarray)
     (_, _, mtr_combined) = calc.mtr(variable_str='e00900p')
-    assert type(mtr_combined) == np.ndarray
+    assert isinstance(mtr_combined, np.ndarray)
     (_, _, mtr_combined) = calc.mtr(variable_str='e01700')
-    assert type(mtr_combined) == np.ndarray
+    assert isinstance(mtr_combined, np.ndarray)
     (_, _, mtr_combined) = calc.mtr(variable_str='e26270')
-    assert type(mtr_combined) == np.ndarray
+    assert isinstance(mtr_combined, np.ndarray)
+    (_, _, mtr_combined) = calc.mtr(variable_str='e00200p')
+    assert np.allclose(mtr_combined, mtr_cmb)
 
 
 def test_calculator_mtr_when_PT_rates_differ():

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -177,29 +177,35 @@ def test_calculator_mtr(cps_subsample):
     recs_pre_e00200p = copy.deepcopy(calc.array('e00200p'))
     (mtr_ptx, mtr_itx, mtr_cmb) = calc.mtr(variable_str='e00200p',
                                            zero_out_calculated_vars=True)
-    combined = calc.array('combined')
-    c00100 = calc.array('c00100')
     recs_post_e00200p = calc.array('e00200p')
     assert np.allclose(recs_post_e00200p, recs_pre_e00200p)
+    assert np.allclose(calc.array('combined'), combinedx)
+    assert np.allclose(calc.array('c00100'), c00100x)
     assert np.array_equal(mtr_cmb, mtr_ptx) is False
     assert np.array_equal(mtr_ptx, mtr_itx) is False
-    assert np.allclose(combined, combinedx)
-    assert np.allclose(c00100, c00100x)
     with pytest.raises(ValueError):
         calc.mtr(variable_str='bad_income_type')
-    (_, _, mtr_combined) = calc.mtr(variable_str='e00200s')
+    (_, _, mtr_combined) = calc.mtr(variable_str='e00200s',
+                                    calc_all_already_called=True)
     assert isinstance(mtr_combined, np.ndarray)
     (_, _, mtr_combined) = calc.mtr(variable_str='e00650',
-                                    negative_finite_diff=True)
+                                    negative_finite_diff=True,
+                                    calc_all_already_called=True)
     assert isinstance(mtr_combined, np.ndarray)
-    (_, _, mtr_combined) = calc.mtr(variable_str='e00900p')
+    (_, _, mtr_combined) = calc.mtr(variable_str='e00900p',
+                                    calc_all_already_called=True)
     assert isinstance(mtr_combined, np.ndarray)
-    (_, _, mtr_combined) = calc.mtr(variable_str='e01700')
+    (_, _, mtr_combined) = calc.mtr(variable_str='e01700',
+                                    calc_all_already_called=True)
     assert isinstance(mtr_combined, np.ndarray)
-    (_, _, mtr_combined) = calc.mtr(variable_str='e26270')
+    (_, _, mtr_combined) = calc.mtr(variable_str='e26270',
+                                    calc_all_already_called=True)
     assert isinstance(mtr_combined, np.ndarray)
-    (_, _, mtr_combined) = calc.mtr(variable_str='e00200p')
+    (_, _, mtr_combined) = calc.mtr(variable_str='e00200p',
+                                    calc_all_already_called=True)
     assert np.allclose(mtr_combined, mtr_cmb)
+    assert np.allclose(calc.array('combined'), combinedx)
+    assert np.allclose(calc.array('c00100'), c00100x)
 
 
 def test_calculator_mtr_when_PT_rates_differ():


### PR DESCRIPTION
This pull request adds an argument to Calculator.mtr that can be used to speed up the calculation of marginal tax rates for many different variables.  Best to illustrate in an example.  The old way of "mass producing" MTRs is like this:
```
calc = Calculator(...)
_, _, mtr1 = calc.mtr('e00650')
_, _, mtr2 = calc.mtr('e01700')
_, _, mtr3 = calc.mtr('p22250')
_, _, mtr4 = calc.mtr('p23250')
```
With this pull request, you can do the following in order to skip one of the two `calc.calc_all()` calls in each of `calc.mtr()` calls:
```
calc = Calculator(...)
calc.calc_all()
_, _, mtr1 = calc.mtr('e00650', calc_all_already_called=True)
_, _, mtr2 = calc.mtr('e01700', calc_all_already_called=True)
_, _, mtr3 = calc.mtr('p22250', calc_all_already_called=True)
_, _, mtr4 = calc.mtr('p23250', calc_all_already_called=True)
```
How much using this technique reduces your script's runtime depends on what fraction of your script's runtime is spent executing the two `calc_all()` calls in the `mtr()` method.  If you want to know where the bottlenecks are in a slow-running script, you should use a [Python profiler](https://docs.python.org/2/library/profile.html) to find out what code your script spends most of its time executing.
