### PR TITLE
fix developer docs build fail

### DIFF
--- a/read-the-docs/source/conf.py
+++ b/read-the-docs/source/conf.py
@@ -118,6 +118,9 @@ else:
 class Mock(MagicMock):
     @classmethod
     def __getattr__(cls, name):
+        if name == "_mock_methods":
+            return name._mock_methods
+        else:
             return Mock()
 
 MOCK_MODULES = ['numba', 'numba.jit', 'numba.vectorize', 'numba.guvectorize']


### PR DESCRIPTION
@martinholmer reported in an email to me and @andersonfrailey that our developer documentation at [taxcalc.readthedocs.io](taxcalc.readthedocs.io) was out dated because the builds were failing between 0.20.1 and 0.20.2. 

This PR aims to fix that problem. Before this PR, the Sphinx docs were not able to build locally, now they are. Thanks to @ifedapoolarewaju for showing how to do this with https://github.com/geoalchemy/geoalchemy2/pull/148. 

I have not tested this at readthedocs.io yet because it would be somewhat troublesome, so we will be testing with this commit to master. 

