### PR TITLE
Require pandas >=0.22.0 and remove zsum() hack

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,7 +10,7 @@ requirements:
   build:
     - python
     - numpy >=1.12.1
-    - pandas >=0.21.0
+    - pandas >=0.22.0
     - numba
     - toolz
     - six
@@ -18,7 +18,7 @@ requirements:
   run:
     - python
     - numpy >=1.12.1
-    - pandas >=0.21.0
+    - pandas >=0.22.0
     - numba
     - toolz
     - six

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: taxcalc-dev
 dependencies:
 - numpy >=1.12.1
-- pandas >=0.21.0
+- pandas >=0.22.0
 - numba
 - toolz
 - six

--- a/taxcalc/__init__.py
+++ b/taxcalc/__init__.py
@@ -19,6 +19,3 @@ import pandas as pd
 from taxcalc._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
-
-# zsum is defined in utils.py
-pd.Series.zsum = zsum

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -131,28 +131,18 @@ SMALL_INCOME_BINS = [-9e99, 0, 4999, 9999, 14999, 19999, 24999, 29999, 39999,
                      1999999, 4999999, 9999999, 9e99]
 
 
-def zsum(self):
-    """
-    pandas 0.21.0 changes sum() behavior so that the result of applying sum
-    over an empty Series is NaN.  Since we apply the sum() function over
-    grouped DataFrames that may contain an empty Series, it makes more sense
-    for us to have a sum() function that returns zero instead of NaN.
-    """
-    return self.sum() if self.size > 0 else 0
-
-
 def unweighted_sum(pdf, col_name):
     """
     Return unweighted sum of Pandas DataFrame col_name items.
     """
-    return pdf[col_name].zsum()
+    return pdf[col_name].sum()
 
 
 def weighted_sum(pdf, col_name):
     """
     Return weighted sum of Pandas DataFrame col_name items.
     """
-    return (pdf[col_name] * pdf['s006']).zsum()
+    return (pdf[col_name] * pdf['s006']).sum()
 
 
 def add_quantile_bins(pdf, income_measure, num_bins,
@@ -242,7 +232,7 @@ def get_sums(pdf):
     sums = dict()
     for col in pdf.columns.values.tolist():
         if col != 'bins':
-            sums[col] = pdf[col].zsum()
+            sums[col] = pdf[col].sum()
     return pd.Series(sums, name='sums')
 
 
@@ -454,7 +444,7 @@ def create_difference_table(vdf1, vdf2, groupby, income_measure, tax_to_diff):
             sdf['perc_inc'] = gpdf.apply(weighted_perc_inc, 'tax_diff')
             sdf['mean'] = gpdf.apply(weighted_mean, 'tax_diff')
             sdf['tot_change'] = gpdf.apply(weighted_sum, 'tax_diff')
-            wtotal = (res2['tax_diff'] * res2['s006']).zsum()
+            wtotal = (res2['tax_diff'] * res2['s006']).sum()
             sdf['share_of_change'] = gpdf.apply(weighted_share_of_total,
                                                 'tax_diff', wtotal)
             res2['afinc1'] = res1['aftertax_income']
@@ -500,8 +490,10 @@ def create_difference_table(vdf1, vdf2, groupby, income_measure, tax_to_diff):
             #              expected 'Python object' but got 'long'"
             #              in 'pandas._libs.lib.is_bool_array' ignored
             #                                                  ^^^^^^^
-            # It is hoped that Pandas PR#17841, which is scheduled for
-            # inclusion in Pandas version 0.22.0 (Jan 2018), will fix this.
+            # It is hoped that Pandas PR#18252, which is scheduled for
+            # inclusion in Pandas version 0.23.0 (Feb 2018), will fix this.
+            # See discussion at the following URL:
+            # https://github.com/pandas-dev/pandas/issues/19037
             pdf['bins'].replace(to_replace=[1, 2, 3, 4, 5],
                                 value=[0, 0, 0, 0, 0], inplace=True)
             pdf['bins'].replace(to_replace=[6, 7, 8, 9],

--- a/taxcalc/utilsprvt.py
+++ b/taxcalc/utilsprvt.py
@@ -15,7 +15,7 @@ def weighted_count_lt_zero(pdf, col_name, tolerance=-0.001):
     If condition is not met by any items, the result of applying sum to an
     empty dataframe is NaN.  This is undesirable and 0 is returned instead.
     """
-    return pdf[pdf[col_name] < tolerance]['s006'].zsum()
+    return pdf[pdf[col_name] < tolerance]['s006'].sum()
 
 
 def weighted_count_gt_zero(pdf, col_name, tolerance=0.001):
@@ -24,22 +24,22 @@ def weighted_count_gt_zero(pdf, col_name, tolerance=0.001):
     If condition is not met by any items, the result of applying sum to an
     empty dataframe is NaN.  This is undesirable and 0 is returned instead.
     """
-    return pdf[pdf[col_name] > tolerance]['s006'].zsum()
+    return pdf[pdf[col_name] > tolerance]['s006'].sum()
 
 
 def weighted_count(pdf):
     """
     Return weighted count of items in Pandas DataFrame.
     """
-    return pdf['s006'].zsum()
+    return pdf['s006'].sum()
 
 
 def weighted_mean(pdf, col_name):
     """
     Return weighted mean of Pandas DataFrame col_name items.
     """
-    return ((pdf[col_name] * pdf['s006']).zsum() /
-            (pdf['s006'].zsum() + EPSILON))
+    return ((pdf[col_name] * pdf['s006']).sum() /
+            (pdf['s006'].sum() + EPSILON))
 
 
 def wage_weighted(pdf, col_name):
@@ -48,8 +48,8 @@ def wage_weighted(pdf, col_name):
     """
     swght = 's006'
     wage = 'e00200'
-    return (((pdf[col_name] * pdf[swght] * pdf[wage]).zsum()) /
-            ((pdf[swght] * pdf[wage]).zsum() + EPSILON))
+    return (((pdf[col_name] * pdf[swght] * pdf[wage]).sum()) /
+            ((pdf[swght] * pdf[wage]).sum() + EPSILON))
 
 
 def agi_weighted(pdf, col_name):
@@ -58,8 +58,8 @@ def agi_weighted(pdf, col_name):
     """
     swght = 's006'
     agi = 'c00100'
-    return ((pdf[col_name] * pdf[swght] * pdf[agi]).zsum() /
-            ((pdf[swght] * pdf[agi]).zsum() + EPSILON))
+    return ((pdf[col_name] * pdf[swght] * pdf[agi]).sum() /
+            ((pdf[swght] * pdf[agi]).sum() + EPSILON))
 
 
 def expanded_income_weighted(pdf, col_name):
@@ -68,8 +68,8 @@ def expanded_income_weighted(pdf, col_name):
     """
     swght = 's006'
     expinc = 'expanded_income'
-    return ((pdf[col_name] * pdf[swght] * pdf[expinc]).zsum() /
-            ((pdf[swght] * pdf[expinc]).zsum() + EPSILON))
+    return ((pdf[col_name] * pdf[swght] * pdf[expinc]).sum() /
+            ((pdf[swght] * pdf[expinc]).sum() + EPSILON))
 
 
 def weighted_perc_inc(pdf, col_name):


### PR DESCRIPTION
The newest version of pandas eliminates a problem that many had with the `sum()` method.
@hdoupe developed a new `zsum()` utility function that worked around this pandas problem.
Now the pandas developers have made the `sum()` method work like almost everybody expects.
So, we can dispense with the work-around by requiring pandas version 0.22.0 or higher.
