### PR TITLE
Add logic to prevent diagnostic_table misuse with behavior

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -343,7 +343,7 @@ class Calculator(object):
         num_years : Integer
             number of years to include in diagnostic table starting
             with the Calculator object's current_year (must be at least
-            one and no more than what would exceed Policy end_year
+            one and no more than what would exceed Policy end_year)
 
         Returns
         -------
@@ -355,6 +355,7 @@ class Calculator(object):
         calc = copy.deepcopy(self)
         tlist = list()
         for iyr in range(1, num_years + 1):
+            assert calc.behavior_has_response() is False
             calc.calc_all()
             diag = create_diagnostic_table(calc.dataframe(DIST_VARIABLES),
                                            calc.current_year)


### PR DESCRIPTION
This pull request adds a few lines of code that prevent the use of the `Calculator.diagnostic_table` when the Calculator object has an embedded Behavior object that has behavioral responses.

These changes leave the results generated by the CLI tool tc, and by the tbi functions, unchanged.

What these changes do is stop one type of misuse of the Tax-Calculator library illustrated in the script described in issue #1845.

As a bit of background information, during October 2016, pull request #988 changed the logic of diagnostic table generation (see, in particular, commit e39f9e5ad0a18) to rule out behavioral-response analysis.  I wasn't involved in the discussion that produced that change, but the historical record is clear that since then a sensible diagnostic table that includes behavioral responses cannot be generated.

This pull request may be viewed as a bug fix in that earlier versions of Tax-Calculator allowed (without any warning or error) illogical use. And because this was allowed users sometimes became confused about the unexpected results generated by their misuse of the Tax-Calculator library. That library may contain other bugs but this pull request is an attempt to eliminate this one bug.