### PR TITLE
Add no_benefits=False optional argument to Records.cps_constructor

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -184,6 +184,7 @@ class Records(object):
 
     @staticmethod
     def cps_constructor(data=None,
+                        no_benefits=False,
                         exact_calculations=False,
                         gfactors=Growfactors()):
         """
@@ -198,12 +199,16 @@ class Records(object):
         """
         if data is None:
             data = os.path.join(Records.CUR_PATH, 'cps.csv.gz')
+        if no_benefits:
+            benefits_filename = None
+        else:
+            benefits_filename = Records.CPS_BENEFITS_FILENAME
         return Records(data=data,
                        exact_calculations=exact_calculations,
                        gfactors=gfactors,
                        weights=Records.CPS_WEIGHTS_FILENAME,
                        adjust_ratios=Records.CPS_RATIOS_FILENAME,
-                       benefits=Records.CPS_BENEFITS_FILENAME,
+                       benefits=benefits_filename,
                        start_year=Records.CPSCSV_YEAR)
 
     @property

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -17,7 +17,7 @@ def test_incorrect_behavior_instantiation():
 
 def test_behavioral_response_calculator(cps_subsample):
     # create Records object
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     year = rec.current_year
     # create Policy object
     pol = Policy()

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -59,7 +59,7 @@ def test_make_calculator(cps_subsample):
     syr = 2014
     pol = Policy(start_year=syr, num_years=9)
     assert pol.current_year == syr
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     consump = Consumption()
     consump.update_consumption({syr: {'_MPC_e20400': [0.05]}})
     assert consump.current_year == Consumption.JSON_START_YEAR
@@ -80,14 +80,14 @@ def test_make_calculator(cps_subsample):
 
 def test_make_calculator_deepcopy(cps_subsample):
     pol = Policy()
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     calc1 = Calculator(policy=pol, records=rec)
     calc2 = copy.deepcopy(calc1)
     assert isinstance(calc2, Calculator)
 
 
 def test_make_calculator_with_policy_reform(cps_subsample):
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     year = rec.current_year
     # create a Policy object and apply a policy reform
     pol = Policy()
@@ -111,7 +111,7 @@ def test_make_calculator_with_policy_reform(cps_subsample):
 
 
 def test_make_calculator_with_multiyear_reform(cps_subsample):
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     year = rec.current_year
     # create a Policy object and apply a policy reform
     pol = Policy()
@@ -137,7 +137,7 @@ def test_make_calculator_with_multiyear_reform(cps_subsample):
 
 
 def test_calculator_advance_to_year(cps_subsample):
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     pol = Policy()
     calc = Calculator(policy=pol, records=rec)
     calc.advance_to_year(2016)
@@ -147,13 +147,13 @@ def test_calculator_advance_to_year(cps_subsample):
 
 
 def test_make_calculator_raises_on_no_policy(cps_subsample):
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     with pytest.raises(ValueError):
         Calculator(records=rec)
 
 
 def test_calculator_mtr(cps_subsample):
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     calcx = Calculator(policy=Policy(), records=rec)
     calcx.calc_all()
     combinedx = calcx.array('combined')
@@ -234,7 +234,7 @@ def test_make_calculator_increment_years_first(cps_subsample):
     reform[2016]['_II_em_cpi'] = False
     pol.implement_reform(reform)
     # create Calculator object with Policy object as modified by reform
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     calc = Calculator(policy=pol, records=rec)
     # compare expected policy parameter values with those embedded in calc
     irates = pol.inflation_rates()
@@ -259,7 +259,7 @@ def test_ID_HC_vs_BS(cps_subsample):
     Test that complete haircut of itemized deductions produces same
     results as a 100% benefit surtax with no benefit deduction.
     """
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     # specify complete-haircut reform policy and Calculator object
     hc_reform = {2013: {'_ID_Medical_hc': [1.0],
                         '_ID_StateLocalTax_hc': [1.0],
@@ -292,7 +292,7 @@ def test_ID_StateLocal_HC_vs_CRT(cps_subsample):
     of AGI is equivalent to a complete haircut on the same state/local tax
     deductions.
     """
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     # specify state/local complete haircut reform policy and Calculator object
     hc_reform = {2013: {'_ID_StateLocalTax_hc': [1.0]}}
     hc_policy = Policy()
@@ -318,7 +318,7 @@ def test_ID_RealEstate_HC_vs_CRT(cps_subsample):
     at 0 percent of AGI is equivalent to a complete haircut on the same real
     estate tax deductions.
     """
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     # specify real estate complete haircut reform policy and Calculator object
     hc_reform = {2013: {'_ID_RealEstate_hc': [1.0]}}
     hc_policy = Policy()
@@ -921,15 +921,15 @@ def test_difference_table(cps_subsample):
 
 
 def test_diagnostic_table(cps_subsample):
-    recs = Records.cps_constructor(data=cps_subsample)
+    recs = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     calc = Calculator(policy=Policy(), records=recs)
     adt = calc.diagnostic_table(3)
     assert isinstance(adt, pd.DataFrame)
 
 
 def test_mtr_graph(cps_subsample):
-    calc = Calculator(policy=Policy(),
-                      records=Records.cps_constructor(data=cps_subsample))
+    recs = Records.cps_constructor(data=cps_subsample, no_benefits=True)
+    calc = Calculator(policy=Policy(), records=recs)
     fig = calc.mtr_graph(calc,
                          mars=2,
                          income_measure='wages',
@@ -942,8 +942,8 @@ def test_mtr_graph(cps_subsample):
 
 
 def test_atr_graph(cps_subsample):
-    calc = Calculator(policy=Policy(),
-                      records=Records.cps_constructor(data=cps_subsample))
+    recs = Records.cps_constructor(data=cps_subsample, no_benefits=True)
+    calc = Calculator(policy=Policy(), records=recs)
     fig = calc.atr_graph(calc, mars=2, atr_measure='itax')
     assert fig
     fig = calc.atr_graph(calc, atr_measure='ptax')
@@ -951,8 +951,8 @@ def test_atr_graph(cps_subsample):
 
 
 def test_privacy_of_embedded_objects(cps_subsample):
-    calc = Calculator(policy=Policy(),
-                      records=Records.cps_constructor(data=cps_subsample))
+    recs = Records.cps_constructor(data=cps_subsample, no_benefits=True)
+    calc = Calculator(policy=Policy(), records=recs)
     with pytest.raises(AttributeError):
         cyr = calc.__policy.current_year
     with pytest.raises(AttributeError):

--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -205,7 +205,8 @@ def fixture_tc_objs(request, reform_xx, puf_subsample, cps_subsample):
     if puftest:
         rec_xx = Records(data=puf_subsample)
     else:
-        rec_xx = Records.cps_constructor(data=cps_subsample)
+        rec_xx = Records.cps_constructor(data=cps_subsample,
+                                         no_benefits=True)
     c_xx = Calculator(policy=p_xx, records=rec_xx, verbose=False)
     c_xx.advance_to_year(TEST_YEAR)
     c_xx.calc_all()
@@ -272,7 +273,8 @@ def test_compatible_data(cps_subsample, puf_subsample,
         if puftest:
             rec_yy = Records(data=puf_subsample)
         else:
-            rec_yy = Records.cps_constructor(data=cps_subsample)
+            rec_yy = Records.cps_constructor(data=cps_subsample,
+                                             no_benefits=True)
         p_yy = Policy()
         p_yy.implement_reform(max_reform, raise_errors=False)
         c_yy = Calculator(policy=p_yy, records=rec_yy, verbose=False)

--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -99,7 +99,7 @@ def test_consumption_response(cps_subsample):
     with pytest.raises(ValueError):
         consump.response(list(), 1)
     # test correct call to response method
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     pre = copy.deepcopy(rec.e20400)
     consump.response(rec, 1.0)
     post = rec.e20400
@@ -107,7 +107,7 @@ def test_consumption_response(cps_subsample):
     expected_diff = np.ones(rec.array_length) * mpc
     assert np.allclose(actual_diff, expected_diff)
     # compute earnings mtr with no consumption response
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     ided0 = copy.deepcopy(rec.e20400)
     calc0 = Calculator(policy=Policy(), records=rec, consumption=None)
     (mtr0_ptax, mtr0_itax, _) = calc0.mtr(variable_str='e00200p',

--- a/taxcalc/tests/test_macro_elasticity.py
+++ b/taxcalc/tests/test_macro_elasticity.py
@@ -14,7 +14,7 @@ def test_proportional_change_in_gdp(cps_subsample):
     """
     Test correct and incorrect calls to proportional_change_in_gdp function.
     """
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     pol = Policy()
     calc1 = Calculator(policy=pol, records=rec)
     reform = {2015: {'_II_em': [0.0]}}  # reform increases taxes and MTRs

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -683,8 +683,8 @@ def test_diff_table_sum_row(cps_subsample):
 
 
 def test_mtr_graph_data(cps_subsample):
-    calc = Calculator(policy=Policy(),
-                      records=Records.cps_constructor(data=cps_subsample))
+    recs = Records.cps_constructor(data=cps_subsample, no_benefits=True)
+    calc = Calculator(policy=Policy(), records=recs)
     year = calc.current_year,
     with pytest.raises(ValueError):
         mtr_graph_data(None, year, mars='bad',
@@ -716,7 +716,7 @@ def test_mtr_graph_data(cps_subsample):
 
 def test_atr_graph_data(cps_subsample):
     pol = Policy()
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     calc = Calculator(policy=pol, records=rec)
     year = calc.current_year
     with pytest.raises(ValueError):
@@ -739,9 +739,8 @@ def test_atr_graph_data(cps_subsample):
 
 
 def test_xtr_graph_plot(cps_subsample):
-    calc = Calculator(policy=Policy(),
-                      records=Records.cps_constructor(data=cps_subsample),
-                      behavior=Behavior())
+    recs = Records.cps_constructor(data=cps_subsample, no_benefits=True)
+    calc = Calculator(policy=Policy(), records=recs, behavior=Behavior())
     mtr = 0.20 * np.ones_like(cps_subsample['e00200'])
     vdf = calc.dataframe(['s006', 'MARS', 'c00100'])
     vdf['mtr1'] = mtr
@@ -767,8 +766,8 @@ def temporary_filename(suffix=''):
 
 
 def test_write_graph_file(cps_subsample):
-    calc = Calculator(policy=Policy(),
-                      records=Records.cps_constructor(data=cps_subsample))
+    recs = Records.cps_constructor(data=cps_subsample, no_benefits=True)
+    calc = Calculator(policy=Policy(), records=recs)
     mtr = 0.20 * np.ones_like(cps_subsample['e00200'])
     vdf = calc.dataframe(['s006', 'e00200', 'c00100'])
     vdf['mtr1'] = mtr
@@ -808,7 +807,7 @@ def test_ce_aftertax_income(cps_subsample):
     cmin = 1000
     assert con == round(certainty_equivalent(con, 0, cmin), 6)
     # test with require_no_agg_tax_change equal to False
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     cyr = 2020
     # specify calc1 and calc_all() for cyr
     pol = Policy()
@@ -883,7 +882,7 @@ def test_table_columns_labels():
 
 def test_dec_graph_plots(cps_subsample):
     pol = Policy()
-    rec = Records.cps_constructor(data=cps_subsample)
+    rec = Records.cps_constructor(data=cps_subsample, no_benefits=True)
     calc1 = Calculator(policy=pol, records=rec)
     year = 2020
     calc1.advance_to_year(year)


### PR DESCRIPTION
The new argument provides Tax-Calculator users with the option of not including benefits information in the Records object.  The default when calling `recs_large = Records.cps_constructor()` is to include benefits in the `recs_large` object.  But if there is no need for benefits information, consider doing this `recs_small = Records.cps_constructor(no_benefits=True)` to not include benefits information in the `recs_small` object.  The size difference in the two Records objects is considerable:
```
recs_small    482.5 MegaBytes
recs_large   3487.4 MegaBytes
```