### PR TITLE
Add "What's New" notice that Tax-Calculator 0.20.3 is last Python 2.7 release

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,6 +43,8 @@ previously visited pages.</i></p>
 
 <p><a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md#2018-09-06-release-0203">Both CPS and PUF data improvements</a>
 are available in Tax-Calculator release 0.20.3 and higher.
+<b>Note that release 0.20.3 is the last release that will be compatible
+with Python 2.7; subsequest releases will run only with Python 3.6.</b>
 
 <p><a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md#2018-05-18-release-0200">Flexible <kbd>quantity_response</kbd>
 utility function</a> is available in Tax-Calculator release 0.20.0 and

--- a/docs/index.htmx
+++ b/docs/index.htmx
@@ -42,6 +42,8 @@ previously visited pages.</i></p>
 
 <p><a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md#2018-09-06-release-0203">Both CPS and PUF data improvements</a>
 are available in Tax-Calculator release 0.20.3 and higher.
+<b>Note that release 0.20.3 is the last release that will be compatible
+with Python 2.7; subsequest releases will run only with Python 3.6.</b>
 
 <p><a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md#2018-05-18-release-0200">Flexible <kbd>quantity_response</kbd>
 utility function</a> is available in Tax-Calculator release 0.20.0 and


### PR DESCRIPTION
The next Tax-Calculator release will be 0.21.0 and the release notes for that version will include an **API Change** that says it is compatible with **only** Python 3.6.

Incompatibilities in the pandas library for Python 2.7 and Python 3.6 make it extremely difficult to make Tax-Calculator code and Cookbook recipes be compatible with both Python 2.7 and Python 3.6.  We've been warning for many months that support for Python 2.7 was ending soon and that Tax-Calculator users should upgrade to Python 3.6 as soon as possible.  The 0.20.3 release, which is compatible with Python 2.7, will remain available to users who have not upgraded to Python 3.6.