### PR TITLE
Rename add_*_bins utility functions

### DIFF
--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -20,7 +20,8 @@ from taxcalc.growdiff import Growdiff
 from taxcalc.growfactors import Growfactors
 from taxcalc.calculate import Calculator
 from taxcalc.utils import (delete_file, write_graph_file,
-                           add_quantile_bins, unweighted_sum, weighted_sum)
+                           add_quantile_table_row_variable,
+                           unweighted_sum, weighted_sum)
 
 
 class TaxCalcIO(object):
@@ -600,9 +601,9 @@ class TaxCalcIO(object):
         """
         Write to tfile the tkind decile table using dfx DataFrame.
         """
-        dfx = add_quantile_bins(dfx, 'expanded_income', 10,
-                                weight_by_income_measure=False)
-        gdfx = dfx.groupby('bins', as_index=False)
+        dfx = add_quantile_table_row_variable(dfx, 'expanded_income', 10,
+                                              weight_by_income_measure=False)
+        gdfx = dfx.groupby('table_row', as_index=False)
         rtns_series = gdfx.apply(unweighted_sum, 's006')
         xinc_series = gdfx.apply(weighted_sum, 'expanded_income')
         itax_series = gdfx.apply(weighted_sum, 'iitax')

--- a/taxcalc/tbi/tbi_utils.py
+++ b/taxcalc/tbi/tbi_utils.py
@@ -13,7 +13,8 @@ import numpy as np
 import pandas as pd
 from taxcalc import (Policy, Records, Calculator,
                      Consumption, Behavior, Growfactors, Growdiff)
-from taxcalc.utils import (add_income_bins, add_quantile_bins,
+from taxcalc.utils import (add_income_table_row_variable,
+                           add_quantile_table_row_variable,
                            create_difference_table, create_distribution_table,
                            DIST_VARIABLES, DIST_TABLE_COLUMNS,
                            STANDARD_INCOME_BINS, read_egg_csv)
@@ -345,12 +346,13 @@ def create_results_columns(df1, df2, mask):
         # pylint: disable=too-many-arguments
         assert bin_type == 'dec' or bin_type == 'bin' or bin_type == 'agg'
         if bin_type == 'dec':
-            df2 = add_quantile_bins(df2, imeasure, 10)
+            df2 = add_quantile_table_row_variable(df2, imeasure, 10)
         elif bin_type == 'bin':
-            df2 = add_income_bins(df2, imeasure, bins=STANDARD_INCOME_BINS)
+            df2 = add_income_table_row_variable(df2, imeasure,
+                                                bins=STANDARD_INCOME_BINS)
         else:
-            df2 = add_quantile_bins(df2, imeasure, 1)
-        gdf2 = df2.groupby('bins')
+            df2 = add_quantile_table_row_variable(df2, imeasure, 1)
+        gdf2 = df2.groupby('table_row')
         if do_fuzzing:
             df2['nofuzz'] = gdf2['mask'].transform(chooser)
         else:  # never do any results fuzzing

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -28,7 +28,8 @@ from taxcalc.utils import (DIST_VARIABLES,
                            wage_weighted, agi_weighted,
                            expanded_income_weighted,
                            weighted_perc_inc, weighted_perc_cut,
-                           add_income_bins, add_quantile_bins,
+                           add_income_table_row_variable,
+                           add_quantile_table_row_variable,
                            mtr_graph_data, atr_graph_data, dec_graph_data,
                            xtr_graph_plot, write_graph_file,
                            read_egg_csv, read_egg_json, delete_file,
@@ -649,21 +650,21 @@ def test_weighted_perc_cut():
 EPSILON = 1e-5
 
 
-def test_add_income_bins():
+def test_add_income_table_row_var():
     dta = np.arange(1, 1e6, 5000)
     dfx = pd.DataFrame(data=dta, columns=['expanded_income'])
     bins = LARGE_INCOME_BINS
-    dfr = add_income_bins(dfx, 'expanded_income', bin_type='tpc', bins=None,
-                          right=True)
-    groupedr = dfr.groupby('bins')
+    dfr = add_income_table_row_variable(dfx, 'expanded_income',
+                                        bin_type='tpc', bins=None, right=True)
+    groupedr = dfr.groupby('table_row')
     idx = 1
     for name, _ in groupedr:
         assert name.closed == 'right'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
-    dfl = add_income_bins(dfx, 'expanded_income', bin_type='tpc', bins=None,
-                          right=False)
-    groupedl = dfl.groupby('bins')
+    dfl = add_income_table_row_variable(dfx, 'expanded_income',
+                                        bin_type='tpc', bins=None, right=False)
+    groupedl = dfl.groupby('table_row')
     idx = 1
     for name, _ in groupedl:
         assert name.closed == 'left'
@@ -671,20 +672,22 @@ def test_add_income_bins():
         idx += 1
 
 
-def test_add_income_bins_soi():
+def test_add_income_table_row_soi():
     dta = np.arange(1, 1e6, 5000)
     dfx = pd.DataFrame(data=dta, columns=['expanded_income'])
 
     bins = SMALL_INCOME_BINS
-    dfr = add_income_bins(dfx, 'expanded_income', bin_type='soi', right=True)
-    groupedr = dfr.groupby('bins')
+    dfr = add_income_table_row_variable(dfx, 'expanded_income',
+                                        bin_type='soi', right=True)
+    groupedr = dfr.groupby('table_row')
     idx = 1
     for name, _ in groupedr:
         assert name.closed == 'right'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
-    dfl = add_income_bins(dfx, 'expanded_income', bin_type='soi', right=False)
-    groupedl = dfl.groupby('bins')
+    dfl = add_income_table_row_variable(dfx, 'expanded_income',
+                                        bin_type='soi', right=False)
+    groupedl = dfl.groupby('table_row')
     idx = 1
     for name, _ in groupedl:
         assert name.closed == 'left'
@@ -692,19 +695,21 @@ def test_add_income_bins_soi():
         idx += 1
 
 
-def test_add_exp_income_bins():
+def test_add_exp_income_table_row_var():
     dta = np.arange(1, 1e6, 5000)
     dfx = pd.DataFrame(data=dta, columns=['expanded_income'])
     bins = [-9e99, 0, 4999, 9999, 14999, 19999, 29999, 32999, 43999, 9e99]
-    dfr = add_income_bins(dfx, 'expanded_income', bins=bins, right=True)
-    groupedr = dfr.groupby('bins')
+    dfr = add_income_table_row_variable(dfx, 'expanded_income',
+                                        bins=bins, right=True)
+    groupedr = dfr.groupby('table_row')
     idx = 1
     for name, _ in groupedr:
         assert name.closed == 'right'
         assert abs(name.right - bins[idx]) < EPSILON
         idx += 1
-    dfl = add_income_bins(dfx, 'expanded_income', bins=bins, right=False)
-    groupedl = dfl.groupby('bins')
+    dfl = add_income_table_row_variable(dfx, 'expanded_income',
+                                        bins=bins, right=False)
+    groupedl = dfl.groupby('table_row')
     idx = 1
     for name, _ in groupedl:
         assert name.closed == 'left'
@@ -712,24 +717,25 @@ def test_add_exp_income_bins():
         idx += 1
 
 
-def test_add_income_bins_raises():
+def test_add_income_table_row_var_raises():
     dta = np.arange(1, 1e6, 5000)
     dfx = pd.DataFrame(data=dta, columns=['expanded_income'])
     with pytest.raises(ValueError):
-        dfx = add_income_bins(dfx, 'expanded_income', bin_type='stuff')
+        dfx = add_income_table_row_variable(dfx, 'expanded_income',
+                                            bin_type='stuff')
 
 
-def test_add_quantile_bins():
+def test_add_quantile_table_row_var():
     dfx = pd.DataFrame(data=DATA, columns=['expanded_income', 's006', 'label'])
-    dfb = add_quantile_bins(dfx, 'expanded_income', 100,
-                            weight_by_income_measure=False)
-    bin_labels = dfb['bins'].unique()
+    dfb = add_quantile_table_row_variable(dfx, 'expanded_income', 100,
+                                          weight_by_income_measure=False)
+    bin_labels = dfb['table_row'].unique()
     default_labels = set(range(1, 101))
     for lab in bin_labels:
         assert lab in default_labels
-    dfb = add_quantile_bins(dfx, 'expanded_income', 100,
-                            weight_by_income_measure=True)
-    assert 'bins' in dfb
+    dfb = add_quantile_table_row_variable(dfx, 'expanded_income', 100,
+                                          weight_by_income_measure=True)
+    assert 'table_row' in dfb
 
 
 def test_dist_table_sum_row(cps_subsample):


### PR DESCRIPTION
Renaming clarifies that the two utility functions add a table-row variable to the Pandas DataFrame object and do not actually create the table rows.