### PR TITLE
Make elderly_dependent plural and add Calculator.n65() method

### DIFF
--- a/puf_fuzz.py
+++ b/puf_fuzz.py
@@ -34,7 +34,7 @@ if DEBUG:
     DROP_VARS = set(['filer'])
 else:
     DROP_VARS = set(['filer', 's006', 'cmbtp',
-                     'nu05', 'nu13', 'elderly_dependent',
+                     'nu05', 'nu13', 'elderly_dependents',
                      'e09700', 'e09800', 'e09900', 'e11200'])
 
 # specify set of variables whose values are not to be randomized

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -252,6 +252,16 @@ class Calculator(object):
         setattr(self.__records, variable_name, variable_value)
         return None
 
+    def n65(self):
+        """
+        Return numpy ndarray containing the number of
+        individuals age 65+ in each filing unit.
+        """
+        vdf = self.dataframe(['age_head', 'age_spouse', 'elderly_dependents'])
+        return ((vdf.age_head >= 65).astype(int) +
+                (vdf.age_spouse >= 65).astype(int) +
+                vdf.elderly_dependents)
+
     def incarray(self, variable_name, variable_add):
         """
         Add variable_add to named variable in embedded Records object.

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -141,7 +141,7 @@ def EI_PayrollTax(SS_Earnings_c, e00200, e00200p, e00200s,
 
 
 @iterate_jit(nopython=True)
-def DependentCare(nu13, elderly_dependent, earned,
+def DependentCare(nu13, elderly_dependents, earned,
                   MARS, ALD_Dependents_thd, ALD_Dependents_hc,
                   ALD_Dependents_Child_c, ALD_Dependents_Elder_c,
                   care_deduction):
@@ -151,7 +151,7 @@ def DependentCare(nu13, elderly_dependent, earned,
     Parameters
     ----------
     nu13: Number of dependents under 13 years old
-    elderly_dependent: 1 if unit has an elderly dependent; 0 otherwise
+    elderly_dependents: number of elderly dependents
     earned: Form 2441 earned income amount
     MARS: Marital Status
     ALD_Dependents_thd: Maximum income to qualify for deduction
@@ -167,7 +167,7 @@ def DependentCare(nu13, elderly_dependent, earned,
     if earned <= ALD_Dependents_thd[MARS - 1]:
         care_deduction = (((1. - ALD_Dependents_hc) * nu13 *
                            ALD_Dependents_Child_c) +
-                          ((1. - ALD_Dependents_hc) * elderly_dependent *
+                          ((1. - ALD_Dependents_hc) * elderly_dependents *
                            ALD_Dependents_Elder_c))
     else:
         care_deduction = 0.

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -437,9 +437,9 @@
       "form": {"2013-2016": "8863 Part I line 10 and 8863 Part III line 31"},
       "availability": "taxdata_puf"
     },
-    "elderly_dependent": {
+    "elderly_dependents": {
       "type": "int",
-      "desc": "1 if filing unit has a dependent age 65+; otherwise 0",
+      "desc": "number of dependents age 65+ in filing unit excluding taxpayer and spouse",
       "form": {"2013-2016": "imputed from CPS data; not used in tax law"},
       "availability": "taxdata_puf, taxdata_cps"
     },

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -973,3 +973,9 @@ def test_privacy_of_embedded_objects(cps_subsample):
         cyr = calc.__consumption.current_year
     with pytest.raises(AttributeError):
         cyr = calc.__behavior.current_year
+
+
+def test_n65(cps_subsample):
+    recs = Records.cps_constructor(data=cps_subsample, no_benefits=True)
+    calc = Calculator(policy=Policy(), records=recs)
+    assert calc.n65().sum() > 1500


### PR DESCRIPTION
This pull request is being submitted in anticipation of new CPS and PUF input data files that include the variable `elderly_dependents` (rather than the `elderly_dependent` dummy variable in the current input data files).  For details on this change, see [this comment](https://github.com/open-source-economics/taxdata/issues/243#issuecomment-403908416) in taxdata issue 243.

Because those new CPS and PUF input data files are not yet available, this pull request does not pass all the tests.

@MaxGhenis @andersonfrailey 
