### PR TITLE
Fix small test differences between Python 2.7 and Python 3.6

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
This pull request uses the new `nonsmall_diffs` utility function to determine if there are significant differences in actual and expected PUF variable means and correlation coefficients generated by the code in the `test_puf_var_stats.py` file.

These changes are part of a sequence of revisions that are trying to resolve the problems reported in #1715.

This pull request does not change any tax-calculating logic or results.