### PR TITLE
Update RELEASES.md information for future release 0.15.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,9 @@ for a complete commit history.
 - Add `--outdir` option to command-line `tc` tool
   [[#1801](https://github.com/open-source-economics/Tax-Calculator/pull/1801)
   by Martin Holmer as suggested by Reuben Fischer-Baum]
+- Make TCJA policy current-law policy
+  [[#1803](https://github.com/open-source-economics/Tax-Calculator/pull/1803)
+  by Martin Holmer with assistance from Cody Kallen]
 
 **Bug Fixes**
 - None

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,7 +15,9 @@ for a complete commit history.
   by Martin Holmer]
 
 **New Features**
-- None
+- Add `--outdir` option to command-line `tc` tool
+  [[#1801](https://github.com/open-source-economics/Tax-Calculator/pull/1801)
+  by Martin Holmer as suggested by Reuben Fischer-Baum]
 
 **Bug Fixes**
 - None

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,23 @@ Go [here](https://github.com/open-source-economics/Tax-Calculator/pulls?q=is%3Ap
 for a complete commit history.
 
 
+2018-01-?? Release 0.15.0
+-------------------------
+(last merged pull request is
+[#18xx](https://github.com/open-source-economics/Tax-Calculator/pull/18xx))
+
+**API Changes**
+- Make objects embedded in a Calculator object private and provide Calculator class access methods to manipulate the embedded objects
+  [[#1791](https://github.com/open-source-economics/Tax-Calculator/pull/1791)
+  by Martin Holmer]
+
+**New Features**
+- None
+
+**Bug Fixes**
+- None
+
+
 2017-12-24 Release 0.14.3
 -------------------------
 (last merged pull request is

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,6 +21,9 @@ for a complete commit history.
 - Make TCJA policy current-law policy
   [[#1803](https://github.com/open-source-economics/Tax-Calculator/pull/1803)
   by Martin Holmer with assistance from Cody Kallen]
+- Change minimum required pandas version from 0.21.0 to 0.22.0 and remove zsum() pandas work-around
+  [[#1805](https://github.com/open-source-economics/Tax-Calculator/pull/1805)
+  by Martin Holmer]
 
 **Bug Fixes**
 - None


### PR DESCRIPTION
This pull request contains changes to `RELEASES.md` that describe the next Tax-Calculator 0.15.0 release.