### PR TITLE
Add Makefile that documents and automates common development operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ help:
 	@echo "             pytest -m ''"
 	@echo "tctest     : generate report for and cleanup after"
 	@echo "             tc --test"
-	@echo "cstest     : generate coding-style reports using"
-	@echo "             pycodestyle and pylint tools"
+	@echo "cstest     : generate coding-style errors using the"
+	@echo "             pycodestyle (nee pep8) and pylint tools"
 
 .PHONY=clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,21 @@
-# GNU Makefile that documents and automates common Tax-Calculator operations
-#     using the GNU make tool (version >= 3.81)
+# GNU Makefile that documents and automates common development operations
+#              using the GNU make tool (version >= 3.81)
 # USAGE: tax-calculator$ make [TARGET]
 
 .PHONY=help
 help:
 	@echo "USAGE: make [TARGET]"
 	@echo "TARGETS:"
-	@echo "  help : help description "
+	@echo "help    : show help message"
+	@echo "clean   : remove .pyc files, caches, and local taxcalc package"
+	@echo "package : build and install local taxcalc package"
 
 .PHONY=clean-pyc
 clean-pyc:
 	@find . -name *pyc -exec rm -f {} \;
 
-.PHONY=clean-cache
-clean-cache:
+.PHONY=clean-caches
+clean-caches:
 	@find . -name *cache -maxdepth 1 -exec rm -rf {} \;
 
 .PHONY=clean-package
@@ -21,4 +23,8 @@ clean-package:
 	@./conda.recipe/remove_local_taxcalc_package.sh
 
 .PHONY=clean
-clean: clean-pyc clean-cache clean-package
+clean: clean-pyc clean-caches clean-package
+
+.PHONY=package
+package:
+	@./conda.recipe/install_local_taxcalc_package.sh

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ help:
 	@echo "             tc --test"
 	@echo "cstest     : generate coding-style errors using the"
 	@echo "             pycodestyle (nee pep8) and pylint tools"
+	@echo "git-sync   : synchronize local, origin, and upstream Git repos"
+	@echo "git-pr N=n : create local pr-n branch containing upstream PR"
 
 .PHONY=clean
 clean:
@@ -69,60 +71,20 @@ tctest: package
 	@$(tctest-cleanup)
 	@echo "validation tests using tc will be added in the future"
 
-# TAXCALC_JSONFILES list is constructed using the following command:
-# tax-calculator$ ls -l ./taxcalc/*json | awk '{print $9}'
-TAXCALC_JSONFILES = ./taxcalc/behavior.json \
-	./taxcalc/consumption.json \
-	./taxcalc/current_law_policy.json \
-	./taxcalc/growdiff.json \
-	./taxcalc/growmodel.json \
-	./taxcalc/records_variables.json
-
-# PYLINT_FILES list is constructed using the following command:
-# tax-calculator$ grep -rl --include="*py" disable=locally-disabled .
-PYLINT_FILES = ./docs/cookbook/make_cookbook.py \
-	./docs/cookbook/test_recipes.py \
-	./docs/make_index.py \
-	./puf_fuzz.py \
-	./simtax.py \
-	./taxcalc/behavior.py \
-	./taxcalc/calculate.py \
-	./taxcalc/cli/tc.py \
-	./taxcalc/consumption.py \
-	./taxcalc/decorators.py \
-	./taxcalc/functions.py \
-	./taxcalc/growdiff.py \
-	./taxcalc/growfactors.py \
-	./taxcalc/growmodel.py \
-	./taxcalc/macro_elasticity.py \
-	./taxcalc/policy.py \
-	./taxcalc/records.py \
-	./taxcalc/simpletaxio.py \
-	./taxcalc/taxcalcio.py \
-	./taxcalc/tbi/tbi.py \
-	./taxcalc/tbi/tbi_utils.py \
-	./taxcalc/tests/test_4package.py \
-	./taxcalc/tests/test_compare.py \
-	./taxcalc/tests/test_compatible_data.py \
-	./taxcalc/tests/test_cpscsv.py \
-	./taxcalc/tests/test_docs.py \
-	./taxcalc/tests/test_functions.py \
-	./taxcalc/tests/test_growfactors.py \
-	./taxcalc/tests/test_macro_elasticity.py \
-	./taxcalc/tests/test_parameters.py \
-	./taxcalc/tests/test_puf_var_stats.py \
-	./taxcalc/tests/test_pufcsv.py \
-	./taxcalc/tests/test_reforms.py \
-	./taxcalc/tests/test_responses.py \
-	./taxcalc/tests/test_simpletaxio.py \
-	./taxcalc/tests/test_taxcalcio.py \
-	./taxcalc/tests/test_utils.py \
-	./taxcalc/utils.py \
-	./taxcalc/utilsprvt.py \
-	./taxcalc/validation/csv_taxdiffs.py
+TAXCALC_JSON_FILES := $(shell ls -l ./taxcalc/*json | awk '{print $$9}')
+PYLINT_FILES := $(shell grep -rl --include="*py" disable=locally-disabled .)
 
 .PHONY=cstest
 cstest:
 	pycodestyle taxcalc
-	@pycodestyle --ignore=E501,E121 $(TAXCALC_JSONFILES)
+	pycodestyle docs/cookbook
+	@pycodestyle --ignore=E501,E121 $(TAXCALC_JSON_FILES)
 	@pylint --disable=locally-disabled --score=no --jobs=4 $(PYLINT_FILES)
+
+.PHONY=git-sync
+git-sync:
+	@./gitsync
+
+.PHONY=git-pr
+git-pr:
+	@./gitpr $(N)

--- a/Makefile
+++ b/Makefile
@@ -6,37 +6,29 @@
 help:
 	@echo "USAGE: make [TARGET]"
 	@echo "TARGETS:"
-	@echo "help : show help message"
-	@echo "clean : remove .pyc files, caches, and local taxcalc package"
-	@echo "package : build and install local taxcalc package"
+	@echo "help       : show help message"
+	@echo "clean      : remove .pyc files and local taxcalc package"
+	@echo "package    : build and install local taxcalc package"
 	@echo "pytest-cps : generate report for and cleanup after"
 	@echo "             pytest -m 'not requires_pufcsv and not pre_release'"
 	@echo "pytest     : generate report for and cleanup after"
 	@echo "             pytest -m 'not pre_release'"
 	@echo "pytest-all : generate report for and cleanup after"
 	@echo "             pytest -m ''"
-
-.PHONY=clean-pyc
-clean-pyc:
-	@find . -name *pyc -exec rm -f {} \;
-
-.PHONY=clean-caches
-clean-caches:
-	@find . -name *cache -maxdepth 1 -exec rm -rf {} \;
-
-.PHONY=clean-package
-clean-package:
-	@./conda.recipe/remove_local_taxcalc_package.sh
+	@echo "tctest     : generate report for and cleanup after"
+	@echo "             tc --test"
 
 .PHONY=clean
-clean: clean-pyc clean-caches clean-package
+clean: clean-pyc clean-package
+	@find . -name *pyc -exec rm {} \;
+	@./conda.recipe/remove_local_taxcalc_package.sh
 
 .PHONY=package
 package:
 	@./conda.recipe/install_local_taxcalc_package.sh
 
 define pytest-cleanup
-find . -name *cache -maxdepth 1 -exec rm -rf {} \;
+find . -name *cache -maxdepth 1 -exec rm -r {} \;
 rm -f df-??-#-*
 rm -f tmp??????-??-#-tmp*
 endef
@@ -61,3 +53,15 @@ pytest-all:
 	@pytest -n4 -m ""
 	@$(pytest-cleanup)
 	@cd ..
+
+define tctest-cleanup
+rm -f test.csv
+rm -f test-18-*
+./conda.recipe/remove_local_taxcalc_package.sh	
+endef
+
+.PHONY=tctest
+tctest: package
+	tc --test
+	@$(tctest-cleanup)
+# TODO: add validation tests that use tc tool from package before cleanup

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,13 @@ help:
 	@echo "             pytest -m ''"
 	@echo "tctest     : generate report for and cleanup after"
 	@echo "             tc --test"
+	@echo "cstest     : generate coding-style reports using"
+	@echo "             pycodestyle and pylint tools"
 
 .PHONY=clean
-clean: clean-pyc clean-package
+clean:
 	@find . -name *pyc -exec rm {} \;
+	@find . -name *cache -maxdepth 1 -exec rm -r {} \;
 	@./conda.recipe/remove_local_taxcalc_package.sh
 
 .PHONY=package
@@ -64,4 +67,62 @@ endef
 tctest: package
 	tc --test
 	@$(tctest-cleanup)
-# TODO: add validation tests that use tc tool from package before cleanup
+	@echo "validation tests using tc will be added in the future"
+
+# TAXCALC_JSONFILES list is constructed using the following command:
+# tax-calculator$ ls -l ./taxcalc/*json | awk '{print $9}'
+TAXCALC_JSONFILES = ./taxcalc/behavior.json \
+	./taxcalc/consumption.json \
+	./taxcalc/current_law_policy.json \
+	./taxcalc/growdiff.json \
+	./taxcalc/growmodel.json \
+	./taxcalc/records_variables.json
+
+# PYLINT_FILES list is constructed using the following command:
+# tax-calculator$ grep -rl --include="*py" disable=locally-disabled .
+PYLINT_FILES = ./docs/cookbook/make_cookbook.py \
+	./docs/cookbook/test_recipes.py \
+	./docs/make_index.py \
+	./puf_fuzz.py \
+	./simtax.py \
+	./taxcalc/behavior.py \
+	./taxcalc/calculate.py \
+	./taxcalc/cli/tc.py \
+	./taxcalc/consumption.py \
+	./taxcalc/decorators.py \
+	./taxcalc/functions.py \
+	./taxcalc/growdiff.py \
+	./taxcalc/growfactors.py \
+	./taxcalc/growmodel.py \
+	./taxcalc/macro_elasticity.py \
+	./taxcalc/policy.py \
+	./taxcalc/records.py \
+	./taxcalc/simpletaxio.py \
+	./taxcalc/taxcalcio.py \
+	./taxcalc/tbi/tbi.py \
+	./taxcalc/tbi/tbi_utils.py \
+	./taxcalc/tests/test_4package.py \
+	./taxcalc/tests/test_compare.py \
+	./taxcalc/tests/test_compatible_data.py \
+	./taxcalc/tests/test_cpscsv.py \
+	./taxcalc/tests/test_docs.py \
+	./taxcalc/tests/test_functions.py \
+	./taxcalc/tests/test_growfactors.py \
+	./taxcalc/tests/test_macro_elasticity.py \
+	./taxcalc/tests/test_parameters.py \
+	./taxcalc/tests/test_puf_var_stats.py \
+	./taxcalc/tests/test_pufcsv.py \
+	./taxcalc/tests/test_reforms.py \
+	./taxcalc/tests/test_responses.py \
+	./taxcalc/tests/test_simpletaxio.py \
+	./taxcalc/tests/test_taxcalcio.py \
+	./taxcalc/tests/test_utils.py \
+	./taxcalc/utils.py \
+	./taxcalc/utilsprvt.py \
+	./taxcalc/validation/csv_taxdiffs.py
+
+.PHONY=cstest
+cstest:
+	pycodestyle taxcalc
+	@pycodestyle --ignore=E501,E121 $(TAXCALC_JSONFILES)
+	@pylint --disable=locally-disabled --score=no --jobs=4 $(PYLINT_FILES)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-# GNU Makefile that documents and automates common Tax-Calculator operations.
-# USAGE: tax-calculator$ make <TARGET>
+# GNU Makefile that documents and automates common Tax-Calculator operations
+#     using the GNU make tool (version >= 3.81)
+# USAGE: tax-calculator$ make [TARGET]
 
 .PHONY=help
 help:
-	@echo "HELP MSG"
+	@echo "USAGE: make [TARGET]"
+	@echo "TARGETS:"
+	@echo "  help : help description "
 
 .PHONY=clean-pyc
 clean-pyc:

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,15 @@
 help:
 	@echo "USAGE: make [TARGET]"
 	@echo "TARGETS:"
-	@echo "help    : show help message"
-	@echo "clean   : remove .pyc files, caches, and local taxcalc package"
+	@echo "help : show help message"
+	@echo "clean : remove .pyc files, caches, and local taxcalc package"
 	@echo "package : build and install local taxcalc package"
+	@echo "pytest-cps : generate report for and cleanup after"
+	@echo "             pytest -m 'not requires_pufcsv and not pre_release'"
+	@echo "pytest     : generate report for and cleanup after"
+	@echo "             pytest -m 'not pre_release'"
+	@echo "pytest-all : generate report for and cleanup after"
+	@echo "             pytest -m ''"
 
 .PHONY=clean-pyc
 clean-pyc:
@@ -28,3 +34,30 @@ clean: clean-pyc clean-caches clean-package
 .PHONY=package
 package:
 	@./conda.recipe/install_local_taxcalc_package.sh
+
+define pytest-cleanup
+find . -name *cache -maxdepth 1 -exec rm -rf {} \;
+rm -f df-??-#-*
+rm -f tmp??????-??-#-tmp*
+endef
+
+.PHONY=pytest-cps
+pytest-cps:
+	@cd taxcalc
+	@pytest -n4 -m "not requires_pufcsv and not pre_release"
+	@$(pytest-cleanup)
+	@cd ..
+
+.PHONY=pytest
+pytest:
+	@cd taxcalc
+	@pytest -n4 -m "not pre_release"
+	@$(pytest-cleanup)
+	@cd ..
+
+.PHONY=pytest-all
+pytest-all:
+	@cd taxcalc
+	@pytest -n4 -m ""
+	@$(pytest-cleanup)
+	@cd ..

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# GNU Makefile that documents and automates common Tax-Calculator operations.
+# USAGE: tax-calculator$ make <TARGET>
+
+.PHONY=help
+help:
+	@echo "HELP MSG"
+
+.PHONY=clean-pyc
+clean-pyc:
+	@find . -name *pyc -exec rm -f {} \;
+
+.PHONY=clean-cache
+clean-cache:
+	@find . -name *cache -maxdepth 1 -exec rm -rf {} \;
+
+.PHONY=clean-package
+clean-package:
+	@./conda.recipe/remove_local_taxcalc_package.sh
+
+.PHONY=clean
+clean: clean-pyc clean-cache clean-package

--- a/conda.recipe/install_local_taxcalc_package.sh
+++ b/conda.recipe/install_local_taxcalc_package.sh
@@ -53,15 +53,15 @@ conda install taxcalc=0.0.0 --use-local --yes 2>&1 > /dev/null
 # clean-up after package build
 echo "CLEAN-UP..."
 conda build purge
-cd ..
-rm -fr build/*
+topdir=$(git rev-parse --show-toplevel)
+pushd $topdir > /dev/null
+rm -rf build/*
 rmdir build/
-rm -fr dist/*
+rm -rf dist/*
 rmdir dist/
-rm -fr taxcalc.egg-info/*
+rm -rf taxcalc.egg-info/*
 rmdir taxcalc.egg-info/
-
-echo "Execute './remove_local_taxcalc_package.sh' after using taxcalc package"
+popd > /dev/null
 
 echo "FINISHED : `date`"
 exit 0

--- a/conda.recipe/install_local_taxcalc_package.sh
+++ b/conda.recipe/install_local_taxcalc_package.sh
@@ -61,7 +61,7 @@ rmdir dist/
 rm -fr taxcalc.egg-info/*
 rmdir taxcalc.egg-info/
 
-echo "Execute 'conda uninstall taxcalc --yes' after using taxcalc package"
+echo "Execute './remove_local_taxcalc_package.sh' after using taxcalc package"
 
 echo "FINISHED : `date`"
 exit 0

--- a/conda.recipe/remove_local_taxcalc_package.sh
+++ b/conda.recipe/remove_local_taxcalc_package.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# USAGE: ./remove_local_taxcalc_package.sh
+# ACTION: (1) uninstalls any installed taxcalc package (conda uninstall)
+# NOTE: for those with experience working with compiled languages,
+#       removing a local conda package is analogous to a "make clean" operation
+
+# uninstall any existing taxcalc conda package
+conda list taxcalc | awk '$1~/taxcalc/{rc=1}END{exit(rc)}'
+if [ $? -eq 1 ]; then
+    conda uninstall taxcalc --yes 2>&1 > /dev/null
+fi
+
+exit 0

--- a/docs/cookbook/recipe01.py
+++ b/docs/cookbook/recipe01.py
@@ -1,6 +1,6 @@
 from __future__ import print_function  # necessary only if using Python 2.7
 from taxcalc import *
-import urllib as url_lib  # on Python 3.6 use "import urllib.request as url_lib"
+import urllib as url_lib  # Python 3.6 uses "import urllib.request as url_lib"
 
 # read two "old" reform files from Tax-Calculator website
 # ("old" means the reform files are defined relative to pre-TCJA policy)

--- a/docs/cookbook/recipe04.py
+++ b/docs/cookbook/recipe04.py
@@ -47,7 +47,7 @@ vdf['atinc2'] = calc2.array('aftertax_income')
 # (note earnings groups are just an example based on no empirical results)
 earnings_bins = [-9e99, 50e3, 9e99]  # two groups: below and above $50,000
 vdf = add_income_table_row_variable(vdf, 'e00200', earnings_bins)
-gbydf = vdf.groupby('table_row', as_index=False) 
+gbydf = vdf.groupby('table_row', as_index=False)
 
 # compute percentage response in charitable giving
 # (note elasticity values are just an example based on no empirical results)

--- a/gitpr
+++ b/gitpr
@@ -1,0 +1,19 @@
+#!/bin/bash
+# stop if not on master branch of local git repo
+git branch | awk '$1~/\*/{if($2~/master/){exit 0}else{exit 1}}'
+if [[ $? -ne 0 ]] ; then
+    echo "STOP: not on master branch of local git repo"
+    exit 1
+fi
+# check manditory command-line argument, which is the pull request number
+if [[ "$#" -ne 1 ]]; then
+    echo "ERROR: must specify exactly one command-line argument,"
+    echo "       the pull request number, NUM"
+    exit 1
+fi
+NUM=$1
+# create local branch containing upstream pull request with NUM
+git fetch upstream pull/$NUM/head:pr-$NUM
+git checkout pr-$NUM
+git status
+exit 0

--- a/gitsync
+++ b/gitsync
@@ -1,0 +1,12 @@
+#!/bin/bash
+# stop if not on master branch of local git repo
+git branch | awk '$1~/\*/{if($2~/master/){exit 0}else{exit 1}}'
+if [ $? -ne 0 ]; then
+    echo "STOP: not on master branch of local git repo"
+    exit 1
+fi
+# synchronize local git repo with central GitHub repo
+git fetch upstream
+git merge upstream/master
+git push origin master
+exit 0

--- a/read-the-docs/source/conf.py
+++ b/read-the-docs/source/conf.py
@@ -56,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Tax-Calculator'
-copyright = u'2017, Open Source Policy Center'
+copyright = u'2016-, Open Source Policy Center'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/simtax.py
+++ b/simtax.py
@@ -7,10 +7,6 @@ SIMple input-output capabilities for TAX-calculator used in validation work
 
 import argparse
 import sys
-import os
-import re
-import six
-import pandas as pd
 from taxcalc import SimpleTaxIO
 
 

--- a/taxcalc/tests/test_taxcalcio.py
+++ b/taxcalc/tests/test_taxcalcio.py
@@ -471,7 +471,6 @@ def test_output_options(rawinputfile, reformfile1, assumpfile1):
             except OSError:
                 pass  # sometimes we can't remove a generated temporary file
         assert 'TaxCalcIO.analyze(dump)_ok' == 'no'
-
     # --dump output with partial dump
     try:
         tcio.analyze(writing_output_file=True,
@@ -484,12 +483,12 @@ def test_output_options(rawinputfile, reformfile1, assumpfile1):
             except OSError:
                 pass  # sometimes we can't remove a generated temporary file
         assert 'TaxCalcIO.analyze(dump)_ok' == 'no'
-    # if tries were successful, remove output file and doc file
-    if os.path.isfile(outfilepath):
-        os.remove(outfilepath)
+    # if tries were successful, remove doc file and output file
     docfilepath = outfilepath.replace('.csv', '-doc.text')
     if os.path.isfile(docfilepath):
         os.remove(docfilepath)
+    if os.path.isfile(outfilepath):
+        os.remove(outfilepath)
 
 
 def test_write_doc_file(rawinputfile, reformfile1, assumpfile1):


### PR DESCRIPTION
This pull request adds a `Tax-Calculator/Makefile` that documents many common development operations, many of which are not documented elsewhere in the repository.  Using the GNU `make` tool to invoke operations in the Makefile makes it easier to conduct common development operations such as cleaning up files, installing and removing a local taxcalc package, conducting one of the three variants of the `pytest` suite, conducting tests of the `tc` tool (which cannot be included in the `pytest` suite), and conducting coding-style tests.  

More details on each of these operations can be obtained by entering, at the command line in the top directory of the repository, the command `make help` or simply `make`.  Here is what happens:
```
Tax-Calculator$ make
USAGE: make [TARGET]
TARGETS:
help       : show help message
clean      : remove .pyc files and local taxcalc package
package    : build and install local taxcalc package
pytest-cps : generate report for and cleanup after
             pytest -m 'not requires_pufcsv and not pre_release'
pytest     : generate report for and cleanup after
             pytest -m 'not pre_release'
pytest-all : generate report for and cleanup after
             pytest -m ''
tctest     : generate report for and cleanup after
             tc --test
cstest     : generate coding-style errors using the
             pycodestyle (nee pep8) and pylint tools
git-sync   : synchronize local, origin, and upstream Git repos
git-pr N=n : create local pr-n branch containing upstream PR
```
The GNU `make` command-line tool comes with Linux and Mac Xcode and can be downloaded and installed easily on Windows.  The `Tax-Calculator/Makefile` expects `make` version 3.81 or higher.  On a Mac after installing Xcode command-line utilities, we have this:
```
Tax-Calculator$ make --version
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for i386-apple-darwin11.3.0
```
