### PR TITLE
Add test that compares tbi and std behavioral-response estimates

### DIFF
--- a/taxcalc/tests/test_tbi.py
+++ b/taxcalc/tests/test_tbi.py
@@ -1,6 +1,7 @@
 """
 Test functions in taxcalc/tbi directory using both puf.csv and cps.csv input.
 """
+from __future__ import print_function
 import numpy as np
 import pandas as pd
 import pytest
@@ -262,3 +263,117 @@ def test_reform_warnings_errors():
     msg_dict = reform_warnings_errors(bad2_mods)
     assert len(msg_dict['warnings']) == 0
     assert len(msg_dict['errors']) > 0
+
+
+@pytest.mark.pre_release
+@pytest.mark.tbi_vs_std_behavior
+@pytest.mark.requires_pufcsv
+def test_behavioral_response(puf_subsample):
+    """
+    Test that behavioral-response results are the same
+    when generated from standard Tax-Calculator calls and
+    when generated from tbi.run_nth_year_tax_calc_model() calls
+    """
+    # specify reform and assumptions
+    reform_json = """
+    {"policy": {
+        "_II_rt5": {"2020": [0.25]},
+        "_II_rt6": {"2020": [0.25]},
+        "_II_rt7": {"2020": [0.25]},
+        "_PT_rt5": {"2020": [0.25]},
+        "_PT_rt6": {"2020": [0.25]},
+        "_PT_rt7": {"2020": [0.25]},
+        "_II_em": {"2020": [1000]}
+    }}
+    """
+    assump_json = """
+    {"behavior": {"_BE_sub": {"2013": [0.25]}},
+     "growdiff_baseline": {},
+     "growdiff_response": {},
+     "consumption": {}
+    }
+    """
+    params = Calculator.read_json_param_objects(reform_json, assump_json)
+    # specify keyword arguments used in tbi function call
+    kwargs = {
+        'start_year': 2019,
+        'year_n': 0,
+        'use_puf_not_cps': True,
+        'use_full_sample': False,
+        'user_mods': {
+            'policy': params['policy'],
+            'behavior': params['behavior'],
+            'growdiff_baseline': params['growdiff_baseline'],
+            'growdiff_response': params['growdiff_response'],
+            'consumption': params['consumption']
+        },
+        'return_dict': False
+    }
+    # generate aggregate results two ways: using tbi and standard calls
+    num_years = 9
+    std_res = dict()
+    tbi_res = dict()
+    for using_tbi in [True, False]:
+        for year in range(0, num_years):
+            cyr = year + kwargs['start_year']
+            if using_tbi:
+                kwargs['year_n'] = year
+                tables = run_nth_year_tax_calc_model(**kwargs)
+                tbi_res[cyr] = dict()
+                for tbl in ['aggr_1', 'aggr_2', 'aggr_d']:
+                    tbi_res[cyr][tbl] = tables[tbl]
+            else:
+                rec = Records(data=puf_subsample)
+                pol = Policy()
+                calc1 = Calculator(policy=pol, records=rec)
+                pol.implement_reform(params['policy'])
+                assert not pol.reform_errors
+                beh = Behavior()
+                beh.update_behavior(params['behavior'])
+                calc2 = Calculator(policy=pol, records=rec, behavior=beh)
+                assert calc2.behavior_has_response()
+                calc1.advance_to_year(cyr)
+                calc2.advance_to_year(cyr)
+                calc2 = Behavior.response(calc1, calc2)
+                std_res[cyr] = dict()
+                for tbl in ['aggr_1', 'aggr_2', 'aggr_d']:
+                    if tbl.endswith('_1'):
+                        itax = calc1.weighted_total('iitax')
+                        ptax = calc1.weighted_total('payrolltax')
+                        ctax = calc1.weighted_total('combined')
+                    elif tbl.endswith('_2'):
+                        itax = calc2.weighted_total('iitax')
+                        ptax = calc2.weighted_total('payrolltax')
+                        ctax = calc2.weighted_total('combined')
+                    elif tbl.endswith('_d'):
+                        itax = (calc2.weighted_total('iitax') -
+                                calc1.weighted_total('iitax'))
+                        ptax = (calc2.weighted_total('payrolltax') -
+                                calc1.weighted_total('payrolltax'))
+                        ctax = (calc2.weighted_total('combined') -
+                                calc1.weighted_total('combined'))
+                    cols = ['0_{}'.format(year)]
+                    rows = ['ind_tax', 'payroll_tax', 'combined_tax']
+                    datalist = [itax, ptax, ctax]
+                    std_res[cyr][tbl] = pd.DataFrame(data=datalist,
+                                                     index=rows,
+                                                     columns=cols)
+    # compare the two sets of results
+    # NOTE that the tbi results have been "fuzzed" for PUF privacy reasons,
+    #      so there is no expectation that the results should be identical.
+    no_diffs = True
+    reltol = 2e-3  # std and tbi differ if more than 0.2 percent different
+    for year in range(0, num_years):
+        cyr = year + kwargs['start_year']
+        col = '0_{}'.format(year)
+        for tbl in ['aggr_1', 'aggr_2', 'aggr_d']:
+            tbi = tbi_res[cyr][tbl][col]
+            std = std_res[cyr][tbl][col]
+            if not np.allclose(tbi, std, atol=0.0, rtol=reltol):
+                no_diffs = False
+                print('**** DIFF for year {} (year_n={}):'.format(cyr, year))
+                print('TBI RESULTS:')
+                print(tbi)
+                print('STD RESULTS:')
+                print(std)
+    assert no_diffs


### PR DESCRIPTION
This pull request contains a new test that has been added to the `test_tbi.py` file and is marked `pre_release` and `tbi_vs_std_behavior` and `requires_pufcsv`.  

This test assumes `_BE_sub` equals 0.25 and compares the aggregate tax revenues generated by standard Python Tax-Calculator programming with those generated by calling the tbi.run_nth_year_tax_calc_model() function.  The motivation for adding this test is the discussion in issue #1827.

Because of the results generated by the tbi function call are "fuzzed" for PUF privacy reasons, there is no expectation that those results would be identical to the results generated by standard Tax-Calculator calls. 

The new test simulates a massive tax reductions caused by reducing the regular-income and pass-through tax rates no higher than 25 percent and raising the personal exemption from zero to $1000 beginning in 2019.  This reform causes a substantial reduction in marginal tax rates and hence a substantial behavioral response.

However, despite the discussion in #1827, there are no significant differences --- meaning more than a 0.2 percent difference in aggregate tax revenues --- in the results generated using the tbi function call and the results generated using standard (that is, non-tbi) function calls.   Here is how I ran the test (using code at the tip of the master branch) and here is what I got:
```
$ cd taxcalc
$ py.test -m tbi_vs_std_behavior
============================= test session starts ==============================
platform darwin -- Python 2.7.14, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
rootdir: /Users/mrh/work/OSPC/tax-calculator, inifile: setup.cfg
plugins: xdist-1.17.1
collected 436 items                                                             

tests/test_tbi.py .

============================= 435 tests deselected =============================
================== 1 passed, 435 deselected in 120.94 seconds ==================
```
Why do these test results seem different from the results reported in #1827?   
Perhaps I've made a mistake in writing the test.  
Or perhaps the code in 0.14.2 is different from the code at the tip of the master branch.  
Or perhaps mistakes were made in the work reported in #1827.

Does anybody have any ideas about this?

@MattHJensen @GoFroggyRun 

