### PR TITLE
Add ability to customize variables included in --dump and --sqldb output

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,8 +13,11 @@ for a complete commit history.
 - Add several Calculator table methods and revise table utilities to not use Calculator object(s)
   [[#1718](https://github.com/open-source-economics/Tax-Calculator/pull/1718)
   by Martin Holmer]
-- Add several Calculator graph methods and revise graph utilities to not use Calculator object(s)
+- Add several Calculator graph methods and revise graph utilities to not use Calculator objects
   [[#1722](https://github.com/open-source-economics/Tax-Calculator/pull/1722)
+  by Martin Holmer]
+- Add Calculator ce_aftertax_income method and revise corresponding utility to not use Calculator object
+  [[#1723](https://github.com/open-source-economics/Tax-Calculator/pull/1723)
   by Martin Holmer]
 
 **New Features**
@@ -24,6 +27,9 @@ for a complete commit history.
 - Remove calculation of AGI tables from the TaxBrain Interface, tbi
   [[#1724](https://github.com/open-source-economics/Tax-Calculator/pull/1724)
   by Martin Holmer as suggested by Matt Jensen and Hank Doupe]
+- Add ability to specify partial customized CLI `tc --dump` output
+  [[#1735](https://github.com/open-source-economics/Tax-Calculator/pull/1735)
+  by Martin Holmer as suggested by Sean Wang]
 
 **Bug Fixes**
 - Fix Behavior.response method to handle very high marginal tax rates

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,8 +22,8 @@ or making an enhancement to the Python source code &mdash; you should go to
 the <a href="https://github.com/open-source-economics/Tax-Calculator">
 developer website</a>.</p>
 
-<p>Please cite the source of your analysis as "Tax-Calculator v.
-#.#.#, author's calculations." If you wish to link to Tax-Calculator,
+<p>Please cite the source of your analysis as <q>Tax-Calculator v.
+#.#.#, author's calculations.</q> If you wish to link to Tax-Calculator,
 this page is preferred. Additionally, we strongly recommend that you 
 provide a link to the materials required to replicate your
 analysis or, at least, note that those materials are available 
@@ -418,6 +418,21 @@ dividends (<kbd>e00650</kbd>) for each filing unit.  Again, it is your
 responsibility to prepare input data in a way that ensures this
 relationship is true for each filing unit.</p>
 
+<p>Here's an example of how to specify a few stylized filing units
+with and without young children.
+<pre>
+RECID,MARS,XTOT,EIC,n24,...
+   11,   1,   1,  0,  0, ... <== single person with no kids
+   12,   4,   2,  1,  1, ... <== single person with a young kid
+   13,   2,   4,  2,  2, ... <== married couple with two young kids
+</pre>
+Be sure to read the documentation of the <kbd>MARS</kbd>, <kbd>XTOT</kbd>,
+<kbd>EIC</kbd>, and <kbd>n24</kbd> input variables.  Also, there may
+be a need to add of child-age input variables if you want to simulate
+reforms like a child credit bonus for children under five years of
+age.  Also, the universal basic income (UBI) reform is implemented
+using its own set of three age-count input variables.
+
 <p><a href="#cli">Back to Section Contents</a></p>
 
 
@@ -470,9 +485,9 @@ named <kbd>test-20-#-#-doc.text</kbd>.</p>
 name <kbd>test-20-#-#.csv</kbd> as the minimal output file produced in
 example (1).  No other output is generated other than the
 <kbd>test-20-#-#-doc.text</kbd> file.   The
-<kbd>--dump</kbd> option causes all the input variables (including the
-one's understood by Tax-Calculator but not included
-in <kbd>test.csv</kbd>, which are all zero) and all the output
+<kbd>--dump</kbd> option causes <b>all</b> the input variables (including
+the ones understood by Tax-Calculator but not included
+in <kbd>test.csv</kbd>, which are all zero) and <b>all</b> the output
 variables calculated by Tax-Calculator to be included in the output
 file.  For a complete list of input variables, see
 the <a href="#input">Input Variables</a> section.  For a complete list
@@ -483,6 +498,20 @@ example (2) can be used as an input file and it will produce exactly
 the same tax liabilities (apart from rounding errors of one or two
 cents) as in the original dump output.</p>
 
+<p>This full dump output can be useful for debugging and is small
+when using a number of stylized filing units as input.  But when using
+large samples as input (for example, the <kbd>cps.csv</kbd> input
+file), the size of the dump output can be quite large.  Beginning with
+Tax-Calculator version 0.14.0, there is a way to specify a partial
+dump that includes only variables of interest.  To have <kbd>tc</kbd>
+do a partial dump, create a file named <kbd>tcdumpvars</kbd> in the
+directory where <kbd>tc</kbd> writes output files and in that
+<kbd>tcdumpvars</kbd> file list the names of the variables to be
+included in the partial dump.  You can put the varible names on
+separate lines and/or put several names on one line separated by
+spaces.  If there is no <kbd>tcdumpvars</kbd> file, the
+<kbd>--dump</kbd> option produces a full dump.</p>
+
 <p><pre>
 (3)$ tc test.csv 2020 --sqldb
 </pre></p>
@@ -492,7 +521,9 @@ that the dump output is written not to a CSV-formatted file, but to
 the dump table in an SQLite3 database file, which is
 called <kbd>test-20-#-#.db</kbd> in this example.  Because
 the <kbd>--dump</kbd> option is not used in example (3), minimal
-output will be written to the <kbd>test-20-#-#.csv</kbd> file.</p>
+output will be written to the <kbd>test-20-#-#.csv</kbd> file.
+Note that the presence of the <kbd>tcdumpvars</kbd> file causes
+the contents of the database file to be a partial dump.</p>
 
 <p> Pros and cons of putting dump output in a CSV file or an SQLite3
 database table:  The CSV file is almost twice as large as the

--- a/docs/index.htmx
+++ b/docs/index.htmx
@@ -417,6 +417,21 @@ dividends (<kbd>e00650</kbd>) for each filing unit.  Again, it is your
 responsibility to prepare input data in a way that ensures this
 relationship is true for each filing unit.</p>
 
+<p>Here's an example of how to specify a few stylized filing units
+with and without young children.
+<pre>
+RECID,MARS,XTOT,EIC,n24,...
+   11,   1,   1,  0,  0, ... <== single person with no kids
+   12,   4,   2,  1,  1, ... <== single person with a young kid
+   13,   2,   4,  2,  2, ... <== married couple with two young kids
+</pre>
+Be sure to read the documentation of the <kbd>MARS</kbd>, <kbd>XTOT</kbd>,
+<kbd>EIC</kbd>, and <kbd>n24</kbd> input variables.  Also, there may
+be a need to add of child-age input variables if you want to simulate
+reforms like a child credit bonus for children under five years of
+age.  Also, the universal basic income (UBI) reform is implemented
+using its own set of three age-count input variables.
+
 <p><a href="#cli">Back to Section Contents</a></p>
 
 
@@ -469,9 +484,9 @@ named <kbd>test-20-#-#-doc.text</kbd>.</p>
 name <kbd>test-20-#-#.csv</kbd> as the minimal output file produced in
 example (1).  No other output is generated other than the
 <kbd>test-20-#-#-doc.text</kbd> file.   The
-<kbd>--dump</kbd> option causes all the input variables (including the
-one's understood by Tax-Calculator but not included
-in <kbd>test.csv</kbd>, which are all zero) and all the output
+<kbd>--dump</kbd> option causes <b>all</b> the input variables (including
+the ones understood by Tax-Calculator but not included
+in <kbd>test.csv</kbd>, which are all zero) and <b>all</b> the output
 variables calculated by Tax-Calculator to be included in the output
 file.  For a complete list of input variables, see
 the <a href="#input">Input Variables</a> section.  For a complete list
@@ -482,6 +497,20 @@ example (2) can be used as an input file and it will produce exactly
 the same tax liabilities (apart from rounding errors of one or two
 cents) as in the original dump output.</p>
 
+<p>This full dump output can be useful for debugging and is small
+when using a number of stylized filing units as input.  But when using
+large samples as input (for example, the <kbd>cps.csv</kbd> input
+file), the size of the dump output can be quite large.  Beginning with
+Tax-Calculator version 0.14.0, there is a way to specify a partial
+dump that includes only variables of interest.  To have <kbd>tc</kbd>
+do a partial dump, create a file named <kbd>tcdumpvars</kbd> in the
+directory where <kbd>tc</kbd> writes output files and in that
+<kbd>tcdumpvars</kbd> file list the names of the variables to be
+included in the partial dump.  You can put the varible names on
+separate lines and/or put several names on one line separated by
+spaces.  If there is no <kbd>tcdumpvars</kbd> file, the
+<kbd>--dump</kbd> option produces a full dump.</p>
+
 <p><pre>
 (3)$ tc test.csv 2020 --sqldb
 </pre></p>
@@ -491,7 +520,9 @@ that the dump output is written not to a CSV-formatted file, but to
 the dump table in an SQLite3 database file, which is
 called <kbd>test-20-#-#.db</kbd> in this example.  Because
 the <kbd>--dump</kbd> option is not used in example (3), minimal
-output will be written to the <kbd>test-20-#-#.csv</kbd> file.</p>
+output will be written to the <kbd>test-20-#-#.csv</kbd> file.
+Note that the presence of the <kbd>tcdumpvars</kbd> file causes
+the contents of the database file to be a partial dump.</p>
 
 <p> Pros and cons of putting dump output in a CSV file or an SQLite3
 database table:  The CSV file is almost twice as large as the

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -6,6 +6,7 @@ which can be accessed as 'tc' from an installed taxcalc conda package.
 # pep8 --ignore=E402 tc.py
 # pylint --disable=locally-disabled tc.py
 
+import os
 import sys
 import argparse
 import difflib
@@ -132,14 +133,16 @@ def cli_tc_main():
         sys.stderr.write(tcio.errmsg)
         sys.stderr.write('USAGE: tc --help\n')
         return 1
+    dumpvar_set = None
     if args.dump or args.sqldb:
-        dumpvar_set = tcio.custom_dump_variables()
-        if tcio.errmsg:
-            sys.stderr.write(tcio.errmsg)
-            sys.stderr.write('USAGE: tc --help\n')
-            return 1
-    else:
-        dumpvar_set = None
+        if os.path.exists('tcdumpvars'):
+            with open('tcdumpvars') as vfile:
+                dump_vars_str = vfile.read()
+            dumpvar_set = tcio.custom_dump_variables(dump_vars_str)
+            if tcio.errmsg:
+                sys.stderr.write(tcio.errmsg)
+                sys.stderr.write('USAGE: tc --help\n')
+                return 1
     tcio.analyze(writing_output_file=True,
                  output_tables=args.tables,
                  output_graphs=args.graphs,

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -86,9 +86,13 @@ def cli_tc_main():
                               'all INPUT variables (extrapolated to TAXYEAR) '
                               'and all calculated tax variables for the '
                               'reform, where all the variables are named '
-                              'using their internal Tax-Calculator names.  No '
-                              '--dump option implies OUTPUT contains minimal '
-                              'tax output for the reform.'),
+                              'using their internal Tax-Calculator names. '
+                              'No --dump option implies OUTPUT contains '
+                              'minimal tax output for the reform. '
+                              'NOTE: create a space-delimited file named '
+                              'tcdumpvars in directory where output is being '
+                              'written in order to specify a custom set of '
+                              'dump variables.'),
                         default=False,
                         action="store_true")
     parser.add_argument('--sqldb',
@@ -128,10 +132,19 @@ def cli_tc_main():
         sys.stderr.write(tcio.errmsg)
         sys.stderr.write('USAGE: tc --help\n')
         return 1
+    if args.dump or args.sqldb:
+        dumpvar_set = tcio.custom_dump_variables()
+        if tcio.errmsg:
+            sys.stderr.write(tcio.errmsg)
+            sys.stderr.write('USAGE: tc --help\n')
+            return 1
+    else:
+        dumpvar_set = None
     tcio.analyze(writing_output_file=True,
                  output_tables=args.tables,
                  output_graphs=args.graphs,
                  output_ceeu=args.ceeu,
+                 dump_varset=dumpvar_set,
                  output_dump=args.dump,
                  output_sqldb=args.sqldb)
     # compare test output with expected test output if --test option specified

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -273,42 +273,35 @@ class TaxCalcIO(object):
         # remember parameter dictionary for reform documentation
         self.param_dict = paramdict
 
-    def custom_dump_variables(self):
+    def custom_dump_variables(self, tcdumpvars_str):
         """
-        Return set of variable names read from tcdumpvars file or
-        return None if the tcdumpvars file does not exist in the
-        current directory.
+        Return set of variable names extracted from tcdumpvars_str, which
+        contains the contents of the tcdumpvars file in the current directory.
         Also, builds self.errmsg if any custom variables are not valid.
         """
+        assert isinstance(tcdumpvars_str, six.string_types)
         self.errmsg = ''
-        if os.path.exists('tcdumpvars'):
-            # read the file contents into a string
-            with open('tcdumpvars') as vfile:
-                dump_vars_str = vfile.read()
-            # change some delimiter characters into spaces
-            dump_vars_str = dump_vars_str.replace('\n', ' ')
-            dump_vars_str = dump_vars_str.replace(',', ' ')
-            dump_vars_str = dump_vars_str.replace(';', ' ')
-            dump_vars_str = dump_vars_str.replace('|', ' ')
-            # split dump_vars_str into a list of dump variables
-            dump_vars_list = dump_vars_str.split()
-            # check that all dump_vars_list items are valid
-            valid_set = Records.USABLE_READ_VARS | Records.CALCULATED_VARS
-            for var in dump_vars_list:
-                if var not in valid_set:
-                    msg = 'invalid variable name in tcdumpvars file: {}'
-                    msg = msg.format(var)
-                    self.errmsg += 'ERROR: {}\n'.format(msg)
-            # add essential variables even if not on custom list
-            if 'RECID' not in dump_vars_list:
-                dump_vars_list.append('RECID')
-            if 'FLPDYR' not in dump_vars_list:
-                dump_vars_list.append('FLPDYR')
-            # convert list into a set
-            custom_varset = set(dump_vars_list)
-        else:  # if no tcdumpvars file exists in current directory
-            custom_varset = None
-        return custom_varset
+        # change some delimiter characters into spaces
+        dump_vars_str = tcdumpvars_str.replace('\n', ' ')
+        dump_vars_str = dump_vars_str.replace(',', ' ')
+        dump_vars_str = dump_vars_str.replace(';', ' ')
+        dump_vars_str = dump_vars_str.replace('|', ' ')
+        # split dump_vars_str into a list of dump variables
+        dump_vars_list = dump_vars_str.split()
+        # check that all dump_vars_list items are valid
+        valid_set = Records.USABLE_READ_VARS | Records.CALCULATED_VARS
+        for var in dump_vars_list:
+            if var not in valid_set:
+                msg = 'invalid variable name in tcdumpvars file: {}'
+                msg = msg.format(var)
+                self.errmsg += 'ERROR: {}\n'.format(msg)
+        # add essential variables even if not on custom list
+        if 'RECID' not in dump_vars_list:
+            dump_vars_list.append('RECID')
+        if 'FLPDYR' not in dump_vars_list:
+            dump_vars_list.append('FLPDYR')
+        # convert list into a set and return
+        return set(dump_vars_list)
 
     def tax_year(self):
         """

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -278,9 +278,8 @@ class TaxCalcIO(object):
         """
         assert isinstance(tcdumpvars_str, six.string_types)
         self.errmsg = ''
-        # change some delimiter characters into spaces
-        dump_vars_str = tcdumpvars_str.replace('\n', ' ')
-        dump_vars_str = dump_vars_str.replace(',', ' ')
+        # change some common delimiter characters into spaces
+        dump_vars_str = tcdumpvars_str.replace(',', ' ')
         dump_vars_str = dump_vars_str.replace(';', ' ')
         dump_vars_str = dump_vars_str.replace('|', ' ')
         # split dump_vars_str into a list of dump variables

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -273,6 +273,43 @@ class TaxCalcIO(object):
         # remember parameter dictionary for reform documentation
         self.param_dict = paramdict
 
+    def custom_dump_variables(self):
+        """
+        Return set of variable names read from tcdumpvars file or
+        return None if the tcdumpvars file does not exist in the
+        current directory.
+        Also, builds self.errmsg if any custom variables are not valid.
+        """
+        self.errmsg = ''
+        if os.path.exists('tcdumpvars'):
+            # read the file contents into a string
+            with open('tcdumpvars') as vfile:
+                dump_vars_str = vfile.read()
+            # change some delimiter characters into spaces
+            dump_vars_str = dump_vars_str.replace('\n', ' ')
+            dump_vars_str = dump_vars_str.replace(',', ' ')
+            dump_vars_str = dump_vars_str.replace(';', ' ')
+            dump_vars_str = dump_vars_str.replace('|', ' ')
+            # split dump_vars_str into a list of dump variables
+            dump_vars_list = dump_vars_str.split()
+            # check that all dump_vars_list items are valid
+            valid_set = Records.USABLE_READ_VARS | Records.CALCULATED_VARS
+            for var in dump_vars_list:
+                if var not in valid_set:
+                    msg = 'invalid variable name in tcdumpvars file: {}'
+                    msg = msg.format(var)
+                    self.errmsg += 'ERROR: {}\n'.format(msg)
+            # add essential variables even if not on custom list
+            if 'RECID' not in dump_vars_list:
+                dump_vars_list.append('RECID')
+            if 'FLPDYR' not in dump_vars_list:
+                dump_vars_list.append('FLPDYR')
+            # convert list into a set
+            custom_varset = set(dump_vars_list)
+        else:  # if no tcdumpvars file exists in current directory
+            custom_varset = None
+        return custom_varset
+
     def tax_year(self):
         """
         Return calendar year for which TaxCalcIO calculations are being done.
@@ -290,6 +327,7 @@ class TaxCalcIO(object):
                 output_tables=False,
                 output_graphs=False,
                 output_ceeu=False,
+                dump_varset=None,
                 output_dump=False,
                 output_sqldb=False):
         """
@@ -312,6 +350,10 @@ class TaxCalcIO(object):
            whether or not to calculate and write to stdout standard
            certainty-equivalent expected-utility statistics
 
+        dump_varset: set
+           custom set of variables to include in dump and sqldb output;
+           None implies include all variables in dump and sqldb output
+
         output_dump: boolean
            whether or not to replace standard output with all input and
            calculated variables using their Tax-Calculator names
@@ -332,9 +374,11 @@ class TaxCalcIO(object):
                               'CONTINUING WITH CALCULATIONS...'))
         calc_clp_calculated = False
         if output_dump or output_sqldb:
+            # might need marginal tax rates
             (mtr_paytax, mtr_inctax,
              _) = self.calc.mtr(wrt_full_compensation=False)
-        else:  # do not need marginal tax rates
+        else:
+            # definitely do not need marginal tax rates
             mtr_paytax = None
             mtr_inctax = None
         if self.behavior_has_any_response:
@@ -363,11 +407,12 @@ class TaxCalcIO(object):
             ceeu_results = None
         # extract output if writing_output_file
         if writing_output_file:
-            self.write_output_file(output_dump, mtr_paytax, mtr_inctax)
+            self.write_output_file(output_dump, dump_varset,
+                                   mtr_paytax, mtr_inctax)
             self.write_doc_file()
         # optionally write --sqldb output to SQLite3 database
         if output_sqldb:
-            self.write_sqldb_file(mtr_paytax, mtr_inctax)
+            self.write_sqldb_file(dump_varset, mtr_paytax, mtr_inctax)
         # optionally write --tables output to text file
         if output_tables:
             if not calc_clp_calculated:
@@ -384,12 +429,13 @@ class TaxCalcIO(object):
         if ceeu_results:
             print(ceeu_results)
 
-    def write_output_file(self, output_dump, mtr_paytax, mtr_inctax):
+    def write_output_file(self, output_dump, dump_varset,
+                          mtr_paytax, mtr_inctax):
         """
         Write output to CSV-formatted file.
         """
         if output_dump:
-            outdf = self.dump_output(mtr_inctax, mtr_paytax)
+            outdf = self.dump_output(dump_varset, mtr_inctax, mtr_paytax)
             column_order = sorted(outdf.columns)
         else:
             outdf = self.minimal_output()
@@ -407,11 +453,11 @@ class TaxCalcIO(object):
         with open(doc_fname, 'w') as dfile:
             dfile.write(doc)
 
-    def write_sqldb_file(self, mtr_paytax, mtr_inctax):
+    def write_sqldb_file(self, dump_varset, mtr_paytax, mtr_inctax):
         """
         Write dump output to SQLite3 database table dump.
         """
-        outdf = self.dump_output(mtr_inctax, mtr_paytax)
+        outdf = self.dump_output(dump_varset, mtr_inctax, mtr_paytax)
         assert len(outdf.index) == self.calc.records.dim
         db_fname = self._output_filename.replace('.csv', '.db')
         dbcon = sqlite3.connect(db_fname)
@@ -598,23 +644,29 @@ class TaxCalcIO(object):
             txt += '      because "alltax difference" is essentially zero'
         return txt
 
-    def dump_output(self, mtr_inctax, mtr_paytax):
+    def dump_output(self, dump_varset, mtr_inctax, mtr_paytax):
         """
         Extract dump output and return it as Pandas DataFrame.
         """
-        # specify mtr values in percentage terms
-        self.calc.records.mtr_inctax[:] = mtr_inctax * 100.
-        self.calc.records.mtr_paytax[:] = mtr_paytax * 100.
+        if dump_varset is None:
+            varset = Records.USABLE_READ_VARS | Records.CALCULATED_VARS
+        else:
+            varset = dump_varset
         # create and return dump output DataFrame
         odf = pd.DataFrame()
-        varset = Records.USABLE_READ_VARS | Records.CALCULATED_VARS
         for varname in varset:
-            vardata = getattr(self.calc.records, varname)
+            vardata = self.calc.array(varname)
             if varname in Records.INTEGER_VARS:
                 odf[varname] = vardata
             else:
                 odf[varname] = vardata.round(2)  # rounded to nearest cent
-        odf['FLPDYR'] = self.tax_year()  # tax calculation year
+        # specify mtr values in percentage terms
+        if 'mtr_inctax' in varset:
+            odf['mtr_inctax'] = (mtr_inctax * 100).round(2)
+        if 'mtr_paytax' in varset:
+            odf['mtr_paytax'] = (mtr_paytax * 100).round(2)
+        # specify tax calculation year
+        odf['FLPDYR'] = self.tax_year()
         return odf
 
     @staticmethod

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -358,6 +358,37 @@ def test_ctor_init_with_cps_files():
     assert tcio.errmsg
 
 
+@pytest.mark.parametrize("dumpvar_str, str_valid", [
+    ("""
+    MARS, combined;iitax|  payrolltax
+
+    c00100
+    """, True),
+    ("""
+    MARS
+    kombined
+    """, False)
+])
+def test_custom_dump_variables(dumpvar_str, str_valid):
+    """
+    Test TaxCalcIO custom_dump_variables method.
+    """
+    recdict = {'RECID': 1, 'MARS': 1, 'e00300': 100000, 's006': 1e8}
+    recdf = pd.DataFrame(data=recdict, index=[0])
+    year = 2018
+    tcio = TaxCalcIO(input_data=recdf, tax_year=year, reform=None, assump=None)
+    assert not tcio.errmsg
+    tcio.init(input_data=recdf, tax_year=year, reform=None, assump=None,
+              growdiff_response=None,
+              aging_input_data=False,
+              exact_calculations=False)
+    assert not tcio.errmsg
+    varset = tcio.custom_dump_variables(dumpvar_str)
+    assert isinstance(varset, set)
+    valid = len(tcio.errmsg) == 0
+    assert valid == str_valid
+
+
 def test_output_otions(rawinputfile, reformfile1, assumpfile1):
     """
     Test TaxCalcIO output_ceeu & output_dump options when writing_output_file.
@@ -387,9 +418,22 @@ def test_output_otions(rawinputfile, reformfile1, assumpfile1):
             except OSError:
                 pass  # sometimes we can't remove a generated temporary file
         assert 'TaxCalcIO.analyze(ceeu)_ok' == 'no'
-    # --dump output
+    # --dump output with full dump
     try:
         tcio.analyze(writing_output_file=True, output_dump=True)
+    except:  # pylint: disable=bare-except
+        if os.path.isfile(outfilepath):
+            try:
+                os.remove(outfilepath)
+            except OSError:
+                pass  # sometimes we can't remove a generated temporary file
+        assert 'TaxCalcIO.analyze(dump)_ok' == 'no'
+
+    # --dump output with partial dump
+    try:
+        tcio.analyze(writing_output_file=True,
+                     dump_varset=set(['combined']),
+                     output_dump=True)
     except:  # pylint: disable=bare-except
         if os.path.isfile(outfilepath):
             try:

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -360,11 +360,11 @@ def test_ctor_init_with_cps_files():
 
 @pytest.mark.parametrize("dumpvar_str, str_valid, num_vars", [
     ("""
-    MARS;iitax	payrolltax|combined,c00100
+    MARS;iitax	payrolltax|combined,
+    c00100
     surtax
-    RECID
-    FLPDYR
-    """, True, 8),
+    """, True, 8),  # these six plus added RECID and FLPDYR
+
     ("""
     MARS;iitax	payrolltax|kombined,c00100
     surtax

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -363,13 +363,13 @@ def test_ctor_init_with_cps_files():
     MARS;iitax	payrolltax|combined,c00100
     surtax
     RECID
-    FLPDYR   
+    FLPDYR
     """, True, 8),
     ("""
     MARS;iitax	payrolltax|kombined,c00100
     surtax
     RECID
-    FLPDYR   
+    FLPDYR
     """, False, 8)
 ])
 def test_custom_dump_variables(dumpvar_str, str_valid, num_vars):

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -358,18 +358,21 @@ def test_ctor_init_with_cps_files():
     assert tcio.errmsg
 
 
-@pytest.mark.parametrize("dumpvar_str, str_valid", [
+@pytest.mark.parametrize("dumpvar_str, str_valid, num_vars", [
     ("""
-    MARS, combined;iitax|  payrolltax
-
-    c00100
-    """, True),
+    MARS;iitax	payrolltax|combined,c00100
+    surtax
+    RECID
+    FLPDYR   
+    """, True, 8),
     ("""
-    MARS
-    kombined
-    """, False)
+    MARS;iitax	payrolltax|kombined,c00100
+    surtax
+    RECID
+    FLPDYR   
+    """, False, 8)
 ])
-def test_custom_dump_variables(dumpvar_str, str_valid):
+def test_custom_dump_variables(dumpvar_str, str_valid, num_vars):
     """
     Test TaxCalcIO custom_dump_variables method.
     """
@@ -387,6 +390,8 @@ def test_custom_dump_variables(dumpvar_str, str_valid):
     assert isinstance(varset, set)
     valid = len(tcio.errmsg) == 0
     assert valid == str_valid
+    if valid:
+        assert len(varset) == num_vars
 
 
 def test_output_otions(rawinputfile, reformfile1, assumpfile1):


### PR DESCRIPTION
This pull request adds to the Tax-Calculator CLI `tc` an option for specifying a partial dump.  After this pull request is merged, if the `tcdumpvars` file exists (in the directory where `tc` writes output files), the `--dump` and `--sqldb` output files contain only the variables listed in the  `tcdumpvars` file (plus `RECID` and `FLPDYR`, if they aren't in the `tcdumpvars` file).  If the `tcdumpvars` file does not exist, the `--dump` and `--sqldb` output files contain **all** input and calculated variables, just as before this pull request.
