### PR TITLE
Remove tests made obsolete by addition of taxdata tests

### DIFF
--- a/taxcalc/tests/test_cpscsv.py
+++ b/taxcalc/tests/test_cpscsv.py
@@ -122,20 +122,6 @@ def test_cps_availability(tests_path, cps_path):
     assert (recvars - cpsvars) == set()
 
 
-def test_ubi_n_variables(cps_path):
-    """
-    Ensure that the three UBI n* variables add up to XTOT variable.
-    """
-    cpsdf = pd.read_csv(cps_path)
-    xtot = cpsdf['XTOT']
-    nsum = cpsdf['nu18'] + cpsdf['n1820'] + cpsdf['n21']
-    if not np.allclose(xtot, nsum):
-        print('number of diffs is:', np.sum(xtot != nsum))
-        print('number xtot < nsum is:', np.sum(xtot < nsum))
-        print('number xtot > nsum is:', np.sum(xtot > nsum))
-        assert 'XTOT' == '(nu18+n1820+n21)'
-
-
 @pytest.mark.skipif(sys.version_info > (3, 0),
                     reason='remove skipif after migration to Python 3.6')
 def test_run_taxcalc_model(tests_path):

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -346,22 +346,6 @@ def test_puf_availability(tests_path, puf_path):
 
 
 @pytest.mark.requires_pufcsv
-@pytest.mark.xfail
-def test_ubi_n_variables(puf_path):
-    """
-    Ensure that the three UBI n* variables add up to XTOT variable,
-    recognizing that XTOT values are often capped in the IRS-SOI PUF,
-    so that XTOT < NSUM might not indicate any data inconsistency.
-    """
-    pufdf = pd.read_csv(puf_path)
-    xtot = pufdf['XTOT']
-    nsum = pufdf['nu18'] + pufdf['n1820'] + pufdf['n21']
-    if not np.sum(xtot > nsum) == 0:
-        print('number xtot > nsum is:', np.sum(xtot > nsum))
-        assert 'XTOT' <= '(nu18+n1820+n21)'
-
-
-@pytest.mark.requires_pufcsv
 def test_run_taxcalc_model(tests_path):
     """
     Test tbi.run_nth_year_taxcalc_model function using PUF data.


### PR DESCRIPTION
This pull request removes two tests that are now being done in the taxdata repository.