### PR TITLE
Rename classes as GrowFactors and GrowDiff

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -21,10 +21,6 @@ class Behavior(ParametersBase):
 
     Parameters
     ----------
-    behavior_dict: dictionary of PARAM:DESCRIPTION pairs
-        dictionary of behavioral-response elasticities; if None, default
-        elasticities are read from the behavior.json file.
-
     start_year: integer
         first calendar year for behavioral-response elasticities.
 
@@ -35,7 +31,7 @@ class Behavior(ParametersBase):
     Raises
     ------
     ValueError:
-        if behavior_dict is neither None nor a dictionary.
+        if start_year is less than Policy.JSON_START_YEAR
         if num_years is less than one.
 
     Returns
@@ -52,8 +48,10 @@ class Behavior(ParametersBase):
                  num_years=DEFAULT_NUM_YEARS):
         super(Behavior, self).__init__()
         self._vals = self._params_dict_from_json_file()
+        if start_year < Policy.JSON_START_YEAR:
+            raise ValueError('start_year < Policy.JSON_START_YEAR')
         if num_years < 1:
-            raise ValueError('num_years < 1 in Behavior ctor')
+            raise ValueError('num_years < 1')
         self.initialize(start_year, num_years)
         self.parameter_errors = ''
 

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -32,8 +32,8 @@ from taxcalc.policy import Policy
 from taxcalc.records import Records
 from taxcalc.consumption import Consumption
 from taxcalc.behavior import Behavior
-from taxcalc.growdiff import Growdiff
-from taxcalc.growfactors import Growfactors
+from taxcalc.growdiff import GrowDiff
+from taxcalc.growfactors import GrowFactors
 from taxcalc.utils import (DIST_VARIABLES, create_distribution_table,
                            DIFF_VARIABLES, create_difference_table,
                            create_diagnostic_table,
@@ -1326,10 +1326,10 @@ class Calculator(object):
         # begin main logic of reform_documentation
         # create Policy object with pre-reform (i.e., baseline) values
         # ... create gdiff_baseline object
-        gdb = Growdiff()
+        gdb = GrowDiff()
         gdb.update_growdiff(params['growdiff_baseline'])
         # ... create Growfactors clp object that incorporates gdiff_baseline
-        gfactors_clp = Growfactors()
+        gfactors_clp = GrowFactors()
         gdb.apply_to(gfactors_clp)
         # ... create Policy object containing pre-reform parameter values
         clp = Policy(gfactors=gfactors_clp)

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -19,11 +19,6 @@ class Consumption(ParametersBase):
 
     Parameters
     ----------
-    consumption_dict: dictionary of PARAM:DESCRIPTION pairs
-        dictionary of marginal propensity to consume (MPC) parameters and
-        benefit (BEN) value-of-in-kind-benefit parameters;
-        if None, all parameters are read from DEFAULTS_FILENAME file.
-
     start_year: integer
         first calendar year for consumption parameters.
 
@@ -34,7 +29,7 @@ class Consumption(ParametersBase):
     Raises
     ------
     ValueError:
-        if consumption_dict is neither None nor a dictionary.
+        if start_year is less than Policy.JSON_START_YEAR.
         if num_years is less than one.
 
     Returns
@@ -46,18 +41,15 @@ class Consumption(ParametersBase):
     DEFAULTS_FILENAME = 'consumption.json'
     DEFAULT_NUM_YEARS = Policy.DEFAULT_NUM_YEARS
 
-    def __init__(self, consumption_dict=None,
+    def __init__(self,
                  start_year=JSON_START_YEAR,
                  num_years=DEFAULT_NUM_YEARS):
         super(Consumption, self).__init__()
-        if consumption_dict is None:
-            self._vals = self._params_dict_from_json_file()
-        elif isinstance(consumption_dict, dict):
-            self._vals = consumption_dict
-        else:
-            raise ValueError('consumption_dict is not None or a dictionary')
+        self._vals = self._params_dict_from_json_file()
+        if start_year < Policy.JSON_START_YEAR:
+            raise ValueError('start_year < Policy.JSON_START_YEAR')
         if num_years < 1:
-            raise ValueError('num_years < 1 in Consumption ctor')
+            raise ValueError('num_years < 1')
         self.initialize(start_year, num_years)
         self.parameter_errors = ''
 

--- a/taxcalc/growdiff.py
+++ b/taxcalc/growdiff.py
@@ -1,5 +1,5 @@
 """
-Tax-Calculator Growdiff class.
+Tax-Calculator GrowDiff class.
 """
 # CODING-STYLE CHECKS:
 # pycodestyle growdiff.py
@@ -9,19 +9,15 @@ import numpy as np
 from taxcalc.parameters import ParametersBase
 
 
-class Growdiff(ParametersBase):
+class GrowDiff(ParametersBase):
     """
-    Growdiff is a subclass of the abstract ParametersBase class, and
+    GrowDiff is a subclass of the abstract ParametersBase class, and
     therefore, inherits its methods (none of which are shown here).
 
     Constructor for growth difference class.
 
     Parameters
     ----------
-    growdiff_dict: dictionary of PARAM:DESCRIPTION pairs
-        dictionary of growth difference parameters; if None, default
-        parameters are read from the growdiff.json file.
-
     start_year: integer
         first calendar year for growth difference parameters.
 
@@ -32,30 +28,27 @@ class Growdiff(ParametersBase):
     Raises
     ------
     ValueError:
-        if growdiff_dict is neither None nor a dictionary.
+        if start_year is less than 2013
         if num_years is less than one.
 
     Returns
     -------
-    class instance: Growdiff
+    class instance: GrowDiff
     """
 
     JSON_START_YEAR = 2013  # must be same as Policy.JSON_START_YEAR
     DEFAULTS_FILENAME = 'growdiff.json'
     DEFAULT_NUM_YEARS = 15  # must be same as Policy.DEFAULT_NUM_YEARS
 
-    def __init__(self, growdiff_dict=None,
+    def __init__(self,
                  start_year=JSON_START_YEAR,
                  num_years=DEFAULT_NUM_YEARS):
-        super(Growdiff, self).__init__()
-        if growdiff_dict is None:
-            self._vals = self._params_dict_from_json_file()
-        elif isinstance(growdiff_dict, dict):
-            self._vals = growdiff_dict
-        else:
-            raise ValueError('growdiff_dict is neither None nor a dictionary')
+        super(GrowDiff, self).__init__()
+        self._vals = self._params_dict_from_json_file()
+        if start_year < GrowDiff.JSON_START_YEAR:
+            raise ValueError('start_year < GrowDiff.JSON_START_YEAR')
         if num_years < 1:
-            raise ValueError('num_years < 1 in Growdiff ctor')
+            raise ValueError('num_years < 1')
         self.initialize(start_year, num_years)
         self.parameter_errors = ''
 
@@ -122,7 +115,7 @@ class Growdiff(ParametersBase):
         """
         # pylint: disable=no-member
         for i in range(0, self.num_years):
-            cyr = i + Growdiff.JSON_START_YEAR
+            cyr = i + self.start_year
             growfactors.update('ABOOK', cyr, self._ABOOK[i])
             growfactors.update('ACGNS', cyr, self._ACGNS[i])
             growfactors.update('ACPIM', cyr, self._ACPIM[i])

--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -1,5 +1,5 @@
 """
-Tax-Calculator Growfactors class.
+Tax-Calculator GrowFactors class.
 """
 # CODING-STYLE CHECKS:
 # pycodestyle growfactors.py
@@ -12,9 +12,9 @@ import pandas as pd
 from taxcalc.utils import read_egg_csv
 
 
-class Growfactors(object):
+class GrowFactors(object):
     """
-    Constructor for the Growfactors class.
+    Constructor for the GrowFactors class.
 
     Parameters
     ----------
@@ -29,12 +29,12 @@ class Growfactors(object):
 
     Returns
     -------
-    class instance: Growfactors
+    class instance: GrowFactors
 
     Notes
     -----
-    Typical usage is "gfactor = Growfactors()", which produces an object
-    containing the default grow factors in the Growfactors.FILENAME file.
+    Typical usage is "gfactor = GrowFactors()", which produces an object
+    containing the default grow factors in the GrowFactors.FILENAME file.
     """
 
     CUR_PATH = os.path.abspath(os.path.dirname(__file__))
@@ -56,17 +56,17 @@ class Growfactors(object):
                                    index_col='YEAR')
             else:
                 # cannot call read_egg_ function in unit tests
-                gfdf = read_egg_csv(Growfactors.FILENAME,
+                gfdf = read_egg_csv(GrowFactors.FILENAME,
                                     index_col='YEAR')  # pragma: no cover
         else:
             raise ValueError('growfactors_filename is not a string')
         assert isinstance(gfdf, pd.DataFrame)
         # check validity of gfdf column names
         gfdf_names = set(list(gfdf))
-        if gfdf_names != Growfactors.VALID_NAMES:
+        if gfdf_names != GrowFactors.VALID_NAMES:
             msg = ('missing names are: {} and invalid names are: {}')
-            missing = Growfactors.VALID_NAMES - gfdf_names
-            invalid = gfdf_names - Growfactors.VALID_NAMES
+            missing = GrowFactors.VALID_NAMES - gfdf_names
+            invalid = gfdf_names - GrowFactors.VALID_NAMES
             raise ValueError(msg.format(missing, invalid))
         # determine first_year and last_year from gfdf
         self._first_year = min(gfdf.index)
@@ -82,14 +82,14 @@ class Growfactors(object):
     @property
     def first_year(self):
         """
-        Growfactors class start_year property.
+        GrowFactors class start_year property.
         """
         return self._first_year
 
     @property
     def last_year(self):
         """
-        Growfactors class last_year property.
+        GrowFactors class last_year property.
         """
         return self._last_year
 
@@ -102,10 +102,10 @@ class Growfactors(object):
             msg = 'first_year={} > last_year={}'
             raise ValueError(msg.format(firstyear, lastyear))
         if firstyear < self.first_year:
-            msg = 'firstyear={} < Growfactors.first_year={}'
+            msg = 'firstyear={} < GrowFactors.first_year={}'
             raise ValueError(msg.format(firstyear, self.first_year))
         if lastyear > self.last_year:
-            msg = 'last_year={} > Growfactors.last_year={}'
+            msg = 'last_year={} > GrowFactors.last_year={}'
             raise ValueError(msg.format(lastyear, self.last_year))
         # pylint: disable=no-member
         rates = [round((self.gfdf['ACPIU'][cyr] - 1.0), 4)
@@ -121,10 +121,10 @@ class Growfactors(object):
             msg = 'firstyear={} > lastyear={}'
             raise ValueError(msg.format(firstyear, lastyear))
         if firstyear < self.first_year:
-            msg = 'firstyear={} < Growfactors.first_year={}'
+            msg = 'firstyear={} < GrowFactors.first_year={}'
             raise ValueError(msg.format(firstyear, self.first_year))
         if lastyear > self.last_year:
-            msg = 'lastyear={} > Growfactors.last_year={}'
+            msg = 'lastyear={} > GrowFactors.last_year={}'
             raise ValueError(msg.format(lastyear, self.last_year))
         # pylint: disable=no-member
         rates = [round((self.gfdf['AWAGE'][cyr] - 1.0), 4)
@@ -136,14 +136,14 @@ class Growfactors(object):
         Return value of factor with specified name for specified year.
         """
         self.used = True
-        if name not in Growfactors.VALID_NAMES:
-            msg = 'name={} not in Growfactors.VALID_NAMES'
+        if name not in GrowFactors.VALID_NAMES:
+            msg = 'name={} not in GrowFactors.VALID_NAMES'
             raise ValueError(msg.format(year, name))
         if year < self.first_year:
-            msg = 'year={} < Growfactors.first_year={}'
+            msg = 'year={} < GrowFactors.first_year={}'
             raise ValueError(msg.format(year, self.first_year))
         if year > self.last_year:
-            msg = 'year={} > Growfactors.last_year={}'
+            msg = 'year={} > GrowFactors.last_year={}'
             raise ValueError(msg.format(year, self.last_year))
         return self.gfdf[name][year]
 

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -9,8 +9,8 @@ from __future__ import print_function
 import six
 import numpy as np
 from taxcalc.parameters import ParametersBase
-from taxcalc.growfactors import Growfactors
-from taxcalc.growdiff import Growdiff
+from taxcalc.growfactors import GrowFactors
+from taxcalc.growdiff import GrowDiff
 
 
 class Policy(ParametersBase):
@@ -22,12 +22,8 @@ class Policy(ParametersBase):
 
     Parameters
     ----------
-    gfactors: Growfactors class instance
+    gfactors: GrowFactors class instance
         containing price inflation rates and wage growth rates
-
-    parameter_dict: dictionary of PARAM:DESCRIPTION pairs
-        dictionary of policy parameters; if None, default policy
-        parameters are read from the current_law_policy.json file.
 
     start_year: integer
         first calendar year for historical policy parameters.
@@ -39,8 +35,8 @@ class Policy(ParametersBase):
     Raises
     ------
     ValueError:
-        if gfactors is not a Growfactors class instance.
-        if parameter_dict is neither None nor a dictionary.
+        if gfactors is not a GrowFactors class instance.
+        if start_year is less than JSON_START_YEAR.
         if num_years is less than one.
 
     Returns
@@ -61,15 +57,17 @@ class Policy(ParametersBase):
         super(Policy, self).__init__()
 
         if gfactors is None:
-            self._gfactors = Growfactors()
-        elif isinstance(gfactors, Growfactors):
+            self._gfactors = GrowFactors()
+        elif isinstance(gfactors, GrowFactors):
             self._gfactors = gfactors
         else:
-            raise ValueError('gfactors is not None or a Growfactors instance')
+            raise ValueError('gfactors is not None or a GrowFactors instance')
 
         # read default parameters
         self._vals = self._params_dict_from_json_file()
 
+        if start_year < Policy.JSON_START_YEAR:
+            raise ValueError('start_year cannot be less than JSON_START_YEAR')
         if num_years < 1:
             raise ValueError('num_years cannot be less than one')
 
@@ -314,11 +312,11 @@ class Policy(ParametersBase):
             Return param_base:year dictionary having only suffix parameters.
             """
             if bool(growdiff_baseline_dict) or bool(growdiff_response_dict):
-                gdiff_baseline = Growdiff()
+                gdiff_baseline = GrowDiff()
                 gdiff_baseline.update_growdiff(growdiff_baseline_dict)
-                gdiff_response = Growdiff()
+                gdiff_response = GrowDiff()
                 gdiff_response.update_growdiff(growdiff_response_dict)
-                growfactors = Growfactors()
+                growfactors = GrowFactors()
                 gdiff_baseline.apply_to(growfactors)
                 gdiff_response.apply_to(growfactors)
             else:

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -10,7 +10,7 @@ import json
 import six
 import numpy as np
 import pandas as pd
-from taxcalc.growfactors import Growfactors
+from taxcalc.growfactors import GrowFactors
 from taxcalc.utils import read_egg_csv, read_egg_json
 
 
@@ -33,7 +33,7 @@ class Records(object):
         any smoothing of "stair-step" provisions in income tax law;
         default value is false.
 
-    gfactors: Growfactors class instance or None
+    gfactors: GrowFactors class instance or None
         containing record data extrapolation (or "blowup") factors.
         NOTE: the constructor should never call the _blowup() method.
 
@@ -66,7 +66,7 @@ class Records(object):
         if data is not the appropriate type.
         if taxpayer and spouse variables do not add up to filing-unit total.
         if dividends is less than qualified dividends.
-        if gfactors is not None or a Growfactors class instance.
+        if gfactors is not None or a GrowFactors class instance.
         if start_year is not an integer.
         if files cannot be found.
 
@@ -111,7 +111,7 @@ class Records(object):
     def __init__(self,
                  data='puf.csv',
                  exact_calculations=False,
-                 gfactors=Growfactors(),
+                 gfactors=GrowFactors(),
                  weights=PUF_WEIGHTS_FILENAME,
                  adjust_ratios=PUF_RATIOS_FILENAME,
                  benefits=None,
@@ -147,9 +147,9 @@ class Records(object):
             raise ValueError(msg)
         del nontaxable_pensions
         # handle grow factors
-        is_correct_type = isinstance(gfactors, Growfactors)
+        is_correct_type = isinstance(gfactors, GrowFactors)
         if gfactors is not None and not is_correct_type:
-            msg = 'gfactors is neither None nor a Growfactors instance'
+            msg = 'gfactors is neither None nor a GrowFactors instance'
             raise ValueError(msg)
         self.gfactors = gfactors
         # read sample weights
@@ -187,7 +187,7 @@ class Records(object):
     def cps_constructor(data=None,
                         no_benefits=False,
                         exact_calculations=False,
-                        gfactors=Growfactors()):
+                        gfactors=GrowFactors()):
         """
         Static method returns a Records object instantiated with CPS
         input data.  This works in a analogous way to Records(), which

--- a/taxcalc/taxcalcio.py
+++ b/taxcalc/taxcalcio.py
@@ -16,8 +16,8 @@ from taxcalc.policy import Policy
 from taxcalc.records import Records
 from taxcalc.consumption import Consumption
 from taxcalc.behavior import Behavior
-from taxcalc.growdiff import Growdiff
-from taxcalc.growfactors import Growfactors
+from taxcalc.growdiff import GrowDiff
+from taxcalc.growfactors import GrowFactors
 from taxcalc.calculate import Calculator
 from taxcalc.utils import (delete_file, write_graph_file,
                            add_quantile_table_row_variable,
@@ -217,8 +217,8 @@ class TaxCalcIO(object):
         First five are same as the first five of the TaxCalcIO constructor:
             input_data, tax_year, baseline, reform, assump.
 
-        growdiff_response: Growdiff object or None
-            growdiff_response Growdiff object is used only by the
+        growdiff_response: GrowDiff object or None
+            growdiff_response GrowDiff object is used only by the
             TaxCalcIO.growmodel_analysis method;
             must be None in all other cases.
 
@@ -255,21 +255,21 @@ class TaxCalcIO(object):
         beh.update_behavior(paramdict['behavior'])
         self.behavior_has_any_response = beh.has_any_response()
         # create gdiff_baseline object
-        gdiff_baseline = Growdiff()
+        gdiff_baseline = GrowDiff()
         gdiff_baseline.update_growdiff(paramdict['growdiff_baseline'])
-        # create Growfactors base object that incorporates gdiff_baseline
-        gfactors_base = Growfactors()
+        # create GrowFactors base object that incorporates gdiff_baseline
+        gfactors_base = GrowFactors()
         gdiff_baseline.apply_to(gfactors_base)
         # specify gdiff_response object
         if growdiff_response is None:
-            gdiff_response = Growdiff()
+            gdiff_response = GrowDiff()
             gdiff_response.update_growdiff(paramdict['growdiff_response'])
-        elif isinstance(growdiff_response, Growdiff):
+        elif isinstance(growdiff_response, GrowDiff):
             gdiff_response = growdiff_response
         else:
             gdiff_response = None
             msg = 'TaxCalcIO.more_init: growdiff_response is neither None '
-            msg += 'nor a Growdiff object'
+            msg += 'nor a GrowDiff object'
             self.errmsg += 'ERROR: {}\n'.format(msg)
         if gdiff_response is not None:
             some_gdiff_response = gdiff_response.has_any_response()
@@ -277,8 +277,8 @@ class TaxCalcIO(object):
                 msg = 'ASSUMP file cannot specify any "behavior" when using '
                 msg += 'GrowModel or when ASSUMP file has "growdiff_response"'
                 self.errmsg += 'ERROR: {}\n'.format(msg)
-        # create Growfactors ref object that has both gdiff objects applied
-        gfactors_ref = Growfactors()
+        # create GrowFactors ref object that has both gdiff objects applied
+        gfactors_ref = GrowFactors()
         gdiff_baseline.apply_to(gfactors_ref)
         if gdiff_response is not None:
             gdiff_response.apply_to(gfactors_ref)
@@ -825,7 +825,7 @@ class TaxCalcIO(object):
         for year in range(Policy.JSON_START_YEAR, tax_year + 1):
             print(progress.format(year))  # pylint: disable=superfluous-parens
             # specify growdiff_response using gdiff_dict
-            growdiff_response = Growdiff()
+            growdiff_response = GrowDiff()
             growdiff_response.update_growdiff(gdiff_dict)
             gd_dict = TaxCalcIO.annual_analysis(input_data, tax_year,
                                                 baseline, reform, assump,
@@ -865,7 +865,7 @@ class TaxCalcIO(object):
 
         Returns
         -------
-        gd_dict: Growdiff sub-dictionary for year+1
+        gd_dict: GrowDiff sub-dictionary for year+1
         """
         # pylint: disable=too-many-arguments,too-many-locals
         # instantiate TaxCalcIO object for specified year and growdiff_response

--- a/taxcalc/tbi/tbi.py
+++ b/taxcalc/tbi/tbi.py
@@ -29,7 +29,7 @@ from taxcalc.tbi.tbi_utils import (check_years_return_first_year,
                                    AGGR_ROW_NAMES)
 from taxcalc import (DIST_TABLE_LABELS, DIFF_TABLE_LABELS,
                      proportional_change_in_gdp,
-                     Growdiff, Growfactors, Policy, Behavior, Consumption)
+                     GrowDiff, GrowFactors, Policy, Behavior, Consumption)
 
 AGG_ROW_NAMES = AGGR_ROW_NAMES
 
@@ -53,19 +53,19 @@ def reform_warnings_errors(user_mods):
                 'consumption': {'warnings': '', 'errors': ''},
                 'growdiff_baseline': {'warnings': '', 'errors': ''},
                 'growdiff_response': {'warnings': '', 'errors': ''}}
-    # create Growdiff objects
-    gdiff_baseline = Growdiff()
+    # create GrowDiff objects
+    gdiff_baseline = GrowDiff()
     try:
         gdiff_baseline.update_growdiff(user_mods['growdiff_baseline'])
     except ValueError as valerr_msg:
         rtn_dict['growdiff_baseline']['errors'] = valerr_msg.__str__()
-    gdiff_response = Growdiff()
+    gdiff_response = GrowDiff()
     try:
         gdiff_response.update_growdiff(user_mods['growdiff_response'])
     except ValueError as valerr_msg:
         rtn_dict['growdiff_response']['errors'] = valerr_msg.__str__()
     # create Growfactors object
-    growfactors = Growfactors()
+    growfactors = GrowFactors()
     gdiff_baseline.apply_to(growfactors)
     gdiff_response.apply_to(growfactors)
     # create Policy object

--- a/taxcalc/tbi/tbi_utils.py
+++ b/taxcalc/tbi/tbi_utils.py
@@ -13,7 +13,7 @@ import hashlib
 import numpy as np
 import pandas as pd
 from taxcalc import (Policy, Records, Calculator,
-                     Consumption, Behavior, Growfactors, Growdiff)
+                     Consumption, Behavior, GrowFactors, GrowDiff)
 from taxcalc.utils import (add_income_table_row_variable,
                            add_quantile_table_row_variable,
                            create_difference_table, create_distribution_table,
@@ -85,17 +85,17 @@ def calculate(year_n, start_year,
     consump.update_consumption(consump_assumptions)
 
     # specify growdiff_baseline and growdiff_response
-    growdiff_baseline = Growdiff()
-    growdiff_response = Growdiff()
+    growdiff_baseline = GrowDiff()
+    growdiff_response = GrowDiff()
     growdiff_base_assumps = user_mods['growdiff_baseline']
     growdiff_resp_assumps = user_mods['growdiff_response']
     growdiff_baseline.update_growdiff(growdiff_base_assumps)
     growdiff_response.update_growdiff(growdiff_resp_assumps)
 
-    # create pre-reform and post-reform Growfactors instances
-    growfactors_pre = Growfactors()
+    # create pre-reform and post-reform GrowFactors instances
+    growfactors_pre = GrowFactors()
     growdiff_baseline.apply_to(growfactors_pre)
-    growfactors_post = Growfactors()
+    growfactors_post = GrowFactors()
     growdiff_baseline.apply_to(growfactors_post)
     growdiff_response.apply_to(growfactors_post)
 

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -10,6 +10,8 @@ from taxcalc import Policy, Records, Calculator, Behavior
 
 def test_incorrect_behavior_instantiation():
     with pytest.raises(ValueError):
+        Behavior(start_year=2000)
+    with pytest.raises(ValueError):
         Behavior(num_years=0)
     with pytest.raises(FloatingPointError):
         np.divide(1., 0.)

--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -9,14 +9,9 @@ from taxcalc import Policy, Records, Calculator, Consumption
 
 def test_incorrect_Consumption_instantiation():
     with pytest.raises(ValueError):
-        consump = Consumption(consumption_dict=list())
+        consump = Consumption(start_year=2000)
     with pytest.raises(ValueError):
         consump = Consumption(num_years=0)
-
-
-def test_correct_but_not_recommended_Consumption_instantiation():
-    consump = Consumption(consumption_dict={})
-    assert consump
 
 
 def test_validity_of_consumption_vars_set():

--- a/taxcalc/tests/test_growdiff.py
+++ b/taxcalc/tests/test_growdiff.py
@@ -5,42 +5,37 @@ import os
 import json
 from numpy.testing import assert_allclose
 import pytest
-from taxcalc import Growdiff, Growfactors, Policy
+from taxcalc import GrowDiff, GrowFactors, Policy
 
 
 def test_year_consistency():
-    assert Growdiff.JSON_START_YEAR == Policy.JSON_START_YEAR
-    assert Growdiff.DEFAULT_NUM_YEARS == Policy.DEFAULT_NUM_YEARS
+    assert GrowDiff.JSON_START_YEAR == Policy.JSON_START_YEAR
+    assert GrowDiff.DEFAULT_NUM_YEARS == Policy.DEFAULT_NUM_YEARS
 
 
 def test_incorrect_growdiff_ctor():
     with pytest.raises(ValueError):
-        gdiff = Growdiff(growdiff_dict=list())
+        gdiff = GrowDiff(start_year=2000)
     with pytest.raises(ValueError):
-        gdiff = Growdiff(num_years=0)
-
-
-def test_correct_but_not_useful_growdiff_ctor():
-    gdiff = Growdiff(growdiff_dict={})
-    assert gdiff
+        gdiff = GrowDiff(num_years=0)
 
 
 def test_update_and_apply_growdiff():
     syr = 2013
     nyrs = 5
     lyr = syr + nyrs - 1
-    gdiff = Growdiff(start_year=syr, num_years=nyrs)
-    # update Growdiff instance
+    gdiff = GrowDiff(start_year=syr, num_years=nyrs)
+    # update GrowDiff instance
     diffs = {2014: {'_AWAGE': [0.01]},
              2016: {'_AWAGE': [0.02]}}
     gdiff.update_growdiff(diffs)
     expected_wage_diffs = [0.00, 0.01, 0.01, 0.02, 0.02]
     assert_allclose(gdiff._AWAGE, expected_wage_diffs, atol=0.0, rtol=0.0)
-    # apply growdiff to Growfactors instance
-    gf = Growfactors()
+    # apply growdiff to GrowFactors instance
+    gf = GrowFactors()
     pir_pre = gf.price_inflation_rates(syr, lyr)
     wgr_pre = gf.wage_growth_rates(syr, lyr)
-    gfactors = Growfactors()
+    gfactors = GrowFactors()
     gdiff.apply_to(gfactors)
     pir_pst = gfactors.price_inflation_rates(syr, lyr)
     wgr_pst = gfactors.wage_growth_rates(syr, lyr)
@@ -52,22 +47,22 @@ def test_update_and_apply_growdiff():
 
 def test_incorrect_update_growdiff():
     with pytest.raises(ValueError):
-        Growdiff().update_growdiff([])
+        GrowDiff().update_growdiff([])
     with pytest.raises(ValueError):
-        Growdiff().update_growdiff({'xyz': {'_ABOOK': [0.02]}})
+        GrowDiff().update_growdiff({'xyz': {'_ABOOK': [0.02]}})
     with pytest.raises(ValueError):
-        Growdiff().update_growdiff({2012: {'_ABOOK': [0.02]}})
+        GrowDiff().update_growdiff({2012: {'_ABOOK': [0.02]}})
     with pytest.raises(ValueError):
-        Growdiff().update_growdiff({2052: {'_ABOOK': [0.02]}})
+        GrowDiff().update_growdiff({2052: {'_ABOOK': [0.02]}})
     with pytest.raises(ValueError):
-        Growdiff().update_growdiff({2014: {'_MPC_exxxxx': [0.02]}})
+        GrowDiff().update_growdiff({2014: {'_MPC_exxxxx': [0.02]}})
     with pytest.raises(ValueError):
-        Growdiff().update_growdiff({2014: {'_ABOOK': [-1.1]}})
+        GrowDiff().update_growdiff({2014: {'_ABOOK': [-1.1]}})
 
 
 def test_has_any_response():
     syr = 2014
-    gdiff = Growdiff(start_year=syr)
+    gdiff = GrowDiff(start_year=syr)
     assert gdiff.has_any_response() is False
     gdiff.update_growdiff({2020: {'_AWAGE': [0.01]}})
     assert gdiff.current_year == syr

--- a/taxcalc/tests/test_growfactors.py
+++ b/taxcalc/tests/test_growfactors.py
@@ -1,5 +1,5 @@
 """
-Tests of Tax-Calculator Growfactors class.
+Tests of Tax-Calculator GrowFactors class.
 """
 # CODING-STYLE CHECKS:
 # pycodestyle test_growfactors.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 import pytest
 # pylint: disable=import-error
-from taxcalc import Growfactors, Records, Policy
+from taxcalc import GrowFactors, Records, Policy
 
 
 @pytest.fixture(scope='module', name='bad_gf_file')
@@ -29,13 +29,13 @@ def fixture_bad_gf_file():
 
 def test_improper_usage(bad_gf_file):
     """
-    Tests of improper usage of Growfactors object.
+    Tests of improper usage of GrowFactors object.
     """
     with pytest.raises(ValueError):
-        gfo = Growfactors(dict())
+        gfo = GrowFactors(dict())
     with pytest.raises(ValueError):
-        gfo = Growfactors(bad_gf_file.name)
-    gfo = Growfactors()
+        gfo = GrowFactors(bad_gf_file.name)
+    gfo = GrowFactors()
     fyr = gfo.first_year
     lyr = gfo.last_year
     with pytest.raises(ValueError):
@@ -60,9 +60,9 @@ def test_improper_usage(bad_gf_file):
 
 def test_update_after_use():
     """
-    Test of improper update after Growfactors object has been used.
+    Test of improper update after GrowFactors object has been used.
     """
-    gfo = Growfactors()
+    gfo = GrowFactors()
     gfo.price_inflation_rates(gfo.first_year, gfo.last_year)
     with pytest.raises(ValueError):
         gfo.update('AWAGE', 2013, 0.01)
@@ -70,9 +70,9 @@ def test_update_after_use():
 
 def test_proper_usage():
     """
-    Test proper usage of Growfactors object.
+    Test proper usage of GrowFactors object.
     """
-    gfo = Growfactors()
+    gfo = GrowFactors()
     pir = gfo.price_inflation_rates(2013, 2020)
     assert len(pir) == 8
     wgr = gfo.wage_growth_rates(2013, 2021)
@@ -85,9 +85,9 @@ def test_growfactors_csv_values():
     """
     Test numerical contents of growfactors.csv file.
     """
-    gfo = Growfactors()
+    gfo = GrowFactors()
     min_data_year = min(Records.PUFCSV_YEAR, Records.CPSCSV_YEAR)
     if min_data_year < Policy.JSON_START_YEAR:
-        for gfname in Growfactors.VALID_NAMES:
+        for gfname in GrowFactors.VALID_NAMES:
             val = gfo.factor_value(gfname, min_data_year)
             assert val == 1

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -9,7 +9,31 @@ import tempfile
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
-from taxcalc import Policy, Calculator, Growfactors, Growdiff
+from taxcalc import Policy, Calculator
+
+
+def test_incorrect_Policy_instantiation():
+    with pytest.raises(ValueError):
+        Policy(gfactors=list())
+    with pytest.raises(ValueError):
+        Policy(start_year=2000)
+    with pytest.raises(ValueError):
+        Policy(num_years=0)
+
+
+def test_correct_Policy_instantiation():
+    pol = Policy()
+    assert pol
+    pol.implement_reform({})
+    with pytest.raises(ValueError):
+        pol.implement_reform(list())
+    with pytest.raises(ValueError):
+        pol.implement_reform({2099: {'_II_em': [99000]}})
+    pol.set_year(2019)
+    with pytest.raises(ValueError):
+        pol.implement_reform({2018: {'_II_em': [99000]}})
+    with pytest.raises(ValueError):
+        pol.implement_reform({2020: {'_II_em': [-1000]}})
 
 
 @pytest.fixture(scope='module', name='policyfile')
@@ -29,28 +53,6 @@ def fixture_policyfile():
     # Must close and then yield for Windows platform
     yield f
     os.remove(f.name)
-
-
-def test_incorrect_Policy_instantiation():
-    with pytest.raises(ValueError):
-        p = Policy(gfactors=dict())
-    with pytest.raises(ValueError):
-        p = Policy(num_years=0)
-
-
-def test_correct_Policy_instantiation():
-    pol = Policy()
-    assert pol
-    pol.implement_reform({})
-    with pytest.raises(ValueError):
-        pol.implement_reform(list())
-    with pytest.raises(ValueError):
-        pol.implement_reform({2099: {'_II_em': [99000]}})
-    pol.set_year(2019)
-    with pytest.raises(ValueError):
-        pol.implement_reform({2018: {'_II_em': [99000]}})
-    with pytest.raises(ValueError):
-        pol.implement_reform({2020: {'_II_em': [-1000]}})
 
 
 def test_policy_json_content():

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal
 import pandas as pd
 import pytest
 from io import StringIO
-from taxcalc import Growfactors, Policy, Records, Calculator
+from taxcalc import GrowFactors, Policy, Records, Calculator
 
 
 def test_incorrect_Records_instantiation(cps_subsample):
@@ -45,7 +45,7 @@ def test_correct_Records_instantiation(cps_subsample):
     benefit_df = pd.read_csv(benefit_path)
     rec2 = Records(data=cps_subsample,
                    exact_calculations=False,
-                   gfactors=Growfactors(),
+                   gfactors=GrowFactors(),
                    weights=wghts_df,
                    adjust_ratios=None,
                    benefits=benefit_df,

--- a/taxcalc/tests/test_responses.py
+++ b/taxcalc/tests/test_responses.py
@@ -8,7 +8,7 @@ Test example JSON response assumption files in taxcalc/responses directory
 import os
 import glob
 # pylint: disable=import-error
-from taxcalc import Calculator, Consumption, Behavior, Growdiff
+from taxcalc import Calculator, Consumption, Behavior, GrowDiff
 
 
 def test_response_json(tests_path):
@@ -34,9 +34,9 @@ def test_response_json(tests_path):
             cons.update_consumption(con)
             behv = Behavior()
             behv.update_behavior(beh)
-            growdiff_baseline = Growdiff()
+            growdiff_baseline = GrowDiff()
             growdiff_baseline.update_growdiff(gdiff_base)
-            growdiff_response = Growdiff()
+            growdiff_response = GrowDiff()
             growdiff_response.update_growdiff(gdiff_resp)
         else:  # jpf_text is not a valid JSON response assumption file
             print('test-failing-filename: ' +

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 import pytest
 import pandas as pd
-from taxcalc import TaxCalcIO, Growdiff  # pylint: disable=import-error
+from taxcalc import TaxCalcIO, GrowDiff  # pylint: disable=import-error
 
 
 @pytest.fixture(scope='module', name='rawinputfile')
@@ -292,19 +292,19 @@ def test_ctor_errors(input_data, baseline, reform, assump, outdir):
 
 @pytest.mark.parametrize('year, base, ref, asm, gdr', [
     (2000, 'reformfile0', 'reformfile0', None, list()),
-    (2099, 'reformfile0', 'reformfile0', None, Growdiff()),
-    (2020, 'errorreformfile', 'errorreformfile', None, Growdiff()),
+    (2099, 'reformfile0', 'reformfile0', None, GrowDiff()),
+    (2020, 'errorreformfile', 'errorreformfile', None, GrowDiff()),
     (2020, 'reformfile0', 'reformfile0', 'assumpfile0', 'has_gdiff_response'),
-    (2020, 'reformfile0', 'reformfile0', 'assumpfile0', Growdiff()),
-    (2020, 'reformfile0', 'reformfilex1', 'assumpfile0', Growdiff()),
-    (2020, 'reformfile0', 'reformfilex2', 'assumpfile0', Growdiff())
+    (2020, 'reformfile0', 'reformfile0', 'assumpfile0', GrowDiff()),
+    (2020, 'reformfile0', 'reformfilex1', 'assumpfile0', GrowDiff()),
+    (2020, 'reformfile0', 'reformfilex2', 'assumpfile0', GrowDiff())
 ])
 def test_init_errors(reformfile0, reformfilex1, reformfilex2, errorreformfile,
                      assumpfile0, year, base, ref, asm, gdr):
     """
     Ensure error messages generated correctly by TaxCalcIO.init method.
     """
-    # pylint: disable=too-many-arguments,too-many-locals
+    # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     recdict = {'RECID': 1, 'MARS': 1, 'e00300': 100000, 's006': 1e8}
     recdf = pd.DataFrame(data=recdict, index=[0])
     # test TaxCalcIO ctor
@@ -329,7 +329,7 @@ def test_init_errors(reformfile0, reformfilex1, reformfilex2, errorreformfile,
     else:
         assump = asm
     if gdr == 'has_gdiff_response':
-        gdiff_resp = Growdiff()
+        gdiff_resp = GrowDiff()
         gdiff_resp.update_growdiff({2015: {"_ABOOK": [-0.01]}})
     else:
         gdiff_resp = gdr
@@ -365,7 +365,7 @@ def test_creation_with_aging(rawinputfile, reformfile0):
               baseline=None,
               reform=reformfile0.name,
               assump=None,
-              growdiff_response=Growdiff(),
+              growdiff_response=GrowDiff(),
               aging_input_data=True,
               exact_calculations=False)
     assert not tcio.errmsg


### PR DESCRIPTION
This pull request adopts the following [PEP8 prescriptive naming convention](https://www.python.org/dev/peps/pep-0008/#id37) for class names:
> Class names should normally use the CapWords convention.

So, the `Growfactors` class has been renamed the `GrowFactors` class.
And the `Growdiff` class has been renamed the `GrowDiff` class.

Any Python scripts that use these two classes will need to be revised.

Also, the constructor dictionary argument in several classes derived from the `ParametersBase` class has been removed as was done for the Behavior class in pull request #1952.
