### PR TITLE
Rename Calculator.param method as Calculator.policy_param

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -273,7 +273,7 @@ class Calculator(object):
         """
         return self.__records.array_length
 
-    def param(self, param_name, param_value=None):
+    def policy_param(self, param_name, param_value=None):
         """
         If param_value is None, return named parameter in
          embedded Policy object.
@@ -687,10 +687,10 @@ class Calculator(object):
         mtr_on_earnings = (variable_str == 'e00200p' or
                            variable_str == 'e00200s')
         if wrt_full_compensation and mtr_on_earnings:
-            adj = np.where(variable < self.param('SS_Earnings_c'),
-                           0.5 * (self.param('FICA_ss_trt') +
-                                  self.param('FICA_mc_trt')),
-                           0.5 * self.param('FICA_mc_trt'))
+            adj = np.where(variable < self.policy_param('SS_Earnings_c'),
+                           0.5 * (self.policy_param('FICA_ss_trt') +
+                                  self.policy_param('FICA_mc_trt')),
+                           0.5 * self.policy_param('FICA_mc_trt'))
         else:
             adj = 0.0
         # compute marginal tax rates

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -96,14 +96,14 @@ def test_make_calculator_with_policy_reform(cps_subsample):
     calc = Calculator(policy=pol, records=rec)
     # check that Policy object embedded in Calculator object is correct
     assert calc.current_year == year
-    assert calc.param('II_em') == 4000
-    assert np.allclose(calc.param('_II_em'),
+    assert calc.policy_param('II_em') == 4000
+    assert np.allclose(calc.policy_param('_II_em'),
                        np.array([4000] * Policy.DEFAULT_NUM_YEARS))
     exp_STD_Aged = [[1600, 1300, 1300,
                      1600, 1600]] * Policy.DEFAULT_NUM_YEARS
-    assert np.allclose(calc.param('_STD_Aged'),
+    assert np.allclose(calc.policy_param('_STD_Aged'),
                        np.array(exp_STD_Aged))
-    assert np.allclose(calc.param('STD_Aged'),
+    assert np.allclose(calc.policy_param('STD_Aged'),
                        np.array([1600, 1300, 1300, 1600, 1600]))
 
 
@@ -122,14 +122,14 @@ def test_make_calculator_with_multiyear_reform(cps_subsample):
     # check that Policy object embedded in Calculator object is correct
     assert pol.num_years == Policy.DEFAULT_NUM_YEARS
     assert calc.current_year == year
-    assert calc.param('II_em') == 3950
+    assert calc.policy_param('II_em') == 3950
     exp_II_em = [3900, 3950, 5000] + [6000] * (Policy.DEFAULT_NUM_YEARS - 3)
-    assert np.allclose(calc.param('_II_em'),
+    assert np.allclose(calc.policy_param('_II_em'),
                        np.array(exp_II_em))
     calc.increment_year()
     calc.increment_year()
     assert calc.current_year == 2016
-    assert np.allclose(calc.param('STD_Aged'),
+    assert np.allclose(calc.policy_param('STD_Aged'),
                        np.array([1600, 1300, 1600, 1300, 1600]))
 
 
@@ -244,10 +244,10 @@ def test_make_calculator_increment_years_first(cps_subsample):
                              [std5, std5, std5, std5, std5],
                              [std6, std6, std6, std6, std6],
                              [std7, std7, std7, std7, std7]])
-    act_STD_Aged = calc.param('_STD_Aged')
+    act_STD_Aged = calc.policy_param('_STD_Aged')
     assert np.allclose(act_STD_Aged[:5], exp_STD_Aged)
     exp_II_em = np.array([3900, 3950, 5000, 6000, 6000])
-    act_II_em = calc.param('_II_em')
+    act_II_em = calc.policy_param('_II_em')
     assert np.allclose(act_II_em[:5], exp_II_em)
 
 


### PR DESCRIPTION
This pull request renames the `param` method of the Calculator class to `policy_param` in order to clarify differences between the various types of parameters (Consumption, Behavior, Policy, and more to come).  

This is a public API change for users of Tax-Calculator who call the old `Calculator.param` method in their applications.  The Tax-Calculator library has been update internally to use the new `Calculator.policy_param` method, but other applications will have to be updated by their developers.