### PR TITLE
Work around conda install bug in conda 4.4

### DIFF
--- a/conda.recipe/install_local_taxcalc_package.sh
+++ b/conda.recipe/install_local_taxcalc_package.sh
@@ -36,7 +36,16 @@ conda build $NOHASH --python $pversion . 2>&1 | awk '$1~/BUILD/||$1~/TEST/'
 
 # install taxcalc conda package
 echo "INSTALLATION..."
-conda install taxcalc=0.0.0 --use-local --yes 2>&1 > /dev/null
+#OLD#conda install taxcalc=0.0.0 --use-local --yes 2>&1 > /dev/null
+#OLD# doesn't work in conda 4.4.0 or 4.4.1
+#OLD# see https://github.com/ContinuumIO/anaconda-issues/issues/7876
+#OLD# conda install --use-local can't find the built package with 4.4.0+
+#OLD# the Continuum staff seems pretty careless in putting out new versions
+#NEW# below works with conda 4.4.1, but users may need to customize ADIR
+#NEW# because recently Continuum started installing Anaconda in
+#NEW# either the ~/anaconda2 or ~/anaconda3 directory
+ADIR=~/anaconda/conda-bld/osx-64
+conda install --offline $ADIR/taxcalc-0.0.0-py27_0.tar.bz2 2>&1 > /dev/null
 
 # clean-up after package build
 echo "CLEAN-UP..."


### PR DESCRIPTION
Other people are reporting the bug; see bug-report URL in `conda.recipe/install_local_taxcalc_package.sh`.

This pull request allows you (maybe after some editing of the value of `ADIR` in`conda.recipe/install_local_taxcalc_package.sh`) to create a taxcalc package on your local computer directly from the source code on your local computer. 