### PR TITLE
Standardize benefit parameter/variable naming scheme

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,9 @@ for a complete commit history.
 - Add ability to extrapolate imputed benefits and benefit-related policy parameters
   [[#1719](https://github.com/open-source-economics/Tax-Calculator/pull/1719)
   by Anderson Frailey]
+- Add ability to specify the consumption value of in-kind benefits to be less than the government cost of providing in-kind benefits
+  [[#1863](https://github.com/open-source-economics/Tax-Calculator/pull/1863)
+  by Anderson Frailey]
 
 **Bug Fixes**
 - None

--- a/taxcalc/consumption.json
+++ b/taxcalc/consumption.json
@@ -76,7 +76,7 @@
 
     "_BEN_snap_value": {
         "long_name": "Consumption value of SNAP benefits",
-        "description": "Portion of SNAP benefits consumed by the beneficiary.",
+        "description": "Consumption value per dollar of SNAP benefits, all of which are in-kind benefits.",
         "section_1": "",
         "section_2": "",
         "notes": "",
@@ -93,8 +93,8 @@
     },
 
     "_BEN_vet_value": {
-        "long_name": "Consumption value of Veterans benefits",
-        "description": "Portion of veterans benefits consumed by the beneficiary.",
+        "long_name": "Consumption value of veterans benefits",
+        "description": "Consumption value per dollar of veterans benefits, some of which are in-kind benefits.",
         "section_1": "",
         "section_2": "",
         "notes": "",
@@ -112,7 +112,7 @@
 
     "_BEN_mcare_value": {
         "long_name": "Consumption value of Medicare benefits",
-        "description": "Portion of Medicare benefits consumed by the beneficiary.",
+        "description": "Consumption value per dollar of Medicare benefits, all of which are in-kind benefits.",
         "section_1": "",
         "section_2": "",
         "notes": "",
@@ -130,7 +130,7 @@
 
     "_BEN_mcaid_value": {
         "long_name": "Consumption value of Medicaid benefits",
-        "description": "Portion of Medicaid benefits consumed by the beneficiary.",
+        "description": "Consumption value per dollar of Medicaid benefits, all of which are in-kind benefits.",
         "section_1": "",
         "section_2": "",
         "notes": "",
@@ -148,7 +148,7 @@
 
     "_BEN_other_value": {
         "long_name": "Consumption value of other benefits",
-        "description": "Portion of other benefits consumed by the beneficiary.",
+        "description": "Consumption value per dollar of other benefits, some of which are in-kind benefits.",
         "section_1": "",
         "section_2": "",
         "notes": "",

--- a/taxcalc/current_law_policy.json
+++ b/taxcalc/current_law_policy.json
@@ -6592,7 +6592,7 @@
         "compatible_data": {"puf": true, "cps": false}
     },
 
-    "_BEN_SSI_repeal": {
+    "_BEN_ssi_repeal": {
         "long_name": "SSI benefit repeal switch",
         "description": "SSI benefits can be repealed by switching this parameter to true.",
         "section_1": "Benefits",
@@ -6616,7 +6616,7 @@
         "compatible_data": {"puf": false, "cps": true}
     },
 
-    "_BEN_SNAP_repeal": {
+    "_BEN_snap_repeal": {
         "long_name": "SNAP benefit repeal switch",
         "description": "SNAP benefits can be repealed by switching this parameter to true.",
         "section_1": "Benefits",
@@ -6640,7 +6640,7 @@
         "compatible_data": {"puf": false, "cps": true}
     },
 
-    "_BEN_Vet_repeal": {
+    "_BEN_vet_repeal": {
         "long_name": "Veterans benefit repeal switch",
         "description": "Veterans benefits can be repealed by switching this parameter to true.",
         "section_1": "Benefits",
@@ -6664,7 +6664,7 @@
         "compatible_data": {"puf": false, "cps": true}
     },
 
-    "_BEN_MCARE_repeal": {
+    "_BEN_mcare_repeal": {
         "long_name": "Medicare benefit repeal switch",
         "description": "Medicare benefits can be repealed by switching this parameter to true.",
         "section_1": "Benefits",
@@ -6688,7 +6688,7 @@
         "compatible_data": {"puf": false, "cps": true}
     },
 
-    "_BEN_MCAID_repeal": {
+    "_BEN_mcaid_repeal": {
         "long_name": "Medicaid benefit repeal switch",
         "description": "Medicaid benefits can be repealed by switching this parameter to true.",
         "section_1": "Benefits",
@@ -6712,9 +6712,9 @@
         "compatible_data": {"puf": false, "cps": true}
     },
 
-    "_BEN_OASDI_repeal": {
+    "_BEN_oasdi_repeal": {
         "long_name": "Social Security benefit repeal switch",
-        "description": "Social Security benefits can be repealed by switching this parameter to true.",
+        "description": "Social Security benefits (e02400) can be repealed by switching this parameter to true.",
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
         "irs_ref": "",
@@ -6733,12 +6733,12 @@
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop",
-        "compatible_data": {"puf": false, "cps": true}
+        "compatible_data": {"puf": true, "cps": true}
     },
 
-    "_BEN_Unemployment_repeal": {
-        "long_name": "Unemployment compensation benefit repeal switch",
-        "description": "Unemployment compensation benefits can be repealed by switching this parameter to true.",
+    "_BEN_ui_repeal": {
+        "long_name": "Unemployment insurance benefit repeal switch",
+        "description": "Unemployment insurance benefits (e02300) can be repealed by switching this parameter to true.",
         "section_1": "Benefits",
         "section_2": "Benefit Repeal",
         "irs_ref": "",
@@ -6757,10 +6757,10 @@
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop",
-        "compatible_data": {"puf": false, "cps": true}
+        "compatible_data": {"puf": true, "cps": true}
     },
 
-    "_BEN_Other_repeal": {
+    "_BEN_other_repeal": {
         "long_name": "Other benefit repeal switch",
         "description": "Other benefits can be repealed by switching this parameter to true.",
         "section_1": "Benefits",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -29,21 +29,21 @@ def BenefitPrograms(calc):
     """
     # zero out benefits delivered by repealed programs
     zero = np.zeros(calc.array_len)
-    if calc.param('BEN_SSI_repeal'):
+    if calc.param('BEN_ssi_repeal'):
         calc.array('ssi_ben', zero)
-    if calc.param('BEN_SNAP_repeal'):
+    if calc.param('BEN_snap_repeal'):
         calc.array('snap_ben', zero)
-    if calc.param('BEN_Vet_repeal'):
+    if calc.param('BEN_vet_repeal'):
         calc.array('vet_ben', zero)
-    if calc.param('BEN_MCARE_repeal'):
+    if calc.param('BEN_mcare_repeal'):
         calc.array('mcare_ben', zero)
-    if calc.param('BEN_MCAID_repeal'):
+    if calc.param('BEN_mcaid_repeal'):
         calc.array('mcaid_ben', zero)
-    if calc.param('BEN_OASDI_repeal'):
+    if calc.param('BEN_oasdi_repeal'):
         calc.array('e02400', zero)
-    if calc.param('BEN_Unemployment_repeal'):
+    if calc.param('BEN_ui_repeal'):
         calc.array('e02300', zero)
-    if calc.param('BEN_Other_repeal'):
+    if calc.param('BEN_other_repeal'):
         calc.array('other_ben', zero)
     # calculate government cost of all benefits
     cost = np.array(

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -208,13 +208,13 @@
     },
     "e02300": {
       "type": "float",
-      "desc": "Unemployment compensation benefits",
+      "desc": "Unemployment insurance benefits",
       "form": {"2013-2016": "1040 line 19"},
       "availability": "taxdata_puf, taxdata_cps"
     },
     "e02400": {
       "type": "float",
-      "desc": "Total social security benefits",
+      "desc": "Total social security (OASDI) benefits",
       "form": {"2013-2016": "1040 line 20a"},
       "availability": "taxdata_puf, taxdata_cps"
     },
@@ -709,7 +709,7 @@
     },
     "c02500": {
       "type": "float",
-      "desc": "Social security benefits included in AGI",
+      "desc": "Social security (OASDI) benefits included in AGI",
       "form": {"2013-2016": "1040 line 20b"}
     },
     "c02900": {

--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -176,7 +176,7 @@ def test_compatible_data(cps_subsample, puf_subsample,
 
     # These parameters are exempt because they are not active under
     # current law and activating them would deactivate other parameters.
-    exempt = ['_CG_ec', '_CG_reinvest_ec_rt']
+    exempt_from_testing = ['_CG_ec', '_CG_reinvest_ec_rt']
 
     # Loop through the parameters in allparams_batch
     errmsg = 'ERROR: {} not {} for {}\n'
@@ -221,8 +221,16 @@ def test_compatible_data(cps_subsample, puf_subsample,
         c_yy = Calculator(policy=p_yy, records=rec_yy, verbose=False)
         c_yy.advance_to_year(TEST_YEAR)
         c_yy.calc_all()
-        max_reform_change = (c_yy.weighted_total('combined') -
-                             c_xx.weighted_total('combined'))
+        if pname.startswith('_BEN') and pname.endswith('_repeal'):
+            max_reform_change = (
+                c_yy.weighted_total('benefit_cost_total') -
+                c_xx.weighted_total('benefit_cost_total')
+            )
+        else:
+            max_reform_change = (
+                c_yy.weighted_total('combined') -
+                c_xx.weighted_total('combined')
+            )
         min_reform_change = 0
         # assess whether min reform changes results, if max reform did not
         if max_reform_change == 0:
@@ -231,13 +239,17 @@ def test_compatible_data(cps_subsample, puf_subsample,
             c_yy = Calculator(policy=p_yy, records=rec_xx)
             c_yy.advance_to_year(TEST_YEAR)
             c_yy.calc_all()
-            if pname.startswith('_BEN_'):
-                min_reform_change = (c_yy.weighted_total('benefits_total') -
-                                     c_xx.weighted_total('benefits_total'))
+            if pname.startswith('_BEN') and pname.endswith('_repeal'):
+                min_reform_change = (
+                    c_yy.weighted_total('benefit_cost_total') -
+                    c_xx.weighted_total('benefit_cost_total')
+                )
             else:
-                min_reform_change = (c_yy.weighted_total('combined') -
-                                     c_xx.weighted_total('combined'))
-            if min_reform_change == 0 and pname not in exempt:
+                min_reform_change = (
+                    c_yy.weighted_total('combined') -
+                    c_xx.weighted_total('combined')
+                )
+            if min_reform_change == 0 and pname not in exempt_from_testing:
                 if puftest:
                     if param['compatible_data']['puf'] is not False:
                         errors += errmsg.format(pname, 'False', 'puf')


### PR DESCRIPTION
Change `_BEN_*_repeal` policy parameter names to lower-case benefit names in order to be consistent with the use of lower-case benefit names in the Records variables and in the Consumption value parameters.

No change in tax-calculating logic or tax/benefit results.