### PR TITLE
Mark test_4package as local rather than pre_release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 # command to run tests
 script:
-  - python -c "import taxcalc"; coverage run -m py.test -v -m "not requires_pufcsv and not pre_release" --pep8
+  - python -c "import taxcalc"; coverage run -m py.test -v -m "not requires_pufcsv and not pre_release and not local" --pep8
 
 after_success:
   - codecov

--- a/TESTING.md
+++ b/TESTING.md
@@ -59,7 +59,7 @@ This will start executing a pytest suite containing hundreds of tests,
 but will skip the tests that require the `puf.csv` file as input and
 the tests that are executed only just before a new release is being
 prepared.  Depending on your computer, the execution time for this
-incomplete suite of tests is a little over one minute.  The `-n4` option
+incomplete suite of tests is roughly two minutes.  The `-n4` option
 calls for using as many as four CPU cores for parallel execution of the
 tests.  If you want sequential execution of the tests (which will
 take at least twice as long to execute), simply omit the `-n4` option.
@@ -79,7 +79,7 @@ This will start executing a pytest suite containing hundreds of tests,
 including the tests that require the `puf.csv` file as input but excluding
 the tests that are executed only just before a new release is being
 prepared. Depending on your computer, the execution time for this suite
-of unit tests is roughly three minutes.  The `-n4` option calls for
+of unit tests is roughly four minutes.  The `-n4` option calls for
 using as many as four CPU cores for parallel execution of the tests.
 If you want sequential execution of the tests (which will take at
 least twice as long to execute), simply omit the `-n4` option.
@@ -91,6 +91,20 @@ execute the pre-release tests using this command:
 ```
 py.test -m pre_release -n4
 ``` 
+
+But if you execute the pre_release tests well before releasing a new
+version of Tax-Calculator, be sure **not** to include the updated
+`docs/index.html` file in your commit.  After checking that you can
+make a `docs/index.html` file that is correct, revert to the old
+version of `docs/index.html` by executing this command:
+
+```
+git checkout -- docs/index.html
+```
+
+Following this procedure will ensure that the documentation is not
+updated before the Tax-Calculator release is available.
+
 
 Testing with validation/tests.sh
 --------------------------------

--- a/continuous_integration/run_tests.cmd
+++ b/continuous_integration/run_tests.cmd
@@ -8,4 +8,4 @@ set PYTHONFAULTHANDLER=1
 set PYTEST=py.test --capture=sys
 
 @rem %PYTEST% -v --runslow dask\dataframe\tests\test_groupby.py
-%PYTEST% -v -m "not requires_pufcsv and not pre_release" --pep8
+%PYTEST% -v -m "not requires_pufcsv and not pre_release and not local" --pep8

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -12,7 +12,7 @@ import yaml
 import pytest
 
 
-@pytest.mark.pre_release
+@pytest.mark.local
 def test_for_package_existence():
     """
     Ensure that no conda taxcalc package is installed when running pytest.


### PR DESCRIPTION
Further streamlining of the testing procedures.
No changes in tax logic or results.