### PR TITLE
Add comments on WARNING messages to existing comments in several TCJA*json files

### DIFF
--- a/taxcalc/reforms/TCJA_House.json
+++ b/taxcalc/reforms/TCJA_House.json
@@ -16,7 +16,7 @@
 // Reform_Parameter_Map:
 // - 1: _II_rt*
 // - 2: _PT_rt*
-// - 3: _STD, _STD_Dep, _STD_Aged
+// - 3: _STD, _STD_Dep, _STD_Aged (can safely ignore WARNINGs about _STD_Dep values)
 // - 4: _II_em
 // - 5: _DependentCredit_*, _FilerCredit_c, _CTC_ps
 // - 6: _AMT_rt*

--- a/taxcalc/reforms/TCJA_House_Amended.json
+++ b/taxcalc/reforms/TCJA_House_Amended.json
@@ -16,7 +16,7 @@
 // Reform_Parameter_Map:
 // - 1: _II_rt*
 // - 2: _PT_rt*
-// - 3: _STD, _STD_Dep, _STD_Aged
+// - 3: _STD, _STD_Dep, _STD_Aged (can safely ignore WARNINGs about _STD_Dep values)
 // - 4: _II_em
 // - 5: _DependentCredit_*, _FilerCredit_c, _CTC_ps
 // - 6: _AMT_rt*

--- a/taxcalc/reforms/TCJA_Reconciliation.json
+++ b/taxcalc/reforms/TCJA_Reconciliation.json
@@ -14,12 +14,12 @@
 // Reform_Parameter_Map:
 // - 1: _II_*
 // - 2: _PT_*
-// - 3: _STD
+// - 3: _STD (can safely ignore WARNINGs about 2026+ values)
 // - 4: _II_em
 // - 5: _DependentCredit_*, _CTC_c, _CTC_ps, _ACTC_Income_thd
 // - 6: _AMT_rt*
 // - 7: _ALD_*
-// - 8: _ID_*
+// - 8: _ID_* (can safely ignore WARNINGs about values for several parameters)
 // - 9: _cpi_offset
 // Note: _II_rt*, _PT_rt*, _STD and _II_em are rounded to the nearest integer value.
 {

--- a/taxcalc/reforms/TCJA_Senate_111417.json
+++ b/taxcalc/reforms/TCJA_Senate_111417.json
@@ -14,12 +14,12 @@
 // Reform_Parameter_Map:
 // - 1: _II_rt*
 // - 2: _PT_rt*
-// - 3: _STD, _STD_Dep, _STD_Aged
+// - 3: _STD (can safely ignore WARNINGs about 2026+ values)
 // - 4: _II_em
 // - 5: _DependentCredit_*, _CTC_c, _CTC_ps, _ACTC_Income_thd
 // - 6: _AMT_rt*
 // - 7: _ALD_DomesticProduction_hc
-// - 8: _ID_*
+// - 8: _ID_* (can safely ignore WARNINGs about values for several parameters)
 // Note: _II_rt*, _PT_rt*, _STD and _II_em are rounded to the nearest integer value.
 {
     "policy": {

--- a/taxcalc/reforms/TCJA_Senate_120117.json
+++ b/taxcalc/reforms/TCJA_Senate_120117.json
@@ -13,12 +13,12 @@
 // Reform_Parameter_Map:
 // - 1: _II_*
 // - 2: _PT_*
-// - 3: _STD
+// - 3: _STD (can safely ignore WARNINGs about 2026+ values)
 // - 4: _II_em
 // - 5: _DependentCredit_*, _CTC_c, _CTC_ps, _ACTC_Income_thd
 // - 6: _AMT_rt*
 // - 7: _ALD_DomesticProduction_hc
-// - 8: _ID_*
+// - 8: _ID_* (can safely ignore WARNINGs about values for several parameters)
 // - 9: _cpi_offset
 // Note: _II_rt*, _PT_rt*, _STD and _II_em are rounded to the nearest integer value.
 {


### PR DESCRIPTION
This pull request adds to the existing comments in several TCJA reform files.  There is no change in the JSON specification of the reform in any of the TCJA reform files.  These changes implement the suggestion by @MattHJensen made in the discussion of issue #1643.