### PR TITLE
Add a_lineno variable to cps.csv.gz data file

### DIFF
--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -455,6 +455,12 @@
       "form": {"2013-2016": "6251"},
       "availability": "taxdata_puf"
     },
+    "a_lineno": {
+      "type": "int",
+      "desc": "CPS line number for the person record of the head of the tax filing unit (not used in tax-calculation logic)",
+      "form": {"2013-2016": "sample construction info"},
+      "availability": "taxdata_cps"
+    },
     "ffpos": {
       "type": "int",
       "desc": "CPS family identifier within household (not used in tax-calculation logic)",

--- a/taxcalc/tests/test_puf_var_stats.py
+++ b/taxcalc/tests/test_puf_var_stats.py
@@ -37,7 +37,7 @@ def create_base_table(test_path):
                  'c09600': 'Federal AMT liability'}
     # specify read variable names and descriptions
     unused_var_set = set(['AGIR1', 'DSI', 'EFI', 'EIC', 'ELECT', 'FDED',
-                          'h_seq', 'ffpos', 'fips', 'agi_bin',
+                          'h_seq', 'a_lineno', 'ffpos', 'fips', 'agi_bin',
                           'FLPDYR', 'FLPDMO', 'f2441', 'f3800', 'f6251',
                           'f8582', 'f8606', 'f8829', 'f8910', 'f8936', 'n20',
                           'n24', 'n25', 'n30', 'PREP', 'SCHB', 'SCHCF', 'SCHE',


### PR DESCRIPTION
This pull request adds a new variable to the `cps.csv.gz` data file that is called `a_lineno`.  This variable, which is the CPS A_LINENO for the person who is the taxpayer (head) in the Tax-Calculator filing unit, is not used in the tax calculations but is useful when matching CPS data to Tax-Calculator filing units.

The changes in this pull request have no effect on tax-calculating logic or on tax results.
