### PR TITLE
Change "value" to "cost" in BenefitPrograms

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -56,7 +56,7 @@ def BenefitPrograms(calc):
         calc.array('e02300') +
         calc.array('other_ben')
     )
-    calc.array('benefit_value_total', cost)
+    calc.array('benefit_cost_total', cost)
     # calculate consumption value of all benefits
     # (assuming that cash benefits have full value)
     value = np.array(


### PR DESCRIPTION
In the `BenefitPrograms` function, the sum of the non consumption-adjusted benefit values are assigned to `benefit_value_total`, rather than `benefit_cost_total`. This PR changes that assignment.