### PR TITLE
Add ability to use or not use PUF adjust_ratios in test_compare.py

### DIFF
--- a/taxcalc/tests/test_compare.py
+++ b/taxcalc/tests/test_compare.py
@@ -253,7 +253,7 @@ def differences(afilename, efilename):
     else:
         os.remove(afilename)
 
-@pytest.mark.one
+
 @pytest.mark.skipif(sys.version_info > (3, 0),
                     reason='remove skipif after migration to Python 3.6')
 @pytest.mark.pre_release

--- a/taxcalc/tests/test_compare.py
+++ b/taxcalc/tests/test_compare.py
@@ -253,7 +253,7 @@ def differences(afilename, efilename):
     else:
         os.remove(afilename)
 
-
+@pytest.mark.one
 @pytest.mark.skipif(sys.version_info > (3, 0),
                     reason='remove skipif after migration to Python 3.6')
 @pytest.mark.pre_release
@@ -263,9 +263,13 @@ def test_itax_compare(tests_path, using_puf, puf_fullsample, cps_fullsample):
     """
     Conduct income tax comparisons using ITAX data.
     """
+    using_puf_adjust_ratios = True
     # generate 2015 estimates by AGI category using Tax-Calculator
     if using_puf:
-        recs = Records(data=puf_fullsample)
+        if using_puf_adjust_ratios:
+            recs = Records(data=puf_fullsample)
+        else:
+            recs = Records(data=puf_fullsample, adjust_ratios=None)
     else:
         recs = Records.cps_constructor(data=cps_fullsample, no_benefits=True)
     calc = Calculator(policy=Policy(), records=recs, verbose=False)


### PR DESCRIPTION
The pull request adds flexibility to the PUF comparison tests in the `test_compare.py` file.
This pull request leaves Tax-Calculator logic and results unchanged and leaves the test results unchanged.