### PR TITLE
Replace tcdumpvars file with tc --dvars option

### DIFF
--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -89,13 +89,18 @@ def cli_tc_main():
                               'reform, where all the variables are named '
                               'using their internal Tax-Calculator names. '
                               'No --dump option implies OUTPUT contains '
-                              'minimal tax output for the reform. '
-                              'NOTE: create a space-delimited file named '
-                              'tcdumpvars in directory where output is being '
-                              'written in order to specify a custom set of '
-                              'dump variables.'),
+                              'minimal tax output for the reform.  NOTE: '
+                              'use the --dvars option to point to a file '
+                              'containing a custom set of dump variables.'
+                              ''),
                         default=False,
                         action="store_true")
+    parser.add_argument('--dvars',
+                        help=('DVARS is name of optional file containing a '
+                              'space-delimited list of variables to include '
+                              'in a partial dump OUTPUT file.  No --dvars '
+                              'implies a full dump containing all variables.'),
+                        default=None)
     parser.add_argument('--sqldb',
                         help=('optional flag that writes SQLite database '
                               'with dump table containing same output as '
@@ -134,15 +139,20 @@ def cli_tc_main():
         sys.stderr.write('USAGE: tc --help\n')
         return 1
     dumpvar_set = None
-    if args.dump or args.sqldb:
-        if os.path.exists('tcdumpvars'):
-            with open('tcdumpvars') as vfile:
-                dump_vars_str = vfile.read()
+    if args.dvars and (args.dump or args.sqldb):
+        if os.path.exists(args.dvars):
+            with open(args.dvars) as dfile:
+                dump_vars_str = dfile.read()
             dumpvar_set = tcio.custom_dump_variables(dump_vars_str)
             if tcio.errmsg:
                 sys.stderr.write(tcio.errmsg)
                 sys.stderr.write('USAGE: tc --help\n')
                 return 1
+        else:
+            msg = 'ERROR: DVARS file {} does not exist\n'
+            sys.stderr.write(msg.format(args.dvars))
+            sys.stderr.write('USAGE: tc --help\n')
+            return 1
     tcio.analyze(writing_output_file=True,
                  output_tables=args.tables,
                  output_graphs=args.graphs,


### PR DESCRIPTION
This pull request does not add a new feature to the command-line tool `tc` but does change the method of specifying the variables to be included in a partial dump.  The new `tc --dvars DVARS` option allows users to more easily specify different partial dumps for different `tc` runs.