### PR TITLE
Add cap on state and local income, sales and real estate tax deduction

### DIFF
--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1207,12 +1207,11 @@
         "out_of_range_action": "stop"
     },
 
-
     "_ID_AllTaxes_c": {
         "long_name": "Ceiling on the amount of state and local income, sales and real estate tax deductions allowed (dollars)",
         "description": "The amount of state and local income, sales and real estate tax deductions is limited to this dollar amount.",
         "section_1": "Itemized Deductions",
-        "section_2": "State and Local, And Foreign Real Estate Taxes",
+        "section_2": "State And Local Income And Sales Taxes",
         "irs_ref": "",
         "notes": "",
         "row_var": "FLPDYR",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -1207,6 +1207,37 @@
         "out_of_range_action": "stop"
     },
 
+
+    "_ID_AllTaxes_c": {
+        "long_name": "Ceiling on the amount of state and local income, sales and real estate tax deductions allowed (dollars)",
+        "description": "The amount of state and local income, sales and real estate tax deductions is limited to this dollar amount.",
+        "section_1": "Itemized Deductions",
+        "section_2": "State and Local, And Foreign Real Estate Taxes",
+        "irs_ref": "",
+        "notes": "",
+        "row_var": "FLPDYR",
+        "row_label": ["2013",
+                      "2014",
+                      "2015",
+                      "2016",
+                      "2017"],
+        "start_year": 2013,
+        "cpi_inflated": true,
+        "col_var": "MARS",
+        "col_label": ["single", "joint", "separate", "headhousehold", "widow"],
+        "boolean_value": false,
+        "integer_value": false,
+        "value": [[9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99],
+                  [9e99, 9e99, 9e99, 9e99, 9e99]],
+        "range": {"min": 0, "max": 9e99},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    },
+
     "_ID_InterestPaid_hc": {
         "long_name": "Interest paid deduction haircut",
         "description": "This decimal fraction can be applied to limit the amount of interest paid deduction allowed.",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -465,7 +465,7 @@ def ItemDed(e17500_capped, e18400_capped, e18500_capped,
             ID_Charity_hc, ID_InterestPaid_hc, ID_RealEstate_hc,
             ID_Medical_c, ID_StateLocalTax_c, ID_RealEstate_c,
             ID_InterestPaid_c, ID_Charity_c, ID_Casualty_c,
-            ID_Miscellaneous_c):
+            ID_Miscellaneous_c, ID_AllTaxes_c):
     """
     ItemDed function: itemized deductions, Form 1040, Schedule A
 
@@ -507,6 +507,9 @@ def ItemDed(e17500_capped, e18400_capped, e18500_capped,
         ID_StateLocalTax_c : Ceiling on state and local tax deduction
 
         ID_RealEstate_c : Ceiling on real estate tax deduction
+
+        ID_AllTaxes_c: Ceiling combined state and local income/sales and
+        real estate tax deductions
 
         ID_InterestPaid_c : Ceiling on interest paid deduction
 
@@ -551,7 +554,7 @@ def ItemDed(e17500_capped, e18400_capped, e18500_capped,
                  ID_StateLocalTax_c[MARS - 1])
     c18500 = min((1. - ID_RealEstate_hc) * e18500_capped,
                  ID_RealEstate_c[MARS - 1])
-    c18300 = c18400 + c18500
+    c18300 = min(c18400 + c18500, ID_AllTaxes_c[MARS - 1])
     # Interest paid
     c19200 = e19200_capped * (1. - ID_InterestPaid_hc)
     c19200 = min(c19200, ID_InterestPaid_c[MARS - 1])


### PR DESCRIPTION
This PR adds the ability to place a cap on the combined state and local income/sales and real estate deductions. This is consistent with the news descriptions of the reconciliation version of the TCJA, and the description from Kevin Brady as mentioned in #1755. 

Note that this simply caps the total amount of the deduction available. 