### PR TITLE
Clarify validation of _BE_subinc_wrt_earnings parameter value

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -386,7 +386,7 @@ class Behavior(ParametersBase):
                     if val > 0.0:
                         raise ValueError(msg.format(param, pos, cyr, val))
                 elif param == '_BE_subinc_wrt_earnings':
-                    if val < 0 or val > 1:
+                    if not (val == 0 or val == 1):
                         raise ValueError(msg.format(param, nob, cyr, val))
                 elif param == '_BE_cg':
                     if val > 0.0:


### PR DESCRIPTION
The need for this enhancement has been pointed out by @hdoupe in #1951.
By way of background, the ParameterBase class stores boolean parameters as numpy arrays with data type `numpy.int8`.