### PR TITLE
fix 1859

### DIFF
--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -72,7 +72,17 @@ TEST_YEAR = 2020
 @pytest.fixture(scope='module', name='reform_xx')
 def fixture_reform_xx():
     """
-    Fixture for reform dictionary where reform starts before TEST_YEAR
+    Fixture for reform dictionary where reform starts before TEST_YEAR.
+
+    The provisions in the baseline reform, designated in _reform_xx,
+    is designed to activate parameters that are inactive under current law.
+    For example a phaseout rate for a new credit is inactive is the credit's
+    amount is set to zero under current law. In order to activate the phaseout
+    rate, the credit amount should be set above zero. The provisions interact
+    with each other: you may acidentally deactivate one parameter
+    by introducing a provision to activate another. If you find that a pair of
+    parameters are impossible test jointly, add one to the local variable
+    `exempt_from_testing` in `test_compatible_data()` as a last resort.
     """
     assert XX_YEAR < TEST_YEAR
 

--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -75,7 +75,7 @@ def fixture_reform_xx():
     Fixture for reform dictionary where reform starts before TEST_YEAR.
 
     The provisions in the baseline reform, designated in _reform_xx,
-    is designed to activate parameters that are inactive under current law.
+    are chosen to activate parameters that are inactive under current law.
     For example a phaseout rate for a new credit is inactive is the credit's
     amount is set to zero under current law. In order to activate the phaseout
     rate, the credit amount should be set above zero. The provisions interact

--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -76,7 +76,7 @@ def fixture_reform_xx():
 
     The provisions in the baseline reform, designated in _reform_xx,
     are chosen to activate parameters that are inactive under current law.
-    For example a phaseout rate for a new credit is inactive is the credit's
+    For example a phaseout rate for a new credit is inactive if the credit's
     amount is set to zero under current law. In order to activate the phaseout
     rate, the credit amount should be set above zero. The provisions interact
     with each other: you may acidentally deactivate one parameter

--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -112,7 +112,7 @@ def fixture_reform_xx():
             '_AGI_surtax_trt': [0.5],
             '_ID_AmountCap_rt': [0.9],
             '_II_brk7': [[1000000, 1000000, 1000000, 1000000, 1000000]],
-            '_ID_BenefitCap_rt': [0.4],
+            '_ID_BenefitCap_rt': [0.3],
             '_PT_rt7': [.35],
             '_II_em': [1000],
             '_ID_Casualty_hc': [.1],


### PR DESCRIPTION
This PR fixes #1859. 

I activated `_ID_BenefitCap_Switch` by reducing `ID_Benefit_Cap_rt`. `ID_Benefit_Cap_rt` is the ceiling on the benefits from itemized deductions as a decimal fraction of total deductible expenses. No tax units in `cps.csv` were subject to the cap when the switch was 0.4, but they were when the cap was set as 0.3. Remember that the test uses a modified baseline, so this should not be taken as a statement about the parameter's behavior in the context of current law. 

@martinholmer, I'd appreciate your feedback on the new docstring, which I added to address the first point of https://github.com/open-source-economics/Tax-Calculator/issues/1846.