### PR TITLE
Add two optional arguments to Policy implement_reform method

### DIFF
--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -5,6 +5,7 @@ Tax-Calculator federal tax policy Policy class.
 # pep8 policy.py
 # pylint --disable=locally-disabled policy.py
 
+from __future__ import print_function
 import six
 import numpy as np
 from taxcalc.parameters import ParametersBase
@@ -102,7 +103,7 @@ class Policy(ParametersBase):
         """
         return self._wage_growth_rates
 
-    def implement_reform(self, reform):
+    def implement_reform(self, reform, print_warnings=True, raise_errors=True):
         """
         Implement multi-year policy reform and leave current_year unchanged.
 
@@ -110,6 +111,16 @@ class Policy(ParametersBase):
         ----------
         reform: dictionary of one or more YEAR:MODS pairs
             see Notes to Parameters _update method for info on MODS structure
+
+        print_warnings: boolean
+            if True (the default), prints warnings when reform_warnings exists;
+            if False, does not print warnings when reform_warnings exists and
+                      leaves warning handling to caller of implement_reform.
+
+        raise_errors: boolean
+            if True (the default), raises ValueError when reform_errors exists;
+            if False, does not raise ValueError when reform_errors exists and
+                      leaves error handling to caller of implement_reform.
 
         Raises
         ------
@@ -212,6 +223,10 @@ class Policy(ParametersBase):
         self.set_year(precall_current_year)
         # validate reform parameter values
         self._validate_parameter_values(reform_parameters)
+        if self.reform_warnings and print_warnings:
+            print(self.reform_warnings)
+        if self.reform_errors and raise_errors:
+            raise ValueError('\n' + self.reform_errors)
 
     def current_law_version(self):
         """
@@ -308,6 +323,8 @@ class Policy(ParametersBase):
                 gdiff_baseline.apply_to(growfactors)
                 gdiff_response.apply_to(growfactors)
             else:
+                gdiff_baseline = None
+                gdiff_response = None
                 growfactors = None
             pol = Policy(gfactors=growfactors)
             pol.ignore_reform_errors()
@@ -323,7 +340,13 @@ class Policy(ParametersBase):
                         idx = Policy.JSON_REFORM_SUFFIXES[suffix]
                         odict[param][year][0][idx] = gdict[param][year][suffix]
                         udict = {int(year): {param: odict[param][year]}}
-                        pol.implement_reform(udict)
+                        pol.implement_reform(udict,
+                                             print_warnings=False,
+                                             raise_errors=False)
+            del gdiff_baseline
+            del gdiff_response
+            del growfactors
+            del pol
             return odict
 
         # high-level logic of translate_json_reform_suffixes method:

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -473,6 +473,7 @@ class Policy(ParametersBase):
                         else:
                             scalar = True  # parameter value is a scalar
                             pvalue = [pvalue]  # make scalar a single-item list
+                        # pylint: disable=consider-using-enumerate
                         for idx in range(0, len(pvalue)):
                             if scalar:
                                 pname = name

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -286,7 +286,9 @@ class TaxCalcIO(object):
         # ... the baseline Policy object
         base = Policy(gfactors=gfactors_base)
         try:
-            base.implement_reform(basedict['policy'])
+            base.implement_reform(basedict['policy'],
+                                  print_warnings=False,
+                                  raise_errors=False)
             self.errmsg += base.reform_errors
         except ValueError as valerr_msg:
             self.errmsg += valerr_msg.__str__()
@@ -295,7 +297,9 @@ class TaxCalcIO(object):
             pol = Policy(gfactors=gfactors_ref)
             for poldict in policydicts:
                 try:
-                    pol.implement_reform(poldict)
+                    pol.implement_reform(poldict,
+                                         print_warnings=False,
+                                         raise_errors=False)
                     self.errmsg += pol.reform_errors
                 except ValueError as valerr_msg:
                     self.errmsg += valerr_msg.__str__()

--- a/taxcalc/tbi/tbi.py
+++ b/taxcalc/tbi/tbi.py
@@ -63,7 +63,9 @@ def reform_warnings_errors(user_mods):
     # create Policy object and implement reform
     pol = Policy(gfactors=growfactors)
     try:
-        pol.implement_reform(user_mods['policy'])
+        pol.implement_reform(user_mods['policy'],
+                             print_warnings=False,
+                             raise_errors=False)
         rtn_dict['warnings'] = pol.reform_warnings
         rtn_dict['errors'] = pol.reform_errors
     except ValueError as valerr_msg:

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -805,7 +805,8 @@ def test_read_json_param_with_suffixes_and_errors():
     params = Calculator.read_json_param_objects(json_reform, None)
     assert isinstance(params, dict)
     pol = Policy()
-    pol.implement_reform(params['policy'])
+    pol.implement_reform(params['policy'],
+                         print_warnings=False, raise_errors=False)
     assert len(pol.reform_errors) > 0
     assert len(pol.reform_warnings) > 0
 

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -51,6 +51,8 @@ def test_correct_Policy_instantiation():
     pol.set_year(2019)
     with pytest.raises(ValueError):
         pol.implement_reform({2018: {'_II_em': [99000]}})
+    with pytest.raises(ValueError):
+        pol.implement_reform({2020: {'_II_em': [-1000]}})
 
 
 def test_policy_json_content():
@@ -935,27 +937,27 @@ def test_validate_param_values_warnings_errors():
     """
     pol1 = Policy()
     ref1 = {2020: {'_ID_Medical_frt': [0.05]}}
-    pol1.implement_reform(ref1)
+    pol1.implement_reform(ref1, print_warnings=False, raise_errors=False)
     assert len(pol1.reform_warnings) > 0
     pol2 = Policy()
     ref2 = {2021: {'_ID_Charity_crt_all': [0.61]}}
-    pol2.implement_reform(ref2)
+    pol2.implement_reform(ref2, print_warnings=False, raise_errors=False)
     assert len(pol2.reform_warnings) > 0
     pol3 = Policy()
     ref3 = {2024: {'_II_brk4': [[0, 0, 0, 0, 0]]}}
-    pol3.implement_reform(ref3)
+    pol3.implement_reform(ref3, print_warnings=False, raise_errors=False)
     assert len(pol3.reform_errors) > 0
     pol4 = Policy()
     ref4 = {2024: {'_II_brk4': [[0, 9e9, 0, 0, 0]]}}
-    pol4.implement_reform(ref4)
+    pol4.implement_reform(ref4, print_warnings=False, raise_errors=False)
     assert len(pol4.reform_errors) > 0
     pol5 = Policy()
     ref5 = {2025: {'_ID_BenefitSurtax_Switch': [[False, True, 0, 1, 0, 1, 0]]}}
-    pol5.implement_reform(ref5)
+    pol5.implement_reform(ref5, print_warnings=False, raise_errors=False)
     assert len(pol5.reform_errors) == 0
     pol6 = Policy()
     ref6 = {2013: {'_STD': [[20000, 25000, 20000, 20000, 25000]]}}
-    pol6.implement_reform(ref6)
+    pol6.implement_reform(ref6, print_warnings=False, raise_errors=False)
     assert pol6.reform_errors == ''
     assert pol6.reform_warnings == ''
 


### PR DESCRIPTION
The need for this enhancement has been pointed out by @hdoupe in #1951.
Now the default behavior of the `implement_reform` method is to print any reform warnings and raise any reform errors as a ValueError.  This is desirable for Tax-Calculator users who are programming in Python on their local computers.  The new method arguments allow the cli and tbi code to defer handling of warnings and errors until after the `implement_method` is called.