### PR TITLE
Rename charitable_giving_response as quantity_response

### DIFF
--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -37,25 +37,6 @@
         "range": {"min": -9e99, "max": 0.0}
     },
 
-    "_BE_subinc_wrt_earnings": {
-        "long_name": "Income and substitution elasticities apply to earnings",
-        "description": "False implies elasticities apply to taxable income; true implies they are both computed as proportional changes and applied to taxpayer earnings only.  Note: must be false if both _BE_sub and _BE_inc are zero.",
-        "section_1": "Behavior",
-        "section_2": "Taxable Income",
-        "notes": "",
-        "row_var": "FLPDYR",
-        "row_label": ["2013"],
-        "start_year": 2013,
-        "cpi_inflatable": false,
-        "cpi_inflated": false,
-        "col_var": "",
-        "col_label": "",
-        "boolean_value": true,
-        "integer_value": false,
-        "value": [false],
-        "range": {"min": false, "max": true}
-    },
-
     "_BE_cg": {
         "long_name": "Semi-elasticity of long-term capital gains",
         "description": "Defined as change in logarithm of long-term capital gains divided by change in marginal tax rate (MTR) on long-term capital gains caused by the reform.  Must be zero or negative.  Read Behavior.response documentation for discussion of appropriate values.",

--- a/taxcalc/responses/economic_responses_template.json
+++ b/taxcalc/responses/economic_responses_template.json
@@ -26,7 +26,6 @@
     "behavior": {
         "_BE_inc": {"2017": [0.0]},
         "_BE_sub": {"2017": [0.0]},
-        "_BE_subinc_wrt_earnings": {"2017": [false]},
         "_BE_cg": {"2017": [0.0]}
     },
     "growdiff_baseline": {

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -41,8 +41,7 @@ def test_behavioral_response_calculator(cps_subsample):
     calc2 = Calculator(policy=pol, records=rec, behavior=behv0)
     assert calc2.behavior_has_response() is False
     calc2_behv0 = Behavior.response(calc1, calc2)
-    behavior1 = {year: {'_BE_sub': [0.3], '_BE_inc': [-0.1], '_BE_cg': [0.0],
-                        '_BE_subinc_wrt_earnings': [True]}}
+    behavior1 = {year: {'_BE_sub': [0.3], '_BE_inc': [-0.1], '_BE_cg': [0.0]}}
     behv1 = Behavior()
     behv1.update_behavior(behavior1)
     calc2 = Calculator(policy=pol, records=rec, behavior=behv1)
@@ -106,8 +105,6 @@ def test_incorrect_update_behavior():
     with pytest.raises(ValueError):
         Behavior().update_behavior({2013: {'_BE_sub': [-0.2]}})
     with pytest.raises(ValueError):
-        Behavior().update_behavior({2017: {'_BE_subinc_wrt_earnings': [2]}})
-    with pytest.raises(ValueError):
         Behavior().update_behavior({2013: {'_BE_cg': [+0.8]}})
     with pytest.raises(ValueError):
         Behavior().update_behavior({2013: {'_BE_xx': [0.0]}})
@@ -138,10 +135,6 @@ def test_validate_param_names_types_errors():
     specs1 = {2019: {'_BE_inc': [True]}}
     with pytest.raises(ValueError):
         behv1.update_behavior(specs1)
-    behv2 = Behavior()
-    specs2 = {2020: {'_BE_subinc_wrt_earnings': [0.3]}}
-    with pytest.raises(ValueError):
-        behv2.update_behavior(specs2)
 
 
 def test_validate_param_values_errors():
@@ -156,7 +149,6 @@ def test_validate_param_values_errors():
     behv2 = Behavior()
     specs2 = {
         2020: {
-            '_BE_subinc_wrt_earnings': [True],
             '_BE_cg': [-0.2],
             '_BE_sub': [0.3]
         }

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -35,7 +35,7 @@ from taxcalc.utils import (DIST_VARIABLES,
                            certainty_equivalent,
                            ce_aftertax_expanded_income,
                            nonsmall_diffs,
-                           charitable_giving_response)
+                           quantity_response)
 
 
 DATA = [[1.0, 2, 'a'],
@@ -881,22 +881,22 @@ def test_nonsmall_diffs():
     assert nonsmall_diffs(['12.3'], ['AAA'])
 
 
-def test_charitable_giving_response():
+def test_quantity_response():
     quantity = np.array([1.0] * 10)
-    res = charitable_giving_response(quantity,
-                                     price_elasticity=0,
-                                     aftertax_price1=None,
-                                     aftertax_price2=None,
-                                     income_elasticity=0,
-                                     aftertax_income1=None,
-                                     aftertax_income2=None)
+    res = quantity_response(quantity,
+                            price_elasticity=0,
+                            aftertax_price1=None,
+                            aftertax_price2=None,
+                            income_elasticity=0,
+                            aftertax_income1=None,
+                            aftertax_income2=None)
     assert np.allclose(res, np.zeros(quantity.shape))
     one = np.ones(quantity.shape)
-    res = charitable_giving_response(quantity,
-                                     price_elasticity=-0.2,
-                                     aftertax_price1=one,
-                                     aftertax_price2=one,
-                                     income_elasticity=0.1,
-                                     aftertax_income1=one,
-                                     aftertax_income2=(one + one))
+    res = quantity_response(quantity,
+                            price_elasticity=-0.2,
+                            aftertax_price1=one,
+                            aftertax_price2=one,
+                            income_elasticity=0.1,
+                            aftertax_income1=one,
+                            aftertax_income2=(one + one))
     assert not np.allclose(res, np.zeros(quantity.shape))

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1648,34 +1648,44 @@ def nonsmall_diffs(linelist1, linelist2, small=0.0):
         return False
 
 
-def charitable_giving_response(quantity,
-                               price_elasticity,
-                               aftertax_price1,
-                               aftertax_price2,
-                               income_elasticity,
-                               aftertax_income1,
-                               aftertax_income2):
+def quantity_response(quantity,
+                      price_elasticity,
+                      aftertax_price1,
+                      aftertax_price2,
+                      income_elasticity,
+                      aftertax_income1,
+                      aftertax_income2):
     """
-    Calculate dollar change in quantity using a log-log response equation.
+    Calculate dollar change in quantity using a log-log response equation,
+    which assumes that the proportional change in the quantity is equal to
+    the sum of two terms:
+    (1) the proportional change in the quanitity's marginal aftertax price
+        times an assumed price elasticity, and
+    (2) the proportional change in aftertax income
+        times an assumed income elasticity.
 
     Parameters
     ----------
     quantity: numpy array
-        pre-response charitable giving
+        pre-response quantity whose response is being calculated
 
     price_elasticity: float
         coefficient of the percentage change in aftertax price of
-        charitable giving in the log-log response equation
+        the quantity in the log-log response equation
 
     aftertax_price1: numpy array
-        marginal aftertax price of charitable giving under baseline policy
-        (function forces price to be in [0.01, 1.0] range)
-        (note this is NOT an array of marginal tax rates)
+        marginal aftertax price of the quanitity under baseline policy
+          Note that this function forces prices to be in [0.01, 1.0] range.
+          Note this is NOT an array of marginal tax rates (MTR), but rather
+            usually 1-MTR (or in the case of quantities, like charitable
+            giving, whose MTR values are non-positive, 1+MTR).
 
     aftertax_price2: numpy array
-        marginal aftertax price of charitable giving under reform policy
-        (function forces price to be in [0.01, 1.0] range)
-        (note this is NOT an array of marginal tax rates)
+        marginal aftertax price of the quantity under reform policy
+          Note that this function forces prices to be in [0.01, 1.0] range.
+          Note this is NOT an array of marginal tax rates (MTR), but rather
+            usually 1-MTR (or in the case of quantities, like charitable
+            giving, whose MTR values are non-positive, 1+MTR).
 
     income_elasticity: float
         coefficient of the percentage change in aftertax income in the
@@ -1683,16 +1693,22 @@ def charitable_giving_response(quantity,
 
     aftertax_income1: numpy array
         aftertax income under baseline policy
-        (function forces income to be in [1, inf] range)
+          Note that this function forces income to be in [1, inf] range,
+          but the caller of this function may want to constrain negative
+          or small incomes to be somewhat larger in order to avoid extreme
+          proportional changes in aftertax income.
 
     aftertax_income2: numpy array
         aftertax income under reform policy
-        (function forces income to be in [1, inf] range)
+          Note that this function forces income to be in [1, inf] range,
+          but the caller of this function may want to constrain negative
+          or small incomes to be somewhat larger in order to avoid extreme
+          proportional changes in aftertax income.
 
     Returns
     -------
     response: numpy array
-        change in quantity calculated from log-log response equation
+        dollar change in quantity calculated from log-log response equation
     """
     # pylint: disable=too-many-arguments
     # compute price term in log-log response equation


### PR DESCRIPTION
This pull request renames the `charitable_giving_response` utility function added in pull request #1995 as `quantity_response` and enhances its documentation.  The new name reflects the broad applicability of the function.  Also, as part of this pull request, the `_BE_subinc_wrt_earnings` Behavior parameter has been removed because the analysis it enabled is more easily done with the `quantity_response` utility function.