### PR TITLE
Add logic to allow dropping units with high MTR while behavioral response calculation

### DIFF
--- a/read-the-docs/notebooks/10_Minutes_to_Tax-Calculator.ipynb
+++ b/read-the-docs/notebooks/10_Minutes_to_Tax-Calculator.ipynb
@@ -26,8 +26,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import sys\n",
@@ -44,8 +46,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# The baseline includes AMT repeal. \n",
@@ -82,8 +86,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -110,8 +116,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "c_xx.advance_to_year(2017)\n",
@@ -129,8 +137,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "c_xx.calc_all()\n",
@@ -146,22 +156,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "-102894721202.03145"
+       "-102935492151.75226"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "((c_yy.records.combined - c_xx.records.combined)*c_xx.records.s006).sum()"
+    "((c_yy.array('combined') - c_xx.array('combined'))*c_yy.array('s006')).sum()"
    ]
   },
   {
@@ -190,7 +202,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -453,11 +453,17 @@ class Behavior(ParametersBase):
         """
         Computes marginal tax rates for Calculator objects calc1 and calc2
         for specified mtr_of income type and specified tax_type.
+
+        The drop_hi_mtr option allows users to calculate behavior response
+        without considering units with high (>0.7) marginal tax rates.
         """
         _, iitax1, combined1 = calc1.mtr(mtr_of, wrt_full_compensation=True)
         _, iitax2, combined2 = calc2.mtr(mtr_of, wrt_full_compensation=True)
         if drop_hi_mtr:
+            # marginal tax rate > 0.7 is considered to be unreasonably high.
             mtr_cap = 0.7
+            # use symmetry to ensure percentage change is zero when calculating
+            # any behavior responses.
             combined1 = np.where(combined1 > mtr_cap, combined2, combined1)
             combined2 = np.where(combined2 > mtr_cap, combined1, combined2)
             iitax1 = np.where(iitax1 > mtr_cap, iitax2, iitax1)

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -179,7 +179,7 @@ class Behavior(ParametersBase):
             wage_mtr1, wage_mtr2 = Behavior._mtr12(calc1, calc2,
                                                    mtr_of='e00200p',
                                                    tax_type='combined',
-                                                   drop_hi_mtr=True)
+                                                   drop_hi_mtr=drop_hi_mtr)
             # calculate magnitude of substitution effect
             if calc2.behavior('BE_sub') == 0.0:
                 sub = np.zeros(calc1.array_len)
@@ -237,7 +237,7 @@ class Behavior(ParametersBase):
             ltcg_mtr1, ltcg_mtr2 = Behavior._mtr12(calc1, calc2,
                                                    mtr_of='p23250',
                                                    tax_type='iitax',
-                                                   drop_hi_mtr=True)
+                                                   drop_hi_mtr=drop_hi_mtr)
             rch = ltcg_mtr2 - ltcg_mtr1
             exp_term = np.exp(calc2.behavior('BE_cg') * rch)
             new_ltcg = calc1.array('p23250') * exp_term
@@ -255,13 +255,13 @@ class Behavior(ParametersBase):
             # cash:
             c_charity_mtr1, c_charity_mtr2 = Behavior._mtr12(
                 calc1, calc2, mtr_of='e19800', tax_type='combined',
-                drop_hi_mtr=True)
+                drop_hi_mtr=drop_hi_mtr)
             c_charity_price_pch = (((1. + c_charity_mtr2) /
                                     (1. + c_charity_mtr1)) - 1.)
             # non-cash:
             nc_charity_mtr1, nc_charity_mtr2 = Behavior._mtr12(
                 calc1, calc2, mtr_of='e20100', tax_type='combined',
-                drop_hi_mtr=True)
+                drop_hi_mtr=drop_hi_mtr)
             nc_charity_price_pch = (((1. + nc_charity_mtr2) /
                                      (1. + nc_charity_mtr1)) - 1.)
             # identify income bin based on baseline income

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -201,12 +201,17 @@ def test_boolean_value_infomation(tests_path):
 
 @pytest.mark.test_drop_hi_mtr
 def test_drop_hi_mtr(cps_subsample):
+    # create Records object
     rec = Records.cps_constructor(data=cps_subsample)
+    # create Policy object
     pol = Policy()
+    # create current-law Calculator object
     calc_b = Calculator(policy=pol, records=rec)
+    # implement policy reform
     reform = {2017: {"_II_em": [1000]}}
     pol.implement_reform(reform)
     behv = Behavior()
+    # specify behavior assumptions
     behv.update_behavior({2014: {'_BE_sub': [0.25]},
                           2014: {'_BE_cg': [-1.4]},
                           2014: {'_BE_charity': [[-0.5, -0.5, -0.5]]}})
@@ -214,10 +219,12 @@ def test_drop_hi_mtr(cps_subsample):
     cyr = 2018
     calc_b.advance_to_year(cyr)
     calc_ref.advance_to_year(cyr)
+    assert behv.has_any_response()
+    # calculate behavior response
     calc_beh_drop = Behavior.response(calc_b, calc_ref, drop_hi_mtr=True)
     calc_beh_reg = Behavior.response(calc_b, calc_ref, drop_hi_mtr=False)
-
-    reltol = 2e-3
+    # compare the two sets of results to make sure the difference is very small
+    reltol = 2e-4
     assert np.allclose(calc_beh_drop.weighted_total('combined'),
                        calc_beh_reg.weighted_total('combined'),
                        atol=0.0, rtol=reltol)

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -197,3 +197,27 @@ def test_boolean_value_infomation(tests_path):
                   val,
                   val_is_boolean)
             assert beh[param]['boolean_value'] == val_is_boolean
+
+
+@pytest.mark.test_drop_hi_mtr
+def test_drop_hi_mtr(cps_subsample):
+    rec = Records.cps_constructor(data=cps_subsample)
+    pol = Policy()
+    calc_b = Calculator(policy=pol, records=rec)
+    reform = {2017: {"_II_em": [1000]}}
+    pol.implement_reform(reform)
+    behv = Behavior()
+    behv.update_behavior({2014: {'_BE_sub': [0.25]},
+                          2014: {'_BE_cg': [-1.4]},
+                          2014: {'_BE_charity': [[-0.5, -0.5, -0.5]]}})
+    calc_ref = Calculator(policy=pol, records=rec, behavior=behv)
+    cyr = 2018
+    calc_b.advance_to_year(cyr)
+    calc_ref.advance_to_year(cyr)
+    calc_beh_drop = Behavior.response(calc_b, calc_ref, drop_hi_mtr=True)
+    calc_beh_reg = Behavior.response(calc_b, calc_ref, drop_hi_mtr=False)
+
+    reltol = 2e-3
+    assert np.allclose(calc_beh_drop.weighted_total('combined'),
+                       calc_beh_reg.weighted_total('combined'),
+                       atol=0.0, rtol=reltol)


### PR DESCRIPTION
This PR implements @feenberg 's suggestion in #1852  that adds optional logic to ignore units with high (`mtr_cap = 0.7` as discussed in #1852) MTRs while calculating behavior responses. 

The added logic replaces the `nearone` logic, where the latter one might amplify notches in cases where unit's MTR is larger than `nearone = 0.999999` (more details can be found [here](https://github.com/open-source-economics/Tax-Calculator/issues/1852#issuecomment-362347404)). A test `test_drop_hi_mtr` is added to `test_behavior.py` to make sure that the error introduced by ignoring those high MTR units is reasonably small. The test passes on my local:

```
(taxcalc-dev) Sean-Wangs-MacBook-Pro:taxcalc seanwang$ py.test -m test_drop_hi_mtr
===================================================== test session starts =====================================================
platform darwin -- Python 2.7.14, pytest-3.3.0, py-1.5.2, pluggy-0.6.0
rootdir: /Users/seanwang/Documents/GIT/tax-calculator, inifile: setup.cfg
plugins: xdist-1.20.1, forked-0.2, hypothesis-3.38.5, pep8-1.0.6
collected 439 items                                                                                                           

tests/test_behavior.py .                                                                                                [100%]

==================================================== 438 tests deselected =====================================================
========================================== 1 passed, 438 deselected in 22.47 seconds ==========================================
```

However, I have encountered one test failure. The test `test_behavioral_response` in `test_tbi.py` fails to pass. The error message reads:

```
(taxcalc-dev) Sean-Wangs-MacBook-Pro:taxcalc seanwang$ py.test -n4
===================================================== test session starts =====================================================
platform darwin -- Python 2.7.14, pytest-3.3.0, py-1.5.2, pluggy-0.6.0
rootdir: /Users/seanwang/Documents/GIT/tax-calculator, inifile: setup.cfg
plugins: xdist-1.20.1, forked-0.2, hypothesis-3.38.5, pep8-1.0.6
gw0 [438] / gw1 [438] / gw2 [438] / gw3 [438]
scheduling tests via LoadScheduling
....................................................................................................................... [ 27%]
....................................................................................................................... [ 54%]
....................................................................................................................... [ 81%]
..............................................................F..................                                       [100%]
========================================================== FAILURES ===========================================================
...
...
...
**** DIFF for year 2026 (year_n=7):
TBI RESULTS:
ind_tax          -204,496,151
payroll_tax    -2,256,177,524
combined_tax   -2,460,673,675
Name: 0_7, dtype: float64
STD RESULTS:
ind_tax          -324,621,038
payroll_tax    -2,258,628,355
combined_tax   -2,583,249,393
Name: 0_7, dtype: float64
**** DIFF for year 2027 (year_n=8):
TBI RESULTS:
ind_tax         2,694,995,128
payroll_tax    -2,179,762,550
combined_tax      515,232,577
Name: 0_8, dtype: float64
STD RESULTS:
ind_tax         2,688,980,813
payroll_tax    -2,179,917,092
combined_tax      509,063,721
Name: 0_8, dtype: float64
...
``` 

I'm not sure why this particular test won't pass. Is `2e-3` percent to small to account for the effect of dropQ? 

cc @martinholmer @hdoupe 