### PR TITLE
Add copy constructor option to Growfactors and Records classes

### DIFF
--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -187,19 +187,25 @@ class Growfactors(object):
 
     def __eq__(self, other):
         """
-        Method that implements == operator for Growfactors instance.
+        Method that implements == operator for Growfactors class.
         """
-        keys = self.__dict__.keys()
-        if isinstance(other, Growfactors) and keys == other.__dict__.keys():
-            for key in keys:
-                val = self.__dict__[key]
-                valo = other.__dict__[key]
-                if isinstance(val, pd.DataFrame):
-                    if not val.equals(valo):
-                        return False
-                else:
-                    if not val == valo:
-                        return False
-            return True
-        else:
+        if isinstance(other, Growfactors):
+            keys = sorted(self.__dict__.keys())
+            keys_other = sorted(other.__dict__.keys())
+            if keys == keys_other:
+                for key in keys:
+                    val = self.__dict__[key]
+                    valo = other.__dict__[key]
+                    if isinstance(val, pd.DataFrame):
+                        if not val.equals(valo):
+                            return False
+                    else:
+                        if not val == valo:
+                            return False
+                del keys
+                del keys_other
+                del val
+                del valo
+                return True
             return False
+        return False

--- a/taxcalc/tests/test_growfactors.py
+++ b/taxcalc/tests/test_growfactors.py
@@ -105,5 +105,10 @@ def test_copy_ctor_and_eq():
     gf_copy.used = True
     assert not gf_copy.__eq__(gf_read)
     gf_copy.used = False
+    assert gf_copy.__eq__(gf_read)
     gf_copy.gfdf = gf_copy.gfdf + 1
+    assert not gf_copy.__eq__(gf_read)
+    gf_copy.gfdf = gf_read.gfdf.copy()
+    assert gf_copy.__eq__(gf_read)
+    gf_copy.__dict__['bogus'] = True
     assert not gf_copy.__eq__(gf_read)

--- a/taxcalc/tests/test_growfactors.py
+++ b/taxcalc/tests/test_growfactors.py
@@ -91,3 +91,19 @@ def test_growfactors_csv_values():
         for gfname in Growfactors.VALID_NAMES:
             val = gfo.factor_value(gfname, min_data_year)
             assert val == 1
+
+
+def test_copy_ctor_and_eq():
+    """
+    Test Growfactors copy constructor and its results as well as __eq__ method.
+    """
+    gf_read = Growfactors()
+    gf_copy = Growfactors(copy_source=gf_read)
+    assert gf_copy == gf_read
+    # check False returns by __eq__ method
+    assert not gf_copy.__eq__(list())
+    gf_copy.used = True
+    assert not gf_copy.__eq__(gf_read)
+    gf_copy.used = False
+    gf_copy.gfdf = gf_copy.gfdf + 1
+    assert not gf_copy.__eq__(gf_read)

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -201,3 +201,30 @@ def test_csv_input_vars_md_contents(tests_path):
         for var in valid_less_civ:
             msg += 'VARIABLE= {}\n'.format(var)
         raise ValueError(msg)
+
+
+def test_copy_ctor_and_eq():
+    """
+    Test Records copy constructor and its results as well as __eq__ method.
+    """
+    recs_read = Records.cps_constructor()
+    recs_copy = Records(copy_source=recs_read)
+    assert recs_copy == recs_read
+    # check False returns by __eq__ method
+    assert not recs_copy.__eq__(list())
+    recs_copy.behavioral_responses_are_included = True
+    assert not recs_copy.__eq__(recs_read)
+    recs_copy.behavioral_responses_are_included = False
+    assert recs_copy.__eq__(recs_read)
+    recs_copy.WT = pd.DataFrame(np.zeros_like(recs_read.WT),
+                                index=recs_read.WT.index,
+                                columns=recs_read.WT.columns)
+    assert not recs_copy.__eq__(recs_read)
+    recs_copy.WT = recs_read.WT.copy()
+    assert recs_copy.__eq__(recs_read)
+    recs_copy.s006 += 1.
+    assert not recs_copy.__eq__(recs_read)
+    recs_copy.s006 = recs_read.s006.copy()
+    assert recs_copy.__eq__(recs_read)
+    recs_copy.__dict__['bogus'] = True
+    assert not recs_copy.__eq__(recs_read)


### PR DESCRIPTION
This pull request adds an optional argument to both the Growfactors and Records class constructor that permits the constructor to operate like a C++ copy constructor.

These changes, which have no effect on tax results, are part of an ongoing effort to improve Tax-Calculator memory-management logic.