### PR TITLE
Add logic to prevent Calculator misuse in presence of behavioral responses

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -322,6 +322,7 @@ class Behavior(ParametersBase):
                                               calc2_behv)
         # Recalculate post-reform taxes incorporating behavioral responses
         calc2_behv.calc_all()
+        calc2_behv.records_include_behavioral_responses()
         return calc2_behv
 
     # ----- begin private methods of Behavior class -----

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -301,6 +301,12 @@ class Calculator(object):
         else:
             setattr(self.__behavior, param_name, param_value)
 
+    def records_include_behavioral_responses(self):
+        """
+        Mark embedded Records object as including behavioral responses
+        """
+        self.__records.behavioral_responses_are_included = True
+
     @property
     def reform_warnings(self):
         """

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -168,6 +168,8 @@ class Records(object):
         wt_colname = 'WT{}'.format(self.current_year)
         if wt_colname in self.WT.columns:
             self.s006 = self.WT[wt_colname] * 0.01
+        # specify that variable values do not include behavioral responses
+        self.behavioral_responses_are_included = False
 
     @staticmethod
     def cps_constructor(data=None,
@@ -218,6 +220,9 @@ class Records(object):
         Add one to current year.
         Also, does extrapolation, reweighting, adjusting for new current year.
         """
+        # no incrementing Records object that includes behavioral responses
+        assert self.behavioral_responses_are_included is False
+        # move to next year
         self.__current_year += 1
         # apply variable extrapolation grow factors
         if self.gfactors is not None:
@@ -226,7 +231,7 @@ class Records(object):
         self._adjust(self.__current_year)
         # specify current-year sample weights
         if self.WT is not None:
-            wt_colname = 'WT{}'.format(self.current_year)
+            wt_colname = 'WT{}'.format(self.__current_year)
             if wt_colname in self.WT.columns:
                 self.s006 = self.WT[wt_colname] * 0.01
 


### PR DESCRIPTION
This pull request adds a few lines of code that prevent incrementing the year of a Calculator object returned by the `Behavior.response()` method, which includes behavioral responses in earnings and other Records variables.

These changes leave the results generated by the CLI tool `tc`, and by the tbi functions, unchanged.

What these changes do is stop one type of misuse of the Tax-Calculator library illustrated in the proposed new test in pull request #1847.

This pull request may be viewed as a bug fix in that earlier versions of Tax-Calculator allowed (without any warning or error) illogical use.  And because this was allowed users sometimes became confused about the unexpected results generated by their misuse of the Tax-Calculator library.  That library may contain other bugs but this pull request is an attempt to eliminate this one bug.