### PR TITLE
Simplify .gitignore contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 
 # Unit test / coverage reports
+*.pytest_cache/
 htmlcov/
 .coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__/
 *.py[cod]
 
 # Unit test / coverage reports
-*.pytest_cache/
+.pytest_cache/
 htmlcov/
 .coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,62 +2,15 @@
 __pycache__/
 *.py[cod]
 
-# C extensions
-*.so
-
-# Distribution / packaging
-test/
-.Python
-env/
-bin/
-build/
-develop-eggs/
-dist/
-eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
 # Unit test / coverage reports
 htmlcov/
-.tox/
 .coverage
-.cache
-nosetests.xml
-coverage.xml
-
-# Translations
-*.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
-
-# Django stuff:
-*.log
-*.pot
 
 # Sphinx documentation
 read-the-docs/_build/
 
-# Sublime
-*.sublime-*
-
 # Mac OS X
 *.DS_Store
 
-# ignore puf data files
+# IRS-SOI PUF data file
 puf.csv


### PR DESCRIPTION
This pull request removes a number of file types from the `.gitignore` file that are never used in Tax-Calculator development.  If it turns out that developers are using a removed file type and want git to ignore it in a `git status` command, then those developers can raise an issue asking for that file type's inclusion in `.gitignore`.