### PR TITLE
Use new Consumption in-kind benefit value parameter names in tax logic

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -65,7 +65,10 @@ class Calculator(object):
         specifies consumption response assumptions used to calculate
         "effective" marginal tax rates; default is None, which implies
         no consumption responses assumed in marginal tax rate calculations;
-        when argument is an object it is copied for internal use
+        when argument is an object it is copied for internal use;
+        also specifies consumption value of in-kind benefis with no in-kind
+        consumption values specified implying consumption value is equal to
+        government cost of providing the in-kind benefits
 
     behavior: Behavior class object
         specifies behavioral responses used by Calculator; default is None,
@@ -287,7 +290,7 @@ class Calculator(object):
         """
         Return value of named parameter in embedded Consumption object.
         """
-        return getattr(self.__consumption, param_name, 1.0)  # TODO: drop 1.0
+        return getattr(self.__consumption, param_name)
 
     def behavior_has_response(self):
         """

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -1,5 +1,5 @@
 """
-Tax-Calculator marginal Consumption class.
+Tax-Calculator Consumption class.
 """
 # CODING-STYLE CHECKS:
 # pep8 --ignore=E402 consumption.py
@@ -15,19 +15,20 @@ class Consumption(ParametersBase):
     Consumption is a subclass of the abstract ParametersBase class, and
     therefore, inherits its methods (none of which are shown here).
 
-    Constructor for marginal Consumption class.
+    Constructor for Consumption class.
 
     Parameters
     ----------
     consumption_dict: dictionary of PARAM:DESCRIPTION pairs
-        dictionary of marginal propensity to consume (MPC) parameters;
-        if None, all MPC parameters are read from DEFAULTS_FILENAME file.
+        dictionary of marginal propensity to consume (MPC) parameters and
+        benefit (BEN) value-of-in-kind-benefit parameters;
+        if None, all parameters are read from DEFAULTS_FILENAME file.
 
     start_year: integer
-        first calendar year for MPC parameters.
+        first calendar year for consumption parameters.
 
     num_years: integer
-        number of calendar years for which to specify MPC parameter
+        number of calendar years for which to specify parameter
         values beginning with start_year.
 
     Raises
@@ -66,9 +67,9 @@ class Consumption(ParametersBase):
         For example: {2014: {'_MPC_xxx': [0.2, 0.1]}}
 
         Note that this method uses the specified revisions to update the
-        default MPC parameter values, so use this method just once
-        rather than calling it sequentially in an attempt to update
-        MPC parameters in several steps.
+        default MPC parameter values and the default BEN parameter values,
+        so use this method just once rather than calling it sequentially
+        in an attempt to update the parameters in several steps.
         """
         precall_current_year = self.current_year
         self.set_default_vals()
@@ -84,8 +85,10 @@ class Consumption(ParametersBase):
 
     def has_response(self):
         """
-        Return true if any MPC parameters are positive for current_year;
-        return false if all MPC parameters are zero.
+        Return true if any MPC parameters are positive for current_year or
+        if any BEN value parameters are less than one for current_year;
+        return false if all MPC parameters are zero and all BEN value
+        parameters are one
         """
         for var in Consumption.RESPONSE_VARS:
             if getattr(self, 'MPC_{}'.format(var)) > 0.0:
@@ -97,7 +100,8 @@ class Consumption(ParametersBase):
 
     def response(self, records, income_change):
         """
-        Changes consumption-related records variables given income_change.
+        Changes consumption-related records variables given income_change
+        and the current values of the MPC consumption parameters
         """
         if not isinstance(records, Records):
             raise ValueError('records is not a Records object')

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -61,13 +61,13 @@ def BenefitPrograms(calc):
     # (assuming that cash benefits have full value)
     value = np.array(
         calc.array('ssi_ben') +
-        calc.array('snap_ben') * calc.consump_param('snap_value') +
-        calc.array('vet_ben') * calc.consump_param('vet_value') +
-        calc.array('mcare_ben') * calc.consump_param('mcare_value') +
-        calc.array('mcaid_ben') * calc.consump_param('mcaid_value') +
+        calc.array('snap_ben') * calc.consump_param('BEN_snap_value') +
+        calc.array('vet_ben') * calc.consump_param('BEN_vet_value') +
+        calc.array('mcare_ben') * calc.consump_param('BEN_mcare_value') +
+        calc.array('mcaid_ben') * calc.consump_param('BEN_mcaid_value') +
         calc.array('e02400') +
         calc.array('e02300') +
-        calc.array('other_ben') * calc.consump_param('other_value')
+        calc.array('other_ben') * calc.consump_param('BEN_other_value')
     )
     calc.array('benefit_value_total', value)
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -495,7 +495,7 @@ def create_difference_table(vdf1, vdf2, groupby, income_measure, tax_to_diff):
             #              in 'pandas._libs.lib.is_bool_array' ignored
             #                                                  ^^^^^^^
             # It is hoped that Pandas PR#18252, which is scheduled for
-            # inclusion in Pandas version 0.23.0 (Feb 2018), will fix this.
+            # inclusion in Pandas version 0.23.0 (Apr 2018), will fix this.
             # See discussion at the following URL:
             # https://github.com/pandas-dev/pandas/issues/19037
             pdf['bins'].replace(to_replace=[1, 2, 3, 4, 5],


### PR DESCRIPTION
When the new Consumption parameter names were added in pull request #1863 the new parameter names were not used in the BenefitPrograms function.  This pull request simply fixes that problem.