### PR TITLE
Revise install_local_taxcalc_package.sh to require conda>=4.4.4

### DIFF
--- a/conda.recipe/install_local_taxcalc_package.sh
+++ b/conda.recipe/install_local_taxcalc_package.sh
@@ -36,10 +36,11 @@ conda build $NOHASH --python $pversion . 2>&1 | awk '$1~/BUILD/||$1~/TEST/'
 
 # install taxcalc conda package
 echo "INSTALLATION..."
-#OLD#conda install taxcalc=0.0.0 --use-local --yes 2>&1 > /dev/null
-#OLD# doesn't work in conda 4.4.0 or 4.4.1
-#OLD# see https://github.com/conda/conda/issues/6520
-conda install -c local taxcalc=0.0.0 --yes 2>&1 > /dev/null
+conda install taxcalc=0.0.0 --use-local --yes 2>&1 > /dev/null
+#NOTE# the --use-local option was broken by conda 4.4.0 and fixed by 4.4.4
+#NOTE# see https://github.com/conda/conda/issues/6520
+#NOTE# interim usage was as follows:
+#NOTE# conda install -c local taxcalc=0.0.0 --yes 2>&1 > /dev/null
 
 # clean-up after package build
 echo "CLEAN-UP..."

--- a/conda.recipe/install_local_taxcalc_package.sh
+++ b/conda.recipe/install_local_taxcalc_package.sh
@@ -19,6 +19,14 @@ if [ $? -eq 1 ]; then
     echo "==> Continuing to build new taxcalc package"
 fi
 
+# check version of conda package
+conda list conda | awk '$1=="conda"{v=$2;gsub(/\./,"",v);if(v<444)rc=1}END{exit(rc)}'
+if [ $? -eq 1 ]; then
+    echo "==> Installing conda 4.4.4+"
+    conda install conda>=4.4.4 --yes 2>&1 > /dev/null
+    echo "==> Continuing to build new taxcalc package"
+fi
+
 # install conda-build package if not present
 conda list build | awk '$1~/conda-build/{rc=1}END{exit(rc)}'
 if [ $? -eq 0 ]; then

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: taxcalc-dev
 dependencies:
-- conda >=4.4.4
 - numpy >=1.12.1
 - pandas >=0.21.0
 - numba

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: taxcalc-dev
 dependencies:
+- conda >=4.4.4
 - numpy >=1.12.1
 - pandas >=0.21.0
 - numba


### PR DESCRIPTION
This pull request revises the `conda.recipe/install_local_taxcalc_package.sh` bash script to upgrade conda to at least version 4.4.4 so that the script will work correctly.
  