### PR TITLE
Add 'pip install pyyaml' to .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - source activate taxcalc-dev
   - conda env update -f environment.yml
   - if [ $TRAVIS_EVENT_TYPE == 'cron' ]; then conda remove numba; fi
+  - pip install pyyaml
   - pip install pytest-pep8
   - pip install coverage
   - pip install codecov

--- a/taxcalc/tests/test_4package.py
+++ b/taxcalc/tests/test_4package.py
@@ -17,7 +17,7 @@ def test_for_package_existence():
     """
     Ensure that no conda taxcalc package is installed when running pytest.
     Primarily to help developers catch mistaken installations of taxcalc;
-    the pre_release mark prevents test from running on GitHub.
+    the local mark prevents test from running on GitHub.
     """
     out = subprocess.check_output(['conda', 'list', 'taxcalc']).decode('ascii')
     envless_out = out.replace('taxcalc-dev', 'environment')


### PR DESCRIPTION
Just to make sure Travis-CI has access to this package (which is used in the `test_4package.py` file) when runing the tests at GitHub check-in.