### PR TITLE
Add cookbook recipe that uses Behavior.response

### DIFF
--- a/docs/cookbook/ingredients/assumpA.json
+++ b/docs/cookbook/ingredients/assumpA.json
@@ -1,0 +1,15 @@
+// NEVER SPECIFY BOTH behavior AND growdiff_response IN SAME RUN
+{
+    "consumption": {
+    },
+    "behavior": {
+	// specify non-zero substitution elasticity of taxable income,
+        // which is response of taxable income to change in marginal tax rate
+	"_BE_sub": {"2013": [0.25]}
+    },
+    "growdiff_baseline": {
+    },
+    "growdiff_response": {
+        // MUST BE EMPTY BECAUSE ASSUMING BEHAVIORAL RESPONSE
+    }
+}

--- a/docs/cookbook/recipe00.py
+++ b/docs/cookbook/recipe00.py
@@ -55,7 +55,7 @@ clp_diagnostic_table = calc1.diagnostic_table(1)
 ref_diagnostic_table = calc2.diagnostic_table(1)
 
 # income-tax distribution for cyr with CLP and REF results side-by-side
-dist_table1, dist_table2 = calc1.distribution_tables(calc2)
+dist_table1, dist_table2 = calc1.distribution_tables(calc2, 'weighted_deciles')
 assert isinstance(dist_table1, pd.DataFrame)
 assert isinstance(dist_table2, pd.DataFrame)
 dist_extract = pd.DataFrame()
@@ -66,7 +66,7 @@ dist_extract['aftertax_inc1($b)'] = dist_table1['aftertax_income'] * 1e-9
 dist_extract['aftertax_inc2($b)'] = dist_table2['aftertax_income'] * 1e-9
 
 # income-tax difference table by expanded-income decile for cyr
-diff_table = calc1.difference_table(calc2, tax_to_diff='iitax')
+diff_table = calc1.difference_table(calc2, 'weighted_deciles', 'iitax')
 assert isinstance(diff_table, pd.DataFrame)
 diff_extract = pd.DataFrame()
 dif_colnames = ['count', 'tot_change', 'mean',

--- a/docs/cookbook/recipe01.py
+++ b/docs/cookbook/recipe01.py
@@ -46,7 +46,7 @@ iitax_rev1 = calc1.weighted_total('iitax')
 iitax_rev2 = calc2.weighted_total('iitax')
 
 # construct reform2-vs-reform1 difference table with results for income deciles
-diff_table = calc1.difference_table(calc2, tax_to_diff='iitax')
+diff_table = calc1.difference_table(calc2, 'weighted_deciles', 'iitax')
 assert isinstance(diff_table, pd.DataFrame)
 diff_extract = pd.DataFrame()
 dif_colnames = ['count', 'tax_cut', 'tax_inc',

--- a/docs/cookbook/recipe02.py
+++ b/docs/cookbook/recipe02.py
@@ -1,0 +1,51 @@
+from __future__ import print_function  # necessary only if using Python 2.7
+from taxcalc import *
+
+# use publicly-available CPS input file
+recs = Records.cps_constructor()
+
+# specify Calculator object representing current-law policy
+pol = Policy()
+calc1 = Calculator(policy=pol, records=recs)
+
+cyr = 2020
+
+# calculate aggregate current-law income tax liabilities for cyr
+calc1.advance_to_year(cyr)
+calc1.calc_all()
+itax_rev1 = calc1.weighted_total('iitax')
+
+# read JSON reform file and use (the default) static analysis assumptions
+reform_filename = './ingredients/reformA.json'
+params = Calculator.read_json_param_objects(reform=reform_filename,
+                                            assump=None)
+
+# specify Calculator object for static analysis of reform policy
+pol.implement_reform(params['policy'])
+calc2 = Calculator(policy=pol, records=recs)
+
+# calculate reform income tax liabilities for cyr under static assumptions
+calc2.advance_to_year(cyr)
+calc2.calc_all()
+itax_rev2 = calc2.weighted_total('iitax')
+
+# read JSON reform file and (dynamic) behavioral-analysis assumptions
+assump_filename = './ingredients/assumpA.json'
+params = Calculator.read_json_param_objects(reform=reform_filename,
+                                            assump=assump_filename)
+behv = Behavior()
+behv.update_behavior(params['behavior'])
+
+# specify Calculator object for behavioral-response analysis of reform policy
+calc3 = Calculator(policy=pol, records=recs, behavior=behv)
+
+# calculate reform income tax liabilities for cyr under dynamic assumptions
+calc3.advance_to_year(cyr)
+calc3br = Behavior.response(calc1, calc3)
+itax_rev3 = calc3br.weighted_total('iitax')
+
+# print total revenue estimates for cyr
+# (estimates in billons of dollars rounded to nearest hundredth of a billion)
+print('{}_CURRENT_LAW_P__itax_rev($B)= {:.2f}'.format(cyr, itax_rev1 * 1e-9))
+print('{}_REFORM_STATIC__itax_rev($B)= {:.2f}'.format(cyr, itax_rev2 * 1e-9))
+print('{}_REFORM_DYNAMIC_itax_rev($B)= {:.2f}'.format(cyr, itax_rev3 * 1e-9))

--- a/docs/cookbook/recipe02.res
+++ b/docs/cookbook/recipe02.res
@@ -1,0 +1,21 @@
+You loaded data for 2014.
+Tax-Calculator startup automatically extrapolated your data to 2014.
+WARNING: Tax-Calculator packages for Python 2.7 will
+         no longer be provided beginning in 2019
+         because Pandas is stopping development for 2.7
+SOLUTION: upgrade to Python 3.6 now
+You loaded data for 2014.
+Tax-Calculator startup automatically extrapolated your data to 2014.
+WARNING: Tax-Calculator packages for Python 2.7 will
+         no longer be provided beginning in 2019
+         because Pandas is stopping development for 2.7
+SOLUTION: upgrade to Python 3.6 now
+You loaded data for 2014.
+Tax-Calculator startup automatically extrapolated your data to 2014.
+WARNING: Tax-Calculator packages for Python 2.7 will
+         no longer be provided beginning in 2019
+         because Pandas is stopping development for 2.7
+SOLUTION: upgrade to Python 3.6 now
+2020_CURRENT_LAW_P__itax_rev($B)= 1278.60
+2020_REFORM_STATIC__itax_rev($B)= 1269.52
+2020_REFORM_DYNAMIC_itax_rev($B)= 1261.18

--- a/docs/index.htmx
+++ b/docs/index.htmx
@@ -1205,7 +1205,8 @@ output variables that Tax-Calculator is programmed to calculate.</p>
 
 <p>This section contains documentation of several sets of parameters
 that characterize responses to a tax reform.  Consumption
-parameters are used to compute marginal tax rates.  Behavior
+parameters are used to compute marginal tax rates and to compute the
+consumption value of in-kind benefits.  Behavior
 parameters are used to compute changes in input variables caused by a
 tax reform in a partial-equilibrium setting.  Growdiff parameters are
 used to specify baseline differences and/or reform responses in the
@@ -1216,11 +1217,19 @@ those with a <i>TB Name</i> appear in the TaxBrain GUI.  All these
 dynamic response parameters control advanced features of
 Tax-Calculator, so understanding the
 <a href="https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc">source
-code</a> that uses them is essential.  Each default parameter value is
-zero and is projected into the future at that value, which implies no
+code</a> that uses them is essential.  Default response parameter values are
+zero and are projected into the future at that value, which implies no
 response to the reform.  Using the default no-reform-response
 assumption for all the response parameters generates a static analysis
-of the tax reform.</p>
+of the tax reform.  The benefit value consumption parameters have a
+default value of one, which implies the consumption value of the
+in-kind benefits is equal to the government cost of providing the
+benefits.</p>
+
+<p>Note that some of the response parameters are incompatible with
+each other, and therefore, cannot be used together.  The behavior
+parameters can not have non-zero values with specifying non-zero
+growdiff response parameters.</p>
 
 
 <h3>Section Contents</h3>

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -202,7 +202,7 @@ class Behavior(ParametersBase):
         return False
 
     @staticmethod
-    def response(calc1, calc2, mtr_cap=0.99, trace=False):
+    def response(calc1, calc2, trace=False):
         """
         Implements TaxBrain "Partial Equilibrium Simulation" dynamic analysis.
 
@@ -262,9 +262,7 @@ class Behavior(ParametersBase):
         # begin main logic of response
         assert calc1.array_len == calc2.array_len
         assert calc1.current_year == calc2.current_year
-        assert mtr_cap >= 0.95 and mtr_cap < 1.0
-        if trace:
-            print('*** TRACE *** mtr_cap={}'.format(mtr_cap))
+        mtr_cap = 0.99
         # calculate sum of substitution and income effects
         if calc2.behavior('BE_sub') == 0.0 and calc2.behavior('BE_inc') == 0.0:
             zero_sub_and_inc = True

--- a/taxcalc/responses/economic_responses_template.json
+++ b/taxcalc/responses/economic_responses_template.json
@@ -1,50 +1,23 @@
-//Parameters for economic responses to tax policy
-//This json serves as a baseline for the implementation of the economic responses of individuals and the overall economy to tax reforms.
-//User documentation can be found at http://open-source-economics.github.io/Tax-Calculator/#params
-//More specific definitions and details on implementations can be found in *.json and *.py files.
-//  consumption
-//    Description: The marginal propensity to consume tax-deductible goods.
-//    Source file: consumption.json
-//    Implemented in Consumption.response()
-//    Applies to:
-//      - e17500, Sch A: Medical and dental expenses
-//      - e18400, Sch A: State and local income/sales taxes
-//      - e19800, Sch A: Gifts to charity: cash/check contributions
-//      - e20400, Sch A: Miscellaneous deductions subject to 2% AGI limitation
-//  behavior
-//    Description: The behavioral response to tax rates. Used in partial equilibrium dynamic analysis.
-//    Source file: behavior.json
-//    Implemented in Behavior.response()
-//    Applies to:
-//      - _BE_inc, Income elasticity of taxable income (response of taxable income to changes in after-tax income)
-//      - _BE_sub, Substitution elasticity of taxable income (response of taxable income to changes in marginal tax rates)
-//      - _BE_cg, Elasticity of long-term capital gains (response of long-term gains to changes in marginal tax rates on capital gains)
-//      - _BE_charity, Elasticity of charitable contributions (response by AGI level to the marginal subsidy on charitable giving)
-//  growdiff
-//    Description: Additive difference from growth rate projection to each parameter type.
-//        Can be applied to both baseline and reform (growdiff_baseline) or just to the reform (growdiff_reform)
-//    Source file: growdiff.json
-//    Implemented in Growdiff.apply_to()
-//    Applies to:
-//      - ABOOK, foreign tax credit and general business credit
-//      - ACGNS, capital gains and losses
-//      - ACPIM, medical expenses and contributions
-//      - ACPIU, consumer price index
-//      - ADIVS, dividends
-//      - AINTS, interest income
-//      - AIPD, interest paid
-//      - ASCHCI, profit from sole proprietorship
-//      - ASCHCL, loss from sole proprietorship
-//      - ASCHEI, Sch. E profit
-//      - ASCHEL, Sch. E loss
-//      - ASCHF, farm net income/loss
-//      - ASOCSEC, Social Security benefits
-//      - ATXPY, all miscellaneous categories
-//      - AUCOMP, Unemployment compensation
-//      - AWAGE, wage and salary income
-
+// Parameters used to specify economic responses to tax policy.
+//
+// This JSON file serves as a template for implementating the economic
+// responses of individuals and of the overall economy to a tax reform.
+//
+// Detailed documentation on these parameters can be found at
+// <http://open-source-economics.github.io/Tax-Calculator/#params>.
+//
+// NOTE that behavior responses are incompatible with growdiff_response,
+// and therefore, both should never be specified in the same run.
 {
     "consumption": {
+        "_BEN_housing_value": {"2017": [1.0]},
+        "_BEN_snap_value": {"2017": [1.0]},
+        "_BEN_tanf_value": {"2017": [1.0]},
+        "_BEN_vet_value": {"2017": [1.0]},
+        "_BEN_wic_value": {"2017": [1.0]},
+        "_BEN_mcare_value": {"2017": [1.0]},
+        "_BEN_mcaid_value": {"2017": [1.0]},
+        "_BEN_other_value": {"2017": [1.0]},
         "_MPC_e17500": {"2017": [0.0]},
         "_MPC_e18400": {"2017": [0.0]},
         "_MPC_e19800": {"2017": [0.0]},


### PR DESCRIPTION
This pull request adds a recipe to the [Tax-Calculator Cookbook](http://open-source-economics.github.io/Tax-Calculator/cookbook.html) that illustrates how to use the Behavior class and its static `response` method .