### PR TITLE
Allow compound reforms when using tc tool --reform option

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,9 @@ for a complete commit history.
 - Add imputed CPS benefits data to Tax-Calculator
   [[#1719](https://github.com/open-source-economics/Tax-Calculator/pull/1719)
   by Anderson Frailey]
+- Add ability to specify a compound reform in the tc `--reform` option
+  [[#1842](https://github.com/open-source-economics/Tax-Calculator/pull/1842)
+  by Martin Holmer as requested by Ernie Tedeschi]
 
 **Bug Fixes**
 - None

--- a/docs/index.htmx
+++ b/docs/index.htmx
@@ -25,12 +25,12 @@ Python source code &mdash; you should go to
 the <a href="https://github.com/open-source-economics/Tax-Calculator">
 developer website</a>.</p>
 
-<p>Please cite the source of your analysis as <q>Tax-Calculator v.
-#.#.#, author's calculations.</q> If you wish to link to Tax-Calculator,
-this page is preferred. Additionally, we strongly recommend that you 
-provide a link to the materials required to replicate your
-analysis or, at least, note that those materials are available 
-upon request.</p>
+<p>Please cite the source of your analysis as <q>Tax-Calculator
+release #.#.#, author's calculations.</q> If you wish to link to
+Tax-Calculator, this page is preferred.  Additionally, we strongly
+recommend that you describe the input data used, and provide a link to
+the materials required to replicate your analysis or, at least, note
+that those materials are available upon request.</p>
 
 
 <h2 id="whatsnew">What's New</h2>
@@ -41,6 +41,10 @@ and higher
 
 <p><a href="https://github.com/open-source-economics/Tax-Calculator/issues/1830#issue-288673028">FAQ on using Tax-Calculator when TCJA is current law</a> is
 now available
+
+<p><a href="#compoundreform">Compound reform</a> capability allows tc
+users to analyze a reform that is specified in more than one JSON
+reform file in Tax-Calculator release 0.15.2 and higher
 
 <p><a href="#partdump">Partial dump</a> capability requires use of
 tc <kbd>--dvars</kbd> option in Tax-Calculator release 0.15.0 and higher
@@ -305,7 +309,7 @@ writing JSON reform files, go
 to <a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/reforms/REFORMS.md">this
 page</a>.</p>
 
-<p>If you want to upload reform files to TaxBrain for static analysis
+<p>If you want to upload a reform file to TaxBrain for static analysis
 (rather than use the tc CLI on your computer for analysis), go to this
 section's <a href="#cli-taxbrain-upload">last part</a>, which
 discusses uploading files to TaxBrain.  If you want to assume any
@@ -597,6 +601,18 @@ the <kbd>ref3.json</kbd> file.  Because no <kbd>--assump</kbd>
 option is used, the output results are produced using static analysis.
 The name of the output file in this example is
 <kbd>test-21-ref3-#.csv</kbd>.</p>
+
+<p id="compoundreform">If, in addition to <kbd>ref3.json</kbd>, there
+was a <kbd>ref4.json</kbd> reform file and analysis of the <b>compound
+reform</b> (consisting of first implementing the <kbd>ref3.json</kbd>
+reform relative to current-law policy and then implementing
+the <kbd>ref4.json</kbd> reform relative to the <kbd>ref3.json</kbd>
+reform) is desired, both reform files can be mentioned in
+the tc <kbd>--reform</kbd> option as follows:
+<pre>
+$ tc test.csv 2021 --reform ref3.json+ref4.json
+</pre>
+The above command generates an output file named <kbd>test-21-ref3+ref4-#.csv</kbd></p>
 
 <p><pre>
 (6)$ tc test.csv 2021 --reform ref3.json --assump res1.json

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -1026,15 +1026,21 @@ class Calculator(object):
                                 'growdiff_baseline', 'growdiff_response'])
 
     @staticmethod
-    def reform_documentation(params):
+    def reform_documentation(params, policy_dicts=None):
         """
         Generate reform documentation.
 
         Parameters
         ----------
         params: dict
-            compound dictionary structured as dict returned from
+            dictionary is structured like dict returned from
             the static Calculator method read_json_param_objects()
+
+        policy_dicts : list of dict or None
+            each dictionary in list is a params['policy'] dictionary
+            representing second or subsequent elements of a compound
+            reform; None implies no compound reform with the simple
+            reform characterized in the params['policy'] dictionary
 
         Returns
         -------
@@ -1057,6 +1063,7 @@ class Calculator(object):
             -------
             doc: String
             """
+            # pylint: disable=too-many-locals
 
             # nested function used only in param_doc
             def lines(text, num_indent_spaces, max_line_length=77):
@@ -1090,12 +1097,13 @@ class Calculator(object):
             # begin main logic of param_doc
             # pylint: disable=too-many-nested-blocks
             assert len(years) == len(change.keys())
-            basevals = getattr(base, '_vals', None)
+            basex = copy.deepcopy(base)
+            basevals = getattr(basex, '_vals', None)
             assert isinstance(basevals, dict)
             doc = ''
             for year in years:
                 # write year
-                base.set_year(year)
+                basex.set_year(year)
                 doc += '{}:\n'.format(year)
                 # write info for each param in year
                 for param in sorted(change[year].keys()):
@@ -1129,13 +1137,13 @@ class Calculator(object):
                         for line in lines('desc: ' + desc, 6):
                             doc += '  ' + line
                     # ... write baseline_value line
-                    if isinstance(base, Policy):
+                    if isinstance(basex, Policy):
                         if param.endswith('_cpi'):
                             rootparam = param[:-4]
                             bval = basevals[rootparam].get('cpi_inflated',
                                                            False)
                         else:
-                            bval = getattr(base, param[1:], None)
+                            bval = getattr(basex, param[1:], None)
                             if isinstance(bval, np.ndarray):
                                 bval = bval.tolist()
                                 if basevals[param]['boolean_value']:
@@ -1144,7 +1152,7 @@ class Calculator(object):
                             elif basevals[param]['boolean_value']:
                                 bval = bool(bval)
                         doc += '  baseline_value: {}\n'.format(bval)
-                    else:  # if base is Growdiff object
+                    else:  # if basex is Growdiff object
                         # all Growdiff parameters have zero as default value
                         doc += '  baseline_value: 0.0\n'
             return doc
@@ -1173,6 +1181,18 @@ class Calculator(object):
             doc += param_doc(years, params['policy'], clp)
         else:
             doc += 'none: using current-law policy parameters\n'
+        if policy_dicts is not None:
+            assert isinstance(policy_dicts, list)
+            base = clp
+            base.implement_reform(params['policy'])
+            assert not base.reform_errors
+            for policy_dict in policy_dicts:
+                assert isinstance(policy_dict, dict)
+                doc += 'Policy Reform Parameter Values by Year:\n'
+                years = sorted(policy_dict.keys())
+                doc += param_doc(years, policy_dict, base)
+                base.implement_reform(policy_dict)
+                assert not base.reform_errors
         return doc
 
     def ce_aftertax_income(self, calc,

--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -37,7 +37,7 @@ def cli_tc_main():
                      'file, with the OUTPUT computed from the INPUT for the '
                      'TAXYEAR using Tax-Calculator. The OUTPUT file is a '
                      'CSV-formatted file that contains tax information for '
-                     'each INPUT filing unit under the reform.'))
+                     'each INPUT filing unit under the reform(s).'))
     parser.add_argument('INPUT', nargs='?',
                         help=('INPUT is name of CSV-formatted file that '
                               'contains for each filing unit variables used '
@@ -52,6 +52,8 @@ def cli_tc_main():
                         default=0)
     parser.add_argument('--reform',
                         help=('REFORM is name of optional JSON reform file. '
+                              'A compound reform can be specified using two '
+                              'file names separated by a plus (+) character. '
                               'No --reform implies a "null" reform (that is, '
                               'current-law policy).'),
                         default=None)

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -174,6 +174,7 @@ class TaxCalcIO(object):
         self.calc = None
         self.calc_base = None
         self.param_dict = None
+        self.policy_dicts = list()
 
     def init(self, input_data, tax_year, reform, assump,
              growdiff_response,
@@ -214,6 +215,9 @@ class TaxCalcIO(object):
         else:
             paramdict = Calculator.read_json_param_objects(reform, assump)
             policydicts = [paramdict['policy']]
+        # remember parameters for reform documentation
+        self.param_dict = paramdict
+        self.policy_dicts = policydicts
         # create Behavior object
         beh = Behavior()
         beh.update_behavior(paramdict['behavior'])
@@ -319,8 +323,6 @@ class TaxCalcIO(object):
                                     verbose=False,
                                     consumption=con,
                                     sync_years=aging_input_data)
-        # remember parameter dictionary for reform documentation
-        self.param_dict = paramdict
 
     def custom_dump_variables(self, tcdumpvars_str):
         """
@@ -492,7 +494,11 @@ class TaxCalcIO(object):
         """
         Write reform documentation to text file.
         """
-        doc = Calculator.reform_documentation(self.param_dict)
+        if len(self.policy_dicts) <= 1:
+            doc = Calculator.reform_documentation(self.param_dict)
+        else:
+            doc = Calculator.reform_documentation(self.param_dict,
+                                                  self.policy_dicts[1:])
         doc_fname = self._output_filename.replace('.csv', '-doc.text')
         with open(doc_fname, 'w') as dfile:
             dfile.write(doc)

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -42,7 +42,7 @@ class TaxCalcIO(object):
 
     reform: None or string
         None implies no policy reform (current-law policy), or
-        string is name of optional REFORM file.
+        string is name of optional REFORM file(s).
 
     assump: None or string
         None implies economic assumptions are standard assumptions,
@@ -59,7 +59,7 @@ class TaxCalcIO(object):
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self, input_data, tax_year, reform, assump, outdir=None):
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments,too-many-locals
         # pylint: disable=too-many-branches,too-many-statements
         self.errmsg = ''
         # check name and existence of INPUT file
@@ -83,25 +83,37 @@ class TaxCalcIO(object):
         else:
             msg = 'INPUT is neither string nor Pandas DataFrame'
             self.errmsg += 'ERROR: {}\n'.format(msg)
-        # check name and existence of REFORM file
+        # check name(s) and existence of REFORM file(s)
         ref = '-x'
         if reform is None:
             self.specified_reform = False
             ref = '-#'
         elif isinstance(reform, six.string_types):
             self.specified_reform = True
-            # remove any leading directory path from REFORM filename
-            fname = os.path.basename(reform)
-            # check if fname ends with ".json"
-            if fname.endswith('.json'):
-                ref = '-{}'.format(fname[:-5])
-            else:
-                msg = 'REFORM file name does not end in .json'
-                self.errmsg += 'ERROR: {}\n'.format(msg)
-            # check existence of REFORM file
-            if not os.path.isfile(reform):
-                msg = 'REFORM file could not be found'
-                self.errmsg += 'ERROR: {}\n'.format(msg)
+            # split any compound reform into list of simple reforms
+            refnames = list()
+            reforms = reform.split('+')
+            for rfm in reforms:
+                # remove any leading directory path from rfm filename
+                fname = os.path.basename(rfm)
+                # check if fname ends with ".json"
+                if not fname.endswith('.json'):
+                    msg = '{} does not end in .json'.format(fname)
+                    self.errmsg += 'ERROR: REFORM file name {}\n'.format(msg)
+                # check existence of REFORM file
+                if not os.path.isfile(rfm):
+                    msg = '{} could not be found'.format(rfm)
+                    self.errmsg += 'ERROR: REFORM file {}\n'.format(msg)
+                # add fname to list of refnames used in output file names
+                refnames.append(fname)
+            # create (possibly compound) reform name for output file names
+            ref = '-'
+            num_refnames = 0
+            for refname in refnames:
+                num_refnames += 1
+                if num_refnames > 1:
+                    ref += '+'
+                ref += '{}'.format(refname[:-5])
         else:
             msg = 'TaxCalcIO.ctor: reform is neither None nor str'
             self.errmsg += 'ERROR: {}\n'.format(msg)
@@ -190,8 +202,18 @@ class TaxCalcIO(object):
         # pylint: disable=too-many-arguments,too-many-locals
         # pylint: disable=too-many-statements,too-many-branches
         self.errmsg = ''
-        # get parameter dictionaries from --reform and --assump files
-        paramdict = Calculator.read_json_param_objects(reform, assump)
+        # get parameter dictionaries from --reform file(s) and --assump file
+        if self.specified_reform:
+            reforms = reform.split('+')
+            paramdict = Calculator.read_json_param_objects(reforms[0], assump)
+            policydicts = [paramdict['policy']]
+            if len(reforms) > 1:  # simulating a compound reform
+                for ref in reforms[1:]:
+                    pdict = Calculator.read_json_param_objects(ref, None)
+                    policydicts.append(pdict['policy'])
+        else:
+            paramdict = Calculator.read_json_param_objects(reform, assump)
+            policydicts = [paramdict['policy']]
         # create Behavior object
         beh = Behavior()
         beh.update_behavior(paramdict['behavior'])
@@ -227,11 +249,12 @@ class TaxCalcIO(object):
         # create Policy objects
         if self.specified_reform:
             pol = Policy(gfactors=gfactors_ref)
-            try:
-                pol.implement_reform(paramdict['policy'])
-                self.errmsg += pol.reform_errors
-            except ValueError as valerr_msg:
-                self.errmsg += valerr_msg.__str__()
+            for poldict in policydicts:
+                try:
+                    pol.implement_reform(poldict)
+                    self.errmsg += pol.reform_errors
+                except ValueError as valerr_msg:
+                    self.errmsg += valerr_msg.__str__()
         else:
             pol = Policy(gfactors=gfactors_base)
         base = Policy(gfactors=gfactors_base)

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -272,8 +272,8 @@ def test_init_errors(reformfile0, reformfilex1, reformfilex2,
         reform = reformfile0.name
     elif ref == 'reformfilex1':
         reform = reformfilex1.name
-    elif ref == 'reformfilex2':
-        reform = reformfilex2.name
+    elif ref == 'reformfilex2':  # specify compound reform
+        reform = '{}+{}'.format(reformfilex1.name, reformfilex2.name)
     else:
         reform = ref
     if asm == 'assumpfile0':

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -395,7 +395,7 @@ def test_custom_dump_variables(dumpvar_str, str_valid, num_vars):
         assert len(varset) == num_vars
 
 
-def test_output_otions(rawinputfile, reformfile1, assumpfile1):
+def test_output_options(rawinputfile, reformfile1, assumpfile1):
     """
     Test TaxCalcIO output_ceeu & output_dump options when writing_output_file.
     """
@@ -450,6 +450,32 @@ def test_output_otions(rawinputfile, reformfile1, assumpfile1):
     # if tries were successful, remove output file and doc file
     if os.path.isfile(outfilepath):
         os.remove(outfilepath)
+    docfilepath = outfilepath.replace('.csv', '-doc.text')
+    if os.path.isfile(docfilepath):
+        os.remove(docfilepath)
+
+
+def test_write_doc_file(rawinputfile, reformfile1, assumpfile1):
+    """
+    Test write_doc_file with compound reform.
+    """
+    taxyear = 2021
+    compound_reform = '{}+{}'.format(reformfile1.name, reformfile1.name)
+    tcio = TaxCalcIO(input_data=rawinputfile.name,
+                     tax_year=taxyear,
+                     reform=compound_reform,
+                     assump=assumpfile1.name)
+    assert not tcio.errmsg
+    tcio.init(input_data=rawinputfile.name,
+              tax_year=taxyear,
+              reform=compound_reform,
+              assump=assumpfile1.name,
+              growdiff_response=None,
+              aging_input_data=False,
+              exact_calculations=False)
+    assert not tcio.errmsg
+    tcio.write_doc_file()
+    outfilepath = tcio.output_filepath()
     docfilepath = outfilepath.replace('.csv', '-doc.text')
     if os.path.isfile(docfilepath):
         os.remove(docfilepath)


### PR DESCRIPTION
This pull request enhances the existing tc `--reform REFORM` option so that it can handle a compound reform.
A compound reform is a reform that is composed of two (or more) individual reforms.  For an example of a compound reform, see the section entitled **A Round-Trip Compound Reform** at the bottom of [this FAQ](https://github.com/open-source-economics/Tax-Calculator/issues/1830#issue-288673028).

So, for example, if a user has specified `reformA.json` and `reformB.json` and is interested in analyzing the joint effect of the two reforms (that is, first implementing reformA relative to current-law policy and then implementing reformB relative to reformA policy), the user simply executes a command like this:
```
$ tc cps.csv 2020 --reform reformA.json+reformB.json
```
The above command will generate two output files with the following names:
```
cps-20-reformA+reformB-#-doc.text    <==== compound reform documentation
cps-20-reformA+reformB-#.csv         <==== minimal output file
```
As one would expect, using this new feature produces the following results:
```
$ cp ../tax-calculator/taxcalc/reforms/2017_law.json .
$ cp ../tax-calculator/taxcalc/reforms/TCJA_Reconciliation.json ./TCJA.json
$ ls *json
2017_law.json   TCJA.json

$ tc cps.csv 2020 --tables
You loaded data for 2014.
Tax-Calculator startup automatically extrapolated your data to 2020.
$ ls cps-20-*
cps-20-#-#-doc.text	cps-20-#-#-tab.text	cps-20-#-#.csv

$ tc cps.csv 2020 --tables --reform 2017_law.json+TCJA.json
You loaded data for 2014.
Tax-Calculator startup automatically extrapolated your data to 2020.
$ ls cps-20-*
cps-20-#-#-doc.text		cps-20-2017_law+TCJA-#-doc.text
cps-20-#-#-tab.text		cps-20-2017_law+TCJA-#-tab.text
cps-20-#-#.csv			cps-20-2017_law+TCJA-#.csv

$ diff  cps-20-#-#-tab.text  cps-20-2017_law+TCJA-#-tab.text 
$
```
As with the Python programming in #1830, the round-trip compound reform (of implementing `2017_law.json` and then `TCJA.json`) produces exactly the same results as does current-law policy.

The need for this enhancement was discussed as part of merged pull request 1803 beginning with [this comment](https://github.com/open-source-economics/Tax-Calculator/pull/1803#issuecomment-359558728).