### PR TITLE
Clarify age requirement for CTC-eligible children

### DIFF
--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -511,7 +511,7 @@
     },
     "n24": {
       "type": "int",
-      "desc": "Number of children eligible for Child Tax Credit",
+      "desc": "Number of children under age 17 eligible for Child Tax Credit",
       "form": {"2013-2016": "imputed from CPS data"},
       "availability": "taxdata_puf, taxdata_cps"
     },


### PR DESCRIPTION
Change in documentation only.  
But it would appear that the current `cps.csv` file incorrectly contains 17-year olds in the `n24` count as described by @MaxGhenis in [taxdata issue 164](https://github.com/open-source-economics/taxdata/issues/164).