### PR TITLE
Add Calculator class distribution_table_dataframe method

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -384,16 +384,18 @@ class Calculator(object):
         assert num_years >= 1
         max_num_years = self.__policy.end_year - self.__policy.current_year + 1
         assert num_years <= max_num_years
+        diag_variables = DIST_VARIABLES + ['surtax']
         calc = copy.deepcopy(self)
         tlist = list()
         for iyr in range(1, num_years + 1):
             assert calc.behavior_has_response() is False
             calc.calc_all()
-            diag = create_diagnostic_table(calc.dataframe(DIST_VARIABLES),
+            diag = create_diagnostic_table(calc.dataframe(diag_variables),
                                            calc.current_year)
             tlist.append(diag)
             if iyr < num_years:
                 calc.increment_year()
+        del diag_variables
         del calc
         del diag
         return pd.concat(tlist, axis=1)

--- a/taxcalc/tbi/tbi.py
+++ b/taxcalc/tbi/tbi.py
@@ -96,8 +96,8 @@ def run_nth_year_tax_calc_model(year_n, start_year,
                                      behavior_allowed=True)
 
     # extract raw results from calc1 and calc2
-    rawres1 = calc1.dataframe(DIST_VARIABLES)
-    rawres2 = calc2.dataframe(DIST_VARIABLES)
+    rawres1 = calc1.distribution_table_dataframe()
+    rawres2 = calc2.distribution_table_dataframe()
 
     # delete calc1 and calc2 now that raw results have been extracted
     del calc1

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -277,7 +277,7 @@ def test_create_tables(cps_subsample):
 
     # test creating various distribution tables
 
-    dist = create_distribution_table(calc2.dataframe(DIST_VARIABLES),
+    dist = create_distribution_table(calc2.distribution_table_dataframe(),
                                      groupby='weighted_deciles',
                                      income_measure='expanded_income',
                                      result_type='weighted_sum')
@@ -375,7 +375,7 @@ def test_create_tables(cps_subsample):
         for val in dist[tabcol].values:
             print('{:.0f},'.format(val))
 
-    dist = create_distribution_table(calc2.dataframe(DIST_VARIABLES),
+    dist = create_distribution_table(calc2.distribution_table_dataframe(),
                                      groupby='standard_income_bins',
                                      income_measure='expanded_income',
                                      result_type='weighted_sum')
@@ -742,16 +742,16 @@ def test_dist_table_sum_row(cps_subsample):
     rec = Records.cps_constructor(data=cps_subsample)
     calc = Calculator(policy=Policy(), records=rec)
     calc.calc_all()
-    tb1 = create_distribution_table(calc.dataframe(DIST_VARIABLES),
+    tb1 = create_distribution_table(calc.distribution_table_dataframe(),
                                     groupby='small_income_bins',
                                     income_measure='expanded_income',
                                     result_type='weighted_sum')
-    tb2 = create_distribution_table(calc.dataframe(DIST_VARIABLES),
+    tb2 = create_distribution_table(calc.distribution_table_dataframe(),
                                     groupby='large_income_bins',
                                     income_measure='expanded_income',
                                     result_type='weighted_sum')
     assert np.allclose(tb1[-1:], tb2[-1:])
-    tb3 = create_distribution_table(calc.dataframe(DIST_VARIABLES),
+    tb3 = create_distribution_table(calc.distribution_table_dataframe(),
                                     groupby='small_income_bins',
                                     income_measure='expanded_income',
                                     result_type='weighted_avg')

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -61,7 +61,13 @@ DATA_FLOAT = [[1.0, 2, 'a'],
 
 def test_validity_of_name_lists():
     assert len(DIST_TABLE_COLUMNS) == len(DIST_TABLE_LABELS)
+    Records.read_var_info()
     assert set(DIST_VARIABLES).issubset(Records.CALCULATED_VARS | {'s006'})
+    assert len(set(DIST_VARIABLES) - set(DIST_TABLE_COLUMNS)) == 0
+    extra_vars_set = set(['num_returns_StandardDed',
+                          'num_returns_ItemDed',
+                          'num_returns_AMT'])
+    assert (set(DIST_TABLE_COLUMNS) - set(DIST_VARIABLES)) == extra_vars_set
 
 
 def test_create_tables(cps_subsample):

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -254,9 +254,9 @@ def create_distribution_table(vdf, groupby, income_measure, result_type):
 
     Parameters
     ----------
-    vdf : Pandas DataFrame including columns named as in STATS_VARIABLES list
-        for example, object returned from Calculator dataframe method in a
-        call like this: vdf = calc.dataframe(STATS_VARIABLES)
+    vdf : Pandas DataFrame including columns named in DIST_TABLE_COLUMNS list
+        for example, object returned from the Calculator class
+        distribution_table_dataframe method
 
     groupby : String object
         options for input: 'weighted_deciles', 'standard_income_bins',
@@ -408,13 +408,13 @@ def create_difference_table(vdf1, vdf2, groupby, income_measure, tax_to_diff):
 
     Parameters
     ----------
-    vdf1 : Pandas DataFrame object including columns in the DIFF_VARIABLES
-           list drawn from a baseline Calculator object using the
-           Calculator.dataframe method
+    vdf1 : Pandas DataFrame including columns named in DIFF_VARIABLES list
+           for example, object returned from a dataframe(DIFF_VARIABLE) call
+           on the basesline Calculator object
 
-    vdf2 : Pandas DataFrame object including columns in the DIFF_VARIABLES
-           list drawn from a baseline Calculator object using the
-           Calculator.dataframe method
+    vdf2 : Pandas DataFrame including columns in the DIFF_VARIABLES list
+           for example, object returned from a dataframe(DIFF_VARIABLE) call
+           on the reform Calculator object
 
     groupby : String object
         options for input: 'weighted_deciles', 'standard_income_bins',

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -34,7 +34,7 @@ from taxcalc.utilsprvt import (weighted_count_lt_zero,
 
 DIST_VARIABLES = ['expanded_income', 'c00100', 'aftertax_income', 'standard',
                   'c04470', 'c04600', 'c04800', 'taxbc', 'c62100', 'c09600',
-                  'c05800', 'othertaxes', 'refund', 'c07100', 'surtax',
+                  'c05800', 'othertaxes', 'refund', 'c07100',
                   'iitax', 'payrolltax', 'combined', 's006', 'ubi',
                   'benefit_cost_total', 'benefit_value_total']
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -299,26 +299,6 @@ def create_distribution_table(vdf, groupby, income_measure, result_type):
           specified income_measure.
     """
     # pylint: disable=too-many-statements,too-many-locals,too-many-branches
-    # nested function that specifies calculated columns
-    def add_columns(pdf):
-        """
-        Nested function that adds several columns to
-        the specified Pandas DataFrame, pdf.
-        """
-        # weight of returns with positive AGI and
-        # itemized deduction greater than standard deduction
-        pdf['c04470'] = pdf['c04470'].where(
-            ((pdf['c00100'] > 0.) & (pdf['c04470'] > pdf['standard'])), 0.)
-        # weight of returns with positive AGI and itemized deduction
-        pdf['num_returns_ItemDed'] = pdf['s006'].where(
-            ((pdf['c00100'] > 0.) & (pdf['c04470'] > 0.)), 0.)
-        # weight of returns with positive AGI and standard deduction
-        pdf['num_returns_StandardDed'] = pdf['s006'].where(
-            ((pdf['c00100'] > 0.) & (pdf['standard'] > 0.)), 0.)
-        # weight of returns with positive Alternative Minimum Tax (AMT)
-        pdf['num_returns_AMT'] = pdf['s006'].where(pdf['c09600'] > 0., 0.)
-        return pdf
-
     # nested function that returns calculated column statistics as a DataFrame
     def stat_dataframe(gpdf):
         """
@@ -334,7 +314,6 @@ def create_distribution_table(vdf, groupby, income_measure, result_type):
             else:
                 sdf[col] = gpdf.apply(weighted_sum, col)
         return sdf
-
     # main logic of create_distribution_table
     assert isinstance(vdf, pd.DataFrame)
     assert (groupby == 'weighted_deciles' or
@@ -349,7 +328,6 @@ def create_distribution_table(vdf, groupby, income_measure, result_type):
     assert income_measure in vdf
     # copy vdf and add variable columns
     res = copy.deepcopy(vdf)
-    res = add_columns(res)
     # sort the data given specified groupby and income_measure
     if groupby == 'weighted_deciles':
         pdf = add_quantile_bins(res, income_measure, 10)


### PR DESCRIPTION
This pull request moves the logic in the `add_columns` function nested in the `create_distribution_table` utility function into a new Calculator method named `distribution_table_dataframe`.  This change has no effect on table results.  The purpose of the change to to add the extra columns once, rather than each time the `create_distribution_table` utility function is called.

This pull request also removes the surtax variable from the `DIST_VARIABLES` list because it is not used in the distribution table.