### PR TITLE
Revise XTOT-vs-NSUM test for puf.csv data

### DIFF
--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -348,13 +348,13 @@ def test_puf_availability(tests_path, puf_path):
 @pytest.mark.xfail
 def test_ubi_n_variables(puf_path):
     """
-    Ensure that the three UBI n* variables add up to XTOT variable.
+    Ensure that the three UBI n* variables add up to XTOT variable,
+    recognizing that XTOT values are often capped in the IRS-SOI PUF,
+    so that XTOT < NSUM might not indicate any data inconsistency.
     """
     pufdf = pd.read_csv(puf_path)
     xtot = pufdf['XTOT']
     nsum = pufdf['nu18'] + pufdf['n1820'] + pufdf['n21']
-    if not np.allclose(xtot, nsum):
-        print('number of diffs is:', np.sum(xtot != nsum))
-        print('number xtot < nsum is:', np.sum(xtot < nsum))
+    if not np.sum(xtot > nsum) == 0:
         print('number xtot > nsum is:', np.sum(xtot > nsum))
-        assert 'XTOT' == '(nu18+n1820+n21)'
+        assert 'XTOT' <= '(nu18+n1820+n21)'


### PR DESCRIPTION
Implements changes in test suggested by @andersonfrailey in discussion of [taxdata issue 149](https://github.com/open-source-economics/taxdata/issues/149).