### PR TITLE
Add test and compatible_data fields for new policy parameters

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,9 @@ for a complete commit history.
   by Martin Holmer as suggested by Max Ghenis]
 
 **New Features**
+- Add validity testing of compatible_data information in `current_law_policy.json`
+  [[#1614](https://github.com/open-source-economics/Tax-Calculator/pull/1614)
+  by Matt Jensen with assistance from Hank Doupe]]
 - Add `--outdir` option to command-line `tc` tool
   [[#1801](https://github.com/open-source-economics/Tax-Calculator/pull/1801)
   by Martin Holmer as suggested by Reuben Fischer-Baum]

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,14 +52,15 @@ top of the repository directory tree:
 
 ```
 cd taxcalc
-py.test -m "not requires_pufcsv" -n4
+py.test -m "not requires_pufcsv and not pre_release" -n4
 ```
 
 This will start executing a pytest suite containing hundreds of tests,
-but will skip the tests that require the `puf.csv` file as input.
-Depending on your computer, the execution time for this incomplete
-suite of tests is a little over one minute.  The `-n4` option calls
-for using as many as four CPU cores for parallel execution of the
+but will skip the tests that require the `puf.csv` file as input and
+the tests that are executed only just before a new release is being
+prepared.  Depending on your computer, the execution time for this
+incomplete suite of tests is a little over one minute.  The `-n4` option
+calls for using as many as four CPU cores for parallel execution of the
 tests.  If you want sequential execution of the tests (which will
 take at least twice as long to execute), simply omit the `-n4` option.
 
@@ -71,26 +72,25 @@ tax-calculator directory at the top of the repository directory tree:
 
 ```
 cd taxcalc
-py.test -n4
+py.test -m "not pre_release" -n4
 ```
 
 This will start executing a pytest suite containing hundreds of tests,
-including the tests that require the `puf.csv` file as input.
-Depending on your computer, the execution time for this complete suite
+including the tests that require the `puf.csv` file as input but excluding
+the tests that are executed only just before a new release is being
+prepared. Depending on your computer, the execution time for this suite
 of unit tests is roughly three minutes.  The `-n4` option calls for
 using as many as four CPU cores for parallel execution of the tests.
 If you want sequential execution of the tests (which will take at
 least twice as long to execute), simply omit the `-n4` option.
 
-If you would like to reduce the test suite's runtime, you can run:
+Just before releasing a new version of Tax-Calculator or just after
+adding a new parameter to `current_law_policy.json`, you should also
+execute the pre-release tests using this command:
 
 ```
-py.test -m "not pre_release" -n4
+py.test -m pre_release -n4
 ``` 
-
-But the `"not pre_release"` option should never be used after 
-adding a new parameter to `current_law_policy.json` or 
-preparing a new taxcalc release. 
 
 Testing with validation/tests.sh
 --------------------------------

--- a/read-the-docs/source/contributor_guide.rst
+++ b/read-the-docs/source/contributor_guide.rst
@@ -85,13 +85,13 @@ Setup Git
     validation tests if you are working on Windows::
 
       tax-calculator$ cd taxcalc
-      tax-calculator/taxcalc$ py.test -m "not requires_pufcsv" -n4
+      tax-calculator/taxcalc$ py.test -m "not requires_pufcsv and not pre_release" -n4
       tax-calculator/taxcalc$ cd validation
       tax-calculator/taxcalc/validation$ bash tests.sh
 
     If you do have a copy of the OSPC-supplied puf.csv file, then on
-    the second line above omit the '-m "not requires_pufcsv"'
-    expression so as to execute 'py.test -n4'.
+    the second line above omit the 'not requires_pufcsv and'
+    expression so as to execute 'py.test -m "not pre_release" -n4'.
 
     If all the tests pass, you're good to go. If they don't pass, enter
     the following updates at the command line and then try running the
@@ -169,7 +169,7 @@ situations, in which case other contributors are here to help.
    the tax-calculator/taxcalc directory (but skip the validation tests
    if you are working on Windows)::
 
-     tax-calculator/taxcalc$ py.test -m "not requires_pufcsv" -n4
+     tax-calculator/taxcalc$ py.test -m "not requires_pufcsv and not pre_release" -n4
      tax-calculator/taxcalc$ cd validation
      tax-calculator/taxcalc/validation$ ./tests
 

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -407,7 +407,8 @@
         "range": {"min": 0, "max": 1},
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
-        "out_of_range_action": "stop"
+        "out_of_range_action": "stop",
+        "compatible_data": {"puf": true, "cps": false}
     },
 
     "_ALD_AlimonyReceived_hc": {
@@ -456,7 +457,7 @@
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop",
-        "compatible_data": {"puf": true, "cps": false}
+        "compatible_data": {"puf": true, "cps": true}
     },
 
     "_ALD_EducatorExpenses_hc": {
@@ -799,7 +800,8 @@
         "range": {"min": 0.0, "max": 9e99},
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
-        "out_of_range_action": "stop"
+        "out_of_range_action": "stop",
+        "compatible_data": {"puf": true, "cps": true}
     },
 
     "_II_em": {
@@ -4375,7 +4377,8 @@
         "range": {"min": 0.0, "max": 9e99},
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
-        "out_of_range_action": "stop"
+        "out_of_range_action": "stop",
+        "compatible_data": {"puf": true, "cps": true}
     },
 
     "_PT_excl_wagelim_thd": {
@@ -4424,7 +4427,7 @@
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop",
-        "compatible_data": {"puf": true, "cps": false}
+        "compatible_data": {"puf": true, "cps": true}
     },
 
     "_PT_excl_wagelim_prt": {
@@ -4472,7 +4475,8 @@
         "range": {"min": 0.0, "max": 1.0},
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
-        "out_of_range_action": "stop"
+        "out_of_range_action": "stop",
+        "compatible_data": {"puf": true, "cps": true}
     },
 
     "_AMT_em": {


### PR DESCRIPTION
This pull request adds a test to check that every policy parameter in the `current_law_policy.json` file has a `compatible_data` field, and it also adds a `compatible_data` field to each new parameter added in pull requests #1818 and #1819.

Because of the complexity of `test_compatible_data`, which was merged in pull request #1614, and the change in what is current-law policy, which happened in pull request #1803, there are still 7 (out of 45 pre_release tests) test failures in this pull request.   The 11 parameters that failed `test_compatible_data` are as follows:
```
taxcalc$ py.test -n4 -m compatible_data 2>&1 | grep ERROR: | grep -v errmsg | sort
ERROR: _ID_BenefitSurtax_Switch not False for cps
ERROR: _ID_Casualty_c not False for puf
ERROR: _ID_Casualty_frt not False for puf
ERROR: _ID_Miscellaneous_c not False for cps
ERROR: _ID_Miscellaneous_c not False for puf
ERROR: _ID_Miscellaneous_frt not False for cps
ERROR: _ID_Miscellaneous_frt not False for puf
ERROR: _ID_crt not False for cps
ERROR: _ID_crt not False for puf
ERROR: _ID_ps not False for cps
ERROR: _ID_ps not False for puf
```
As you can see, all eleven failing parameters have to do with itemized deductions, the rules for which have changed substantially with the passage of TCJA.
