### PR TITLE
Handle pycodestyle (formerly pep8) warnings

### DIFF
--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -484,7 +484,7 @@ class SimpleTaxIO(object):
                     # convert istr to integer value
                     try:
                         val = int(istr)
-                    except:
+                    except ValueError:
                         msg = ('simtax INPUT line {} variable {} has '
                                'value {} that is not an integer')
                         raise ValueError(msg.format(lnum, vnum, istr))

--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -65,6 +65,7 @@ def test_compatible_data_presence(allparams):
             print(msg.format(pname))
         assert 'list of problem_pnames' == 'empty list'
 
+
 XX_YEAR = 2019
 TEST_YEAR = 2020
 
@@ -130,6 +131,7 @@ def fixture_sorted_param_names(allparams):
     Fixture for storing a sorted parameter list
     """
     return sorted(list(allparams.keys()))
+
 
 NPARAMS = len(Policy.default_data())
 BATCHSIZE = 10

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -454,7 +454,7 @@ def test_output_options(rawinputfile, reformfile1, assumpfile1):
     # --ceeu output and standard output
     try:
         tcio.analyze(writing_output_file=True, output_ceeu=True)
-    except:  # pylint: disable=bare-except
+    except Exception:
         if os.path.isfile(outfilepath):
             try:
                 os.remove(outfilepath)
@@ -464,7 +464,7 @@ def test_output_options(rawinputfile, reformfile1, assumpfile1):
     # --dump output with full dump
     try:
         tcio.analyze(writing_output_file=True, output_dump=True)
-    except:  # pylint: disable=bare-except
+    except Exception:
         if os.path.isfile(outfilepath):
             try:
                 os.remove(outfilepath)
@@ -477,7 +477,7 @@ def test_output_options(rawinputfile, reformfile1, assumpfile1):
         tcio.analyze(writing_output_file=True,
                      dump_varset=set(['combined']),
                      output_dump=True)
-    except:  # pylint: disable=bare-except
+    except Exception:
         if os.path.isfile(outfilepath):
             try:
                 os.remove(outfilepath)
@@ -545,7 +545,7 @@ def test_sqldb_option(rawinputfile, reformfile1, assumpfile1):
     # --sqldb output
     try:
         tcio.analyze(writing_output_file=False, output_sqldb=True)
-    except:  # pylint: disable=bare-except
+    except Exception:
         if os.path.isfile(dbfilepath):
             try:
                 os.remove(dbfilepath)
@@ -826,5 +826,5 @@ def test_growmodel_analysis(reformfile1, assumpfile1):
                                      assump=assumpfile1.name,
                                      aging_input_data=False,
                                      exact_calculations=False)
-    except:  # pylint: disable=bare-except
+    except Exception:
         assert 'TaxCalcIO.growmodel_analysis_ok' == 'no'

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -64,7 +64,7 @@ def test_validity_of_name_lists():
     assert len(DIST_TABLE_COLUMNS) == len(DIST_TABLE_LABELS)
     Records.read_var_info()
     assert set(DIST_VARIABLES).issubset(Records.CALCULATED_VARS | {'s006'})
-    assert len(set(DIST_VARIABLES) - set(DIST_TABLE_COLUMNS)) == 0
+    assert len(set(DIST_VARIABLES)) == len(set(DIST_TABLE_COLUMNS))
     extra_vars_set = set(['num_returns_StandardDed',
                           'num_returns_ItemDed',
                           'num_returns_AMT'])
@@ -894,7 +894,7 @@ def test_write_graph_file(cps_subsample):
     htmlfname = temporary_filename(suffix='.html')
     try:
         write_graph_file(gplot, htmlfname, 'title')
-    except:  # pylint: disable=bare-except
+    except Exception:
         if os.path.isfile(htmlfname):
             try:
                 os.remove(htmlfname)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -3,7 +3,6 @@ Tests of Tax-Calculator utility functions.
 """
 # CODING-STYLE CHECKS:
 # pep8 test_utils.py
-
 # pylint --disable=locally-disabled test_utils.py
 #
 # pylint: disable=missing-docstring,no-member,protected-access,too-many-lines
@@ -64,7 +63,6 @@ def test_validity_of_name_lists():
     assert len(DIST_TABLE_COLUMNS) == len(DIST_TABLE_LABELS)
     Records.read_var_info()
     assert set(DIST_VARIABLES).issubset(Records.CALCULATED_VARS | {'s006'})
-    assert len(set(DIST_VARIABLES)) == len(set(DIST_TABLE_COLUMNS))
     extra_vars_set = set(['num_returns_StandardDed',
                           'num_returns_ItemDed',
                           'num_returns_AMT'])

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1441,7 +1441,7 @@ def read_egg_csv(fname, index_col=None):
                 path_in_egg),
             index_col=index_col
         )
-    except:
+    except Exception:
         raise ValueError('could not read {} data from egg'.format(fname))
     # cannot call read_egg_ function in unit tests
     return vdf  # pragma: no cover
@@ -1460,7 +1460,7 @@ def read_egg_json(fname):
                 path_in_egg).read().decode('utf-8'),
             object_pairs_hook=collections.OrderedDict
         )
-    except:
+    except Exception:
         raise ValueError('could not read {} data from egg'.format(fname))
     # cannot call read_egg_ function in unit tests
     return pdict  # pragma: no cover


### PR DESCRIPTION
Handle warnings generated by version 2.3.1 of`pycodestyle` (the successor to `pep8`, which will be removed in the future).

Here is the pep8-deprecated warning generated by version 1.7.1 of `pep8`:
```
/Users/mrh/anaconda2/lib/python2.7/site-packages/pep8.py:2124: UserWarning: 

pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.

$ pip install pycodestyle
$ pycodestyle ...
```