### PR TITLE
Make 'tc --version' report 'Tax-Calculator locally.generated.package' when appropriate

### DIFF
--- a/taxcalc/cli/tc.py
+++ b/taxcalc/cli/tc.py
@@ -140,7 +140,10 @@ def cli_tc_main():
     args = parser.parse_args()
     # show Tax-Calculator version and quit if --version option specified
     if args.version:
-        sys.stdout.write('Tax-Calculator {}\n'.format(tc.__version__))
+        version = tc.__version__
+        if version == 'unknown':
+            version = 'locally.generated.package'
+        sys.stdout.write('Tax-Calculator {}\n'.format(version))
         return 0
     # write test input and expected output files if --test option specified
     if args.test:


### PR DESCRIPTION
A cosmetic change to the `tc --version` logic.