### PR TITLE
Broaden scope of 'make cstest' and fix taxcalc/tests/reforms.json format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ tctest: package
 	@echo "validation tests using tc will be added in the future"
 
 TAXCALC_JSON_FILES := $(shell ls -l ./taxcalc/*json | awk '{print $$9}')
+TESTS_JSON_FILES := $(shell ls -l ./taxcalc/tests/*json | awk '{print $$9}')
 PYLINT_FILES := $(shell grep -rl --include="*py" disable=locally-disabled .)
 
 .PHONY=cstest
@@ -77,6 +78,7 @@ cstest:
 	pycodestyle taxcalc
 	pycodestyle docs/cookbook
 	@pycodestyle --ignore=E501,E121 $(TAXCALC_JSON_FILES)
+	@pycodestyle --ignore=E501,E121 $(TESTS_JSON_FILES)
 	@pylint --disable=locally-disabled --score=no --jobs=4 $(PYLINT_FILES)
 
 define coverage-cleanup

--- a/taxcalc/tests/reforms.json
+++ b/taxcalc/tests/reforms.json
@@ -70,7 +70,6 @@
       "output_type": "iitax",
       "compare_with": {"Tax Expenditure": [8.7, 10.0, 11.4, 16.2]},
       "expected": "Tax-Calculator,7.0,7.3,7.3,7.5"
-                                  
   },
 
   "8": {
@@ -641,7 +640,7 @@
       "output_type": "iitax",
       "compare_with": {},
       "expected": "Tax-Calculator,0.0,-31.5,-34.4,-37.2"
-  }, 
+  },
 
   "59": {
       "baseline": "2017_law.json",


### PR DESCRIPTION
Cosmetic changes only.
Thanks, @derrickchoe, for pointing out these coding-style problems in the `reforms.json` file.