### PR TITLE
Add cps_benefits.csv.gz to list of files in the taxcalc package "egg"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ include taxcalc/consumption.json
 include taxcalc/records_variables.json
 include taxcalc/cps.csv.gz
 include taxcalc/cps_weights.csv.gz
+include taxcalc/cps_benefits.csv.gz


### PR DESCRIPTION
Add something that was inadvertently left out of pull request #1719, which added the `cps_benefits.csv.gz` file to the repository.