### PR TITLE
Improve links to Markdown documentation files

### DIFF
--- a/ODD_RECORDS.md
+++ b/ODD_RECORDS.md
@@ -1,13 +1,13 @@
 Odd Tax Records
 ===============
 
-Tax-Calculator is capable of dealing with large amounts of input
-data, so long as each filing unit has variable names that are in the
+Tax-Calculator is capable of dealing with large amounts of input data,
+so long as each filing unit has variable names that are in the
 `USABLE_READ_VARS` set in the [records.py
 file](https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/records.py).
-More details about data input requirements can be found here in the
-[DATAPREP.md
-file](https://github.com/open-source-economics/Tax-Calculator/blob/master/DATAPREP.md).
+More details about data input requirements can be found in the
+[data-preparation
+documentation](https://github.com/open-source-economics/Tax-Calculator/blob/master/DATAPREP.md#tax-calculator-input-file-preparation-guidelines).
 
 Thanks to such capability, we are able to test the current tax logic
 with as many "extreme" units as we want, and thus are able to find

--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ If you want to **propose code changes**, follow the directions in the
 Guide](http://taxcalc.readthedocs.io/en/latest/contributor_guide.html)
 on how to fork and clone the Tax-Calculator git repository.  Before
 developing any code changes be sure to read completely the Contributor
-Guide and then read about the [pull-request workflow](WORKFLOW.md).
-The Tax-Calculator [release history](RELEASES.md) provides a
-high-level summary of past pull requests and access to a complete list
-of merged, closed, and pending pull requests.
+Guide and then read about the [pull-request
+workflow](https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow).
+The Tax-Calculator [release
+history](https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md#tax-calculator-release-history)
+provides a high-level summary of past pull requests and access to a
+complete list of merged, closed, and pending pull requests.
 
 If you are relying on Tax-Calculator capabilities in your own project,
 be sure to read the definition of the [Tax-Calculator Public

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Developing Tax-Calculator
 =========================
 
 This document tells you how to begin contributing to Tax-Calculator by
-reporting a bug, improving the documentation or making an enhancement
-to the Python source code.  If you only want to use Tax-Calculator,
+reporting a bug, improving the documentation, or making an enhancement
+to the Python source code.  If you only want to **use** Tax-Calculator,
 you should begin by reading the [user
 documentation](http://open-source-economics.github.io/Tax-Calculator/)
 that describes how to use Tax-Calculator on your own computer (without

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![Python 3.6.5](https://img.shields.io/badge/python-3.6.5-blue.svg)](https://www.python.org/downloads/release/python-365/)
 [![Build Status](https://travis-ci.org/open-source-economics/Tax-Calculator.svg?branch=master)](https://travis-ci.org/open-source-economics/Tax-Calculator)
 [![Codecov](https://codecov.io/gh/open-source-economics/Tax-Calculator/branch/master/graph/badge.svg)](https://codecov.io/gh/open-source-economics/Tax-Calculator)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -14,9 +14,10 @@ to your GitHub account, and have cloned that forked copy to your local
 computer.
 
 This document also assumes that you have read the [pull-request
-workflow](WORKFLOW.md) document so that you understand where the
-testing procedures fit into the broader workflow of preparing a
-pull request that changes Tax-Calculator source code.
+workflow](https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow)
+document so that you understand where the testing procedures fit into
+the broader workflow of preparing a pull request that changes
+Tax-Calculator source code.
 
 Currently there are two phases of testing.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -62,8 +62,8 @@ the file in place of `NEWNAME`).
 
 5. Next test your proposed source-code changes in two ways: for coding
 style and for substantive results.  Read the documentation on [testing
-procedures](TESTING.md) for how to conduct these tests on your local
-computer.
+procedures](https://github.com/open-source-economics/Tax-Calculator/blob/master/TESTING.md#tax-calculator-testing-procedures)
+for how to conduct these tests on your local computer.
 
 6. When you have successfully tested your changes, commit the changes
 to your local repository by doing `git commit -a -m "MESSAGE"` (where

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,8 +18,6 @@ enhancement.
 Proposing code changes
 ----------------------
 In a new pull request, provide a clear description of the rationale
-and nature of the code changes.  Make sure that your proposed changes
-are consistent with our [coding
-style](https://github.com/open-source-economics/Tax-Calculator/blob/master/CODING.md)
-and our [testing
-procedures](https://github.com/open-source-economics/Tax-Calculator/blob/master/TESTING.md).
+and nature of the code changes.  Make sure that you prepare your pull
+request using the [suggested workflow and testing
+procedures](https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow).

--- a/read-the-docs/source/contributor_guide.rst
+++ b/read-the-docs/source/contributor_guide.rst
@@ -217,7 +217,9 @@ situations, in which case other contributors are here to help.
    your newly added code.  Add tests so that the number of untested
    statements is the same as it is on the master branch.
 
+You should now read the more `detailed pull-request workflow`_ document.
 
+   
 Simple Usage
 ------------
 
@@ -303,3 +305,6 @@ interpreter or imported into a Python notebook for interactive execution.
 
 .. _`Cookbook of Tested Recipes for Python Programming with Tax-Calculator`:
    https://github.com/open-source-economics/Tax-Calculator/blob/master/docs/cookbook.html
+
+.. _`detailed pull-request workflow`:
+   https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow

--- a/taxcalc/assumptions/ASSUMPTIONS.md
+++ b/taxcalc/assumptions/ASSUMPTIONS.md
@@ -81,8 +81,8 @@ GrowModel parameter values:
 
 The rules about structuring a non-empty value for a top-level key are
 the same as for policy reform files, which are described
-[here](../reforms/REFORMS.md).  The assumption parameter names
-recognized by Tax-Calculator, and there default values, are listed in
-[this
+[here](https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/reforms/REFORMS.md#how-to-specify-a-tax-reform-in-a-json-policy-reform-file).
+The assumption parameter names recognized by Tax-Calculator, and there
+default values, are listed in [this
 section](http://open-source-economics.github.io/Tax-Calculator/index.html#params)
 of the user documentation.

--- a/taxcalc/assumptions/README.md
+++ b/taxcalc/assumptions/README.md
@@ -9,5 +9,7 @@ the tc CLI (command-line interface) to Tax-Calculator, as described in
 the [user
 documentation](http://open-source-economics.github.io/Tax-Calculator/index.html#cli).
 
-[This document](ASSUMPTIONS.md) provides access to a template
-economic assumption filea and guidelines about their preparation.
+[This
+document](https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/assumptions/ASSUMPTIONS.md#how-to-specify-economic-assumptions-in-a-json-assumption-file)
+provides access to a template economic assumption files and guidelines
+about their preparation.

--- a/taxcalc/reforms/README.md
+++ b/taxcalc/reforms/README.md
@@ -8,5 +8,7 @@ analyzed on your local computer using the tc CLI (command-line
 interface) to Tax-Calculator, as described in the [user
 documentation](http://open-source-economics.github.io/Tax-Calculator/index.html#cli).
 
-[This document](REFORMS.md) provides access to several reform files
-that represent recent tax reform proposals.
+[This
+document](https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/reforms/REFORMS.md#how-to-specify-a-tax-reform-in-a-json-policy-reform-file)
+provides access to several reform files that represent recent tax
+reform proposals.

--- a/taxcalc/validation/README.md
+++ b/taxcalc/validation/README.md
@@ -49,7 +49,7 @@ four-step process are provided in a different sub-directory for each
 other model.  Here are links to the cross-model validation results
 that are currently available:
 
-[Internet-TAXSIM](taxsim/README.md)
+[Internet-TAXSIM](https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/validation/taxsim/README.md#validation-of-tax-calculator-against-internet-taxsim)
 
 [...]()
 

--- a/taxcalc/validation/taxsim/README.md
+++ b/taxcalc/validation/taxsim/README.md
@@ -1,9 +1,11 @@
 Validation of Tax-Calculator against Internet-TAXSIM
 ====================================================
 
-The cross-model validation process described [here](../README.md) has used
+The cross-model validation process described
+[here](https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/validation/README.md#validation-of-tax-calculator-logic)
+has used
 [Internet-TAXSIM](http://users.nber.org/~taxsim/taxsim-calc9/index.html)
-to generate step-three results.  
+to generate step-three results.
 
 We are in the process of comparing Tax-Calculator and Internet-TAXSIM
 results generated from the `a` and `d` assumption sets in the


### PR DESCRIPTION
This pull request makes changes only in several `*.md` documentation files.
There are no changes in tax calculation logic or results.