### PR TITLE
Incorporate new CPS data in which the three UBI n* variables are consistent with XTOT

### DIFF
--- a/taxcalc/tests/test_cpscsv.py
+++ b/taxcalc/tests/test_cpscsv.py
@@ -127,7 +127,6 @@ def test_cps_availability(tests_path, cps_path):
     assert (recvars - cpsvars) == set()
 
 
-@pytest.mark.xfail
 def test_ubi_n_variables(cps_path):
     """
     Ensure that the three UBI n* variables add up to XTOT variable.


### PR DESCRIPTION
This pull request incorporates a new `cps.csv.gz` file that has been generated by @andersonfrailey's [taxdata pull request 151](https://github.com/open-source-economics/taxdata/pull/151).  The new CPS data includes changes in the value of one or more of the UBI-related head-count variables (`nu18`, `n1820`, `n21`) for a small fraction of the 456,465 CPS filing units (full details in @andersonfrailey's comments in [taxdata issue 149](https://github.com/open-source-economics/taxdata/issues/149)).  The new CPS data leaves the value of `XTOT` unchanged for each filing unit.

These data enhancements allow the `test_ubi_n_variables` in the `test_cpscsv.py` file to pass, so it is no longer marked `xfail`.
