### PR TITLE
Add calculation of ALL values for perc_cut and perc_inc in difference table

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,6 +24,9 @@ for a complete commit history.
 - Remove calculation of AGI tables from the TaxBrain Interface, tbi
   [[#1724](https://github.com/open-source-economics/Tax-Calculator/pull/1724)
   by Martin Holmer as suggested by Matt Jensen and Hank Doupe]
+- Add calculation of two values on the ALL row of the difference table
+  [[#1741](https://github.com/open-source-economics/Tax-Calculator/pull/1741)
+  by Martin Holmer]
 
 **Bug Fixes**
 - Fix Behavior.response method to handle very high marginal tax rates

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -491,6 +491,15 @@ def create_difference_table(vdf1, vdf2, groupby, income_measure, tax_to_diff):
         if groupby == 'weighted_deciles':
             pdf = gpdf.get_group(10)  # top decile as its own DataFrame
             pdf = add_quantile_bins(copy.deepcopy(pdf), income_measure, 10)
+            # TODO: following statement generates this IGNORED error:
+            # ValueError: Buffer dtype mismatch,
+            #             expected 'Python object' but got 'long'
+            # Exception ValueError: "Buffer dtype mismatch,
+            #              expected 'Python object' but got 'long'"
+            #              in 'pandas._libs.lib.is_bool_array' ignored
+            #                                                  ^^^^^^^
+            # It is hoped that Pandas PR#17841, which is scheduled for
+            # inclusion in Pandas version 0.22.0 (Jan 2018), will fix this.
             pdf['bins'].replace(to_replace=[1, 2, 3, 4, 5],
                                 value=[0, 0, 0, 0, 0], inplace=True)
             pdf['bins'].replace(to_replace=[6, 7, 8, 9],


### PR DESCRIPTION
This pull request completes the process of calculating every one of the values in the difference table.  Since the beginning of the project, Tax-Calculator had left several values on the ALL (whole-sample) table row unspecified, setting them to NaN.  Now every value in the difference table is calculated in Tax-Calculator and all TaxBrain needs to do is display the calculated values.

This pull request resolves issue #1737 on the Tax-Calculator side, but there needs to be difference-table enhancements on the TaxBrain side, as described in OpenSourcePolicyCenter/PolicyBrain#73 and OpenSourcePolicyCenter/PolicyBrain#770.