### PR TITLE
Extend no_benefits logic originally implemented in PR#1985

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -119,7 +119,7 @@ class Records(object):
         # pylint: disable=too-many-arguments,too-many-locals
         self.__data_year = start_year
         # read specified data
-        self._read_data(data, exact_calculations)
+        self._read_data(data, exact_calculations, (benefits is None))
         # check that three sets of split-earnings variables have valid values
         msg = 'expression "{0} == {0}p + {0}s" is not true for every record'
         tol = 0.020001  # handles "%.2f" rounding errors
@@ -430,12 +430,13 @@ class Records(object):
         setattr(self, 'mcaid_ben', self.BEN['mcaid_{}'.format(year)])
         self.other_ben *= self.gfactors.factor_value('ABENEFITS', year)
 
-    def _read_data(self, data, exact_calcs):
+    def _read_data(self, data, exact_calcs, no_benefits):
         """
         Read Records data from file or use specified DataFrame as data.
         Specifies exact array depending on boolean value of exact_calcs.
+        Set benefits to zero if no_benefits is True; otherwise do nothing.
         """
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-statements,too-many-branches
         if Records.INTEGER_VARS is None:
             Records.read_var_info()
         # read specified data
@@ -495,6 +496,21 @@ class Records(object):
             raise ValueError('not all EIC values in [0,3] range')
         # specify value of exact array
         self.exact[:] = np.where(exact_calcs is True, 1, 0)
+        # optionally set benefits to zero
+        if no_benefits:
+            self.housing_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+            self.ssi_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+            self.snap_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+            self.tanf_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+            self.vet_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+            self.wic_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+            self.mcare_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+            self.mcaid_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+            self.other_ben[:] = np.zeros(self.array_length, dtype=np.float64)
+        # delete intermediate variables
+        del READ_VARS
+        del UNREAD_VARS
+        del ZEROED_VARS
 
     def zero_out_changing_calculated_vars(self):
         """

--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -204,8 +204,7 @@ def fixture_tc_objs(request, reform_xx, puf_subsample, cps_subsample):
     if puftest:
         rec_xx = Records(data=puf_subsample)
     else:
-        rec_xx = Records.cps_constructor(data=cps_subsample,
-                                         no_benefits=True)
+        rec_xx = Records.cps_constructor(data=cps_subsample)
     c_xx = Calculator(policy=p_xx, records=rec_xx, verbose=False)
     c_xx.advance_to_year(TEST_YEAR)
     c_xx.calc_all()
@@ -236,7 +235,7 @@ def test_compatible_data(cps_subsample, puf_subsample,
     exempt_from_testing = ['_CG_ec', '_CG_reinvest_ec_rt']
 
     # Loop through the parameters in allparams_batch
-    errmsg = 'ERROR: {} not {} for {}\n'
+    errmsg = 'ERROR: {} {}\n'
     errors = ''
     for pname in allparams_batch:
         param = allparams_batch[pname]
@@ -272,8 +271,7 @@ def test_compatible_data(cps_subsample, puf_subsample,
         if puftest:
             rec_yy = Records(data=puf_subsample)
         else:
-            rec_yy = Records.cps_constructor(data=cps_subsample,
-                                             no_benefits=True)
+            rec_yy = Records.cps_constructor(data=cps_subsample)
         p_yy = Policy()
         p_yy.implement_reform(max_reform, raise_errors=False)
         c_yy = Calculator(policy=p_yy, records=rec_yy, verbose=False)
@@ -309,18 +307,18 @@ def test_compatible_data(cps_subsample, puf_subsample,
                 )
             if min_reform_change == 0 and pname not in exempt_from_testing:
                 if puftest:
-                    if param['compatible_data']['puf'] is not False:
-                        errors += errmsg.format(pname, 'False', 'puf')
+                    if param['compatible_data']['puf'] is True:
+                        errors += errmsg.format(pname, 'is not True for puf')
                 else:
-                    if param['compatible_data']['cps'] is not False:
-                        errors += errmsg.format(pname, 'False', 'cps')
+                    if param['compatible_data']['cps'] is True:
+                        errors += errmsg.format(pname, 'is not True for cps')
         if max_reform_change != 0 or min_reform_change != 0:
             if puftest:
-                if param['compatible_data']['puf'] is not True:
-                    errors += errmsg.format(pname, 'True', 'puf')
+                if param['compatible_data']['puf'] is False:
+                    errors += errmsg.format(pname, 'is not False for puf')
             else:
-                if param['compatible_data']['cps'] is not True:
-                    errors += errmsg.format(pname, 'True', 'cps')
+                if param['compatible_data']['cps'] is False:
+                    errors += errmsg.format(pname, 'is not False for cps')
     # test failure if any errors
     if errors:
         print(errors)


### PR DESCRIPTION
Pull request #1985 added an optional `no_benefits` argument to the `Records.cps_constructor`.  When setting `no_benefits=True` one would expect all the benefit variables to have zero values.  That expectation is now realized with the changes in this pull request.