### PR TITLE
Move code out of calculator.py & parameters.py into new json2dict utility function

### DIFF
--- a/docs/make_index.py
+++ b/docs/make_index.py
@@ -151,7 +151,7 @@ def policy_params(path, text):
     # pylint: disable=too-many-locals
     with open(path) as pfile:
         json_text = pfile.read()
-    params = json2dict(json_text, ordered_dict=True)
+    params = json2dict(json_text)
     assert isinstance(params, OrderedDict)
     # construct section dict containing sec1_sec2 titles
     concat_str = ' @ '
@@ -266,7 +266,7 @@ def assumption_params(ptype, path, text):
     """
     with open(path) as pfile:
         json_text = pfile.read()
-    params = json2dict(json_text, ordered_dict=True)
+    params = json2dict(json_text)
     assert isinstance(params, OrderedDict)
     # construct parameter text for each param
     ptext = ''

--- a/docs/make_index.py
+++ b/docs/make_index.py
@@ -3,17 +3,16 @@ Reads skeletal index.htmx file and writes fleshed-out index.html file
 containing information from several JSON files.
 """
 # CODING-STYLE CHECKS:
-# pycodestyle make_index.py
+# pycodestyle --ignore=E402 make_index.py
 # pylint --disable=locally-disabled make_index.py
 
 import os
 import sys
-import json
 from collections import OrderedDict
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, '..'))
 # pylint: disable=import-error,wrong-import-position
-from taxcalc import Policy
+from taxcalc import Policy, json2dict
 
 
 INPUT_FILENAME = 'index.htmx'
@@ -149,8 +148,10 @@ def policy_params(path, text):
     Read policy parameters from path, integrate them into text, and
     return the integrated text.
     """
+    # pylint: disable=too-many-locals
     with open(path) as pfile:
-        params = json.load(pfile, object_pairs_hook=OrderedDict)
+        json_text = pfile.read()
+    params = json2dict(json_text, ordered_dict=True)
     assert isinstance(params, OrderedDict)
     # construct section dict containing sec1_sec2 titles
     concat_str = ' @ '
@@ -212,7 +213,8 @@ def io_variables(iotype, path, text):
     from path, integrate them into text, and return the integrated text.
     """
     with open(path) as vfile:
-        variables = json.load(vfile)
+        json_text = vfile.read()
+    variables = json2dict(json_text)
     assert isinstance(variables, dict)
     # construct variable text
     vtext = ''
@@ -263,7 +265,8 @@ def assumption_params(ptype, path, text):
     and return the integrated text.
     """
     with open(path) as pfile:
-        params = json.load(pfile, object_pairs_hook=OrderedDict)
+        json_text = pfile.read()
+    params = json2dict(json_text, ordered_dict=True)
     assert isinstance(params, OrderedDict)
     # construct parameter text for each param
     ptext = ''

--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -8,7 +8,6 @@ Tax-Calculator federal tax Calculator class.
 # pylint: disable=invalid-name,no-value-for-parameter,too-many-lines
 
 import os
-import json
 import re
 import copy
 import numpy as np
@@ -32,7 +31,8 @@ from taxcalc.consumption import Consumption
 from taxcalc.behavior import Behavior
 from taxcalc.growdiff import GrowDiff
 from taxcalc.growfactors import GrowFactors
-from taxcalc.utils import (DIST_VARIABLES, create_distribution_table,
+from taxcalc.utils import (json2dict,
+                           DIST_VARIABLES, create_distribution_table,
                            DIFF_VARIABLES, create_difference_table,
                            create_diagnostic_table,
                            ce_aftertax_expanded_income,
@@ -1513,22 +1513,7 @@ class Calculator(object):
         # strip out //-comments without changing line numbers
         json_str = re.sub('//.*', ' ', text_string)
         # convert JSON text into a Python dictionary
-        try:
-            raw_dict = json.loads(json_str)
-        except ValueError as valerr:
-            msg = 'Policy reform text below contains invalid JSON:\n'
-            msg += str(valerr) + '\n'
-            msg += 'Above location of the first error may be approximate.\n'
-            msg += 'The invalid JSON reform text is between the lines:\n'
-            bline = 'XX----.----1----.----2----.----3----.----4'
-            bline += '----.----5----.----6----.----7'
-            msg += bline + '\n'
-            linenum = 0
-            for line in json_str.split('\n'):
-                linenum += 1
-                msg += '{:02d}{}'.format(linenum, line) + '\n'
-            msg += bline + '\n'
-            raise ValueError(msg)
+        raw_dict = json2dict(json_str)
         # check key contents of dictionary
         actual_keys = set(raw_dict.keys())
         missing_keys = Calculator.REQUIRED_REFORM_KEYS - actual_keys
@@ -1583,22 +1568,7 @@ class Calculator(object):
         # strip out //-comments without changing line numbers
         json_str = re.sub('//.*', ' ', text_string)
         # convert JSON text into a Python dictionary
-        try:
-            raw_dict = json.loads(json_str)
-        except ValueError as valerr:
-            msg = 'Economic assumption text below contains invalid JSON:\n'
-            msg += str(valerr) + '\n'
-            msg += 'Above location of the first error may be approximate.\n'
-            msg += 'The invalid JSON asssump text is between the lines:\n'
-            bline = 'XX----.----1----.----2----.----3----.----4'
-            bline += '----.----5----.----6----.----7'
-            msg += bline + '\n'
-            linenum = 0
-            for line in json_str.split('\n'):
-                linenum += 1
-                msg += '{:02d}{}'.format(linenum, line) + '\n'
-            msg += bline + '\n'
-            raise ValueError(msg)
+        raw_dict = json2dict(json_str)
         # check key contents of dictionary
         actual_keys = set(raw_dict.keys())
         missing_keys = Calculator.REQUIRED_ASSUMP_KEYS - actual_keys

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -335,7 +335,7 @@ class ParametersBase(object):
         if os.path.exists(path):
             with open(path) as pfile:
                 json_text = pfile.read()
-            params_dict = json2dict(json_text, ordered_dict=True)
+            params_dict = json2dict(json_text)
         else:
             # cannot call read_egg_ function in unit tests
             params_dict = read_egg_json(

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -7,9 +7,8 @@ Tax-Calculator abstract base parameters class.
 import os
 import json
 import abc
-import collections as collect
 import numpy as np
-from taxcalc.utils import read_egg_json
+from taxcalc.utils import read_egg_json, json2dict
 
 
 class ParametersBase(object):
@@ -335,8 +334,8 @@ class ParametersBase(object):
                             cls.DEFAULTS_FILENAME)
         if os.path.exists(path):
             with open(path) as pfile:
-                params_dict = json.load(pfile,
-                                        object_pairs_hook=collect.OrderedDict)
+                json_text = pfile.read()
+            params_dict = json2dict(json_text, ordered_dict=True)
         else:
             # cannot call read_egg_ function in unit tests
             params_dict = read_egg_json(

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -6,11 +6,10 @@ Tax-Calculator tax-filing-unit Records class.
 # pylint --disable=locally-disabled records.py
 
 import os
-import json
 import numpy as np
 import pandas as pd
 from taxcalc.growfactors import GrowFactors
-from taxcalc.utils import read_egg_csv, read_egg_json
+from taxcalc.utils import read_egg_csv, read_egg_json, json2dict
 
 
 class Records(object):
@@ -259,7 +258,8 @@ class Records(object):
                                      Records.VAR_INFO_FILENAME)
         if os.path.exists(var_info_path):
             with open(var_info_path) as vfile:
-                vardict = json.load(vfile)
+                json_text = vfile.read()
+            vardict = json2dict(json_text)
         else:
             # cannot call read_egg_ function in unit tests
             vardict = read_egg_json(

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1735,17 +1735,14 @@ def quantity_response(quantity,
     return response
 
 
-def json2dict(json_text, ordered_dict=False):
+def json2dict(json_text):
     """
-    Convert specified JSON text into a (regular or ordered) Python dictionary.
+    Convert specified JSON text into an ordered Python dictionary.
 
     Parameters
     ----------
     json_text: string
         JSON text.
-
-    ordered_dict: boolean
-        whether or not to return ordered dictionary.
 
     Raises
     ------
@@ -1754,15 +1751,12 @@ def json2dict(json_text, ordered_dict=False):
 
     Returns
     -------
-    dictionary: dict/OrderedDict
-        JSON data expressed as a (regular or ordered) Python dictionary.
+    dictionary: collections.OrderedDict
+        JSON data expressed as an ordered Python dictionary.
     """
     try:
-        if ordered_dict:
-            raw_dict = json.loads(json_text,
+        ordered_dict = json.loads(json_text,
                                   object_pairs_hook=collections.OrderedDict)
-        else:
-            raw_dict = json.loads(json_text)
     except ValueError as valerr:
         text_lines = json_text.split('\n')
         msg = 'Text below contains invalid JSON:\n'
@@ -1778,4 +1772,4 @@ def json2dict(json_text, ordered_dict=False):
             msg += '{:04d}{}'.format(linenum, line) + '\n'
         msg += bline + '\n'
         raise ValueError(msg)
-    return raw_dict
+    return ordered_dict

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1733,3 +1733,49 @@ def quantity_response(quantity,
     pch_q = price_elasticity * pch_price + income_elasticity * pch_income
     response = pch_q * quantity
     return response
+
+
+def json2dict(json_text, ordered_dict=False):
+    """
+    Convert specified JSON text into a dictionary.
+
+    Parameters
+    ----------
+    json_text: string
+        JSON text.
+
+    ordered_dict: boolean
+        whether or not to return ordered dictionary.
+
+    Raises
+    ------
+    ValueError:
+        if json_text contains a JSON syntax error.
+
+    Returns
+    -------
+    dictionary: dict
+        JSON data expressed as a (regular or ordered) Python dictionary.
+    """
+    try:
+        if ordered_dict:
+            raw_dict = json.loads(json_text,
+                                  object_pairs_hook=collections.OrderedDict)
+        else:
+            raw_dict = json.loads(json_text)
+    except ValueError as valerr:
+        text_lines = json_text.split('\n')
+        msg = 'Text below contains invalid JSON:\n'
+        msg += str(valerr) + '\n'
+        msg += 'Above location of the first error may be approximate.\n'
+        msg += 'The invalid JSON text is between the lines:\n'
+        bline = ('XXXX----.----1----.----2----.----3----.----4'
+                 '----.----5----.----6----.----7')
+        msg += bline + '\n'
+        linenum = 0
+        for line in text_lines:
+            linenum += 1
+            msg += '{:04d}{}'.format(linenum, line) + '\n'
+        msg += bline + '\n'
+        raise ValueError(msg)
+    return raw_dict

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -1737,7 +1737,7 @@ def quantity_response(quantity,
 
 def json2dict(json_text, ordered_dict=False):
     """
-    Convert specified JSON text into a dictionary.
+    Convert specified JSON text into a (regular or ordered) Python dictionary.
 
     Parameters
     ----------
@@ -1754,7 +1754,7 @@ def json2dict(json_text, ordered_dict=False):
 
     Returns
     -------
-    dictionary: dict
+    dictionary: dict/OrderedDict
         JSON data expressed as a (regular or ordered) Python dictionary.
     """
     try:


### PR DESCRIPTION
This pull request adds a new utility function, `json2dict`, that is used to read all JSON text files.  These changes not only consolidate duplicate code, but also provide built-in JSON syntax error detection when reading the six `taxcalc/*.json` files.