### PR TITLE
Rename functions.py as calcfunctions.py in the .coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 omit =
     taxcalc/_version.py
-    taxcalc/functions.py
+    taxcalc/calcfunctions.py
     taxcalc/*.json
     taxcalc/cli/*
     taxcalc/tbi/*


### PR DESCRIPTION
Change that should have been part of pull request #2068.