### PR TITLE
Change minimum required pandas version to 0.21.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,7 +10,7 @@ requirements:
   build:
     - python
     - numpy >=1.12.1
-    - pandas >=0.20.1
+    - pandas >=0.21.0
     - numba
     - toolz
     - six
@@ -18,7 +18,7 @@ requirements:
   run:
     - python
     - numpy >=1.12.1
-    - pandas >=0.20.1
+    - pandas >=0.21.0
     - numba
     - toolz
     - six

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: taxcalc-dev
 dependencies:
 - numpy >=1.12.1
-- pandas >=0.20.1
+- pandas >=0.21.0
 - numba
 - toolz
 - six


### PR DESCRIPTION
**This pull request increases from 0.20.1 to 0.21.0 the minimum required version of pandas.**

This change is required for the new reforms test (see revisions in the `test_reform_json_and_output` function that are part of pull request #1766), which use the mapper argument of the [`pandas.rename` method](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.rename.html) that was first added in pandas version 0.21.  Thanks to @derrickchoe, who was using an older version of pandas, for pointing this out.

The unit tests will fail unless you upgrade using this command: `conda update pandas`
