### PR TITLE
Fix stat_dataframe function nested in create_distribution_table utility function

### DIFF
--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -371,6 +371,8 @@ def create_distribution_table(vdf, groupby, income_measure, result_type):
                 dist_table[col] /= dist_table['s006']
     # set print display format for float table elements
     pd.options.display.float_format = '{:8,.0f}'.format
+    # ensure dist_table columns are in correct order
+    assert dist_table.columns.values.tolist() == DIST_TABLE_COLUMNS
     return dist_table
 
 
@@ -538,6 +540,8 @@ def create_difference_table(vdf1, vdf2, groupby, income_measure, tax_to_diff):
         diffs[col] *= 100.0
     # set print display format for float table elements
     pd.options.display.float_format = '{:10,.2f}'.format
+    # ensure diffs columns are in correct order
+    assert diffs.columns.values.tolist() == DIFF_TABLE_COLUMNS
     return diffs
 
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -310,14 +310,16 @@ def create_distribution_table(vdf, groupby, income_measure, result_type):
         Nested function that returns statistics DataFrame derived from the
         specified grouped Dataframe object, gpdf.
         """
-        sdf = pd.DataFrame()
-        unweighted_columns = set(['s006', 'num_returns_StandardDed',
-                                  'num_returns_ItemDed', 'num_returns_AMT'])
-        for col in unweighted_columns:
-            sdf[col] = gpdf.apply(unweighted_sum, col)
-        weighted_columns = set(DIST_TABLE_COLUMNS) - unweighted_columns
-        for col in weighted_columns:
-            sdf[col] = gpdf.apply(weighted_sum, col)
+        unweighted_columns = ['s006', 'num_returns_StandardDed',
+                              'num_returns_ItemDed', 'num_returns_AMT']
+        stats = list()
+        for col in DIST_TABLE_COLUMNS:
+            if col in unweighted_columns:
+                stats.append(gpdf.apply(unweighted_sum, col))
+            else:
+                stats.append(gpdf.apply(weighted_sum, col))
+        sdf = pd.DataFrame(data=np.column_stack(stats),
+                           columns=DIST_TABLE_COLUMNS)
         return sdf
 
     # main logic of create_distribution_table


### PR DESCRIPTION
This pull request fixes a Tax-Calculator bug that was diagnosed by @hdoupe in [PolicyBrain issue 794](https://github.com/OpenSourcePolicyCenter/PolicyBrain/issues/794).  His ingenious scripts determined that the bug was in Tax-Calculator (because the dictionary tbi results were different from the dataframe tbi results) and that those differences occurred only in distribution table results, not in difference table results or aggregate results. Thanks @hdoupe for the extremely helpful bug report!

Using Hank's script (that compares tbi distribution table results returned as a dataframe with tbi distribution table results returned as a dictionary), I used standard bisection methods to determine that there were no differences in release 0.13.2 and earlier and differences in the next release, which was numbered 0.14.0, and in subsequent releases.  Then reviewing commits made during the few weeks between 0.13.2 (2017-11-17) and 0.14.0 (2017-12-11), revealed commit aef4b20 that introduced a nested function called `stat_dataframe` into the `create_distribution_table` utility function.  Given @hdoupe's diagnosis (the numbers in the dictionary were correct but they were not associated with the correct variable), the source of the bug was obvious once attention was focused on the `stat_dataframe` function.

The changes in this pull request leave all the unit and validation tests that were passing before this pull request still passing.  There are no changes in tax calculating logic.

My guess is that this (now fixed) bug affected only TaxBrain, not other clients of Tax-Calculator.

