### PR TITLE
Add top-level JSON files to cstest target in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 # command to run tests
 script:
-  - python -c "import taxcalc"; coverage run -m py.test -v -m "not requires_pufcsv and not pre_release and not local" --pep8
+  - python -c "import taxcalc"; coverage run -m pytest -v -m "not requires_pufcsv and not pre_release and not local" --pep8
 
 after_success:
   - codecov

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 	@echo "TARGETS:"
 	@echo "help       : show help message"
 	@echo "clean      : remove .pyc files and local taxcalc package"
-	@echo "package    : build and install local taxcalc package"
+	@echo "package    : build and install local package"
 	@echo "pytest-cps : generate report for and cleanup after"
 	@echo "             pytest -m 'not requires_pufcsv and not pre_release'"
 	@echo "pytest     : generate report for and cleanup after"
@@ -30,11 +30,11 @@ help:
 clean:
 	@find . -name *pyc -exec rm {} \;
 	@find . -name *cache -maxdepth 1 -exec rm -r {} \;
-	@./conda.recipe/remove_local_taxcalc_package.sh
+	@./conda.recipe/remove_local_package.sh
 
 .PHONY=package
 package:
-	@./conda.recipe/install_local_taxcalc_package.sh
+	@cd conda.recipe ; ./install_local_package.sh
 
 define pytest-cleanup
 find . -name *cache -maxdepth 1 -exec rm -r {} \;
@@ -60,7 +60,7 @@ pytest-all:
 define tctest-cleanup
 rm -f test.csv
 rm -f test-18-*
-./conda.recipe/remove_local_taxcalc_package.sh	
+./conda.recipe/remove_local_package.sh
 endef
 
 .PHONY=tctest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Development is typically conducted on Linux or Max OS X (with the Xcode
 #              command-line tools installed), so this Makefile is designed
 #              to work in that environment (and not on Windows).
-# USAGE: tax-calculator$ make [TARGET]
+# USAGE: Tax-Calculator$ make [TARGET]
 
 .PHONY=help
 help:

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ tctest: package
 	@$(tctest-cleanup)
 	@echo "validation tests using tc will be added in the future"
 
+TOPLEVEL_JSON_FILES := $(shell ls -l ./*json | awk '{print $$9}')
 TAXCALC_JSON_FILES := $(shell ls -l ./taxcalc/*json | awk '{print $$9}')
 TESTS_JSON_FILES := $(shell ls -l ./taxcalc/tests/*json | awk '{print $$9}')
 PYLINT_FILES := $(shell grep -rl --include="*py" disable=locally-disabled .)
@@ -80,6 +81,7 @@ RECIPE_OPTIONS = --disable=C0103,C0111,W0401,W0614 --score=no --jobs=4
 cstest:
 	pycodestyle taxcalc
 	pycodestyle docs/cookbook
+	@pycodestyle --ignore=E501,E121 $(TOPLEVEL_JSON_FILES)
 	@pycodestyle --ignore=E501,E121 $(TAXCALC_JSON_FILES)
 	@pycodestyle --ignore=E501,E121 $(TESTS_JSON_FILES)
 	@pylint $(PYLINT_OPTIONS) $(PYLINT_FILES)

--- a/conda.recipe/install_local_package.sh
+++ b/conda.recipe/install_local_package.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# USAGE: ./install_local_taxcalc_package.sh
-# ACTION: (1) uninstalls any installed taxcalc package (conda uninstall)
+# USAGE: ./install_local_package.sh
+# ACTION: (1) uninstalls any installed package (remove_local_package.sh)
 #         (2) executes "conda install conda-build" (if necessary)
 #         (3) builds local taxcalc=0.0.0 package (conda build)
-#         (4) installs local taxcalc=0.0.0 package (conda install)
+#         (4) installs local package (conda install)
 # NOTE: for those with experience working with compiled languages,
 #       building a local conda package is analogous to compiling an executable
 
@@ -11,13 +11,8 @@ echo "STARTING : `date`"
 
 echo "BUILD-PREP..."
 
-# uninstall any existing taxcalc conda package
-conda list taxcalc | awk '$1~/taxcalc/{rc=1}END{exit(rc)}'
-if [ $? -eq 1 ]; then
-    echo "==> Uninstalling existing taxcalc package"
-    conda uninstall taxcalc --yes 2>&1 > /dev/null
-    echo "==> Continuing to build new taxcalc package"
-fi
+# uninstall any installed package
+./remove_local_package.sh
 
 # check version of conda package
 conda list conda | awk '$1=="conda"{v=$2;gsub(/\./,"",v);nv=v+0;if(nv<444)rc=1}END{exit(rc)}'
@@ -35,12 +30,12 @@ if [ $? -eq 0 ]; then
     echo "==> Continuing to build new taxcalc package"
 fi
 
-# build taxcalc conda package for this version of Python
+# build conda package for this version of Python
 NOHASH=--old-build-string
 pversion=3.6
 conda build $NOHASH --python $pversion . 2>&1 | awk '$1~/BUILD/||$1~/TEST/'
 
-# install taxcalc conda package
+# install conda package
 echo "INSTALLATION..."
 conda install taxcalc=0.0.0 --use-local --yes 2>&1 > /dev/null
 # NOTE: the --use-local option was broken by conda 4.4.0 and fixed by 4.4.4

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -30,4 +30,4 @@ test:
     - tc --help
 
 about:
-  home: http://www.github.com/OpenSourcePolicyCenter
+  home: https://github.com/open-source-economics/Tax-Calculator

--- a/conda.recipe/remove_local_package.sh
+++ b/conda.recipe/remove_local_package.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# USAGE: ./remove_local_taxcalc_package.sh
+# USAGE: ./remove_local_package.sh
 # ACTION: (1) uninstalls any installed taxcalc package (conda uninstall)
 # NOTE: for those with experience working with compiled languages,
 #       removing a local conda package is analogous to a "make clean" operation

--- a/continuous_integration/build.cmd
+++ b/continuous_integration/build.cmd
@@ -2,5 +2,5 @@ call activate %CONDA_ENV%
 
 @echo on
 
-@rem Install taxcalc
+@rem Install code
 %PIP_INSTALL% --no-deps -e .[complete]

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ cmdclass = versioneer.get_cmdclass()
 
 config = {
     'description': 'Tax Calculator',
-    'url': 'https://github.com/OpenSourcePolicyCenter/Tax-Calculator',
-    'download_url': 'https://github.com/OpenSourcePolicyCenter/Tax-Calculator',
+    'url': 'https://github.com/open-source-economics/Tax-Calculator',
+    'download_url': 'https://github.com/open-source-economics/Tax-Calculator',
     'description': 'taxcalc',
     'long_description': longdesc,
     'version': version,

--- a/taxcalc/tests/test_calcfunctions.py
+++ b/taxcalc/tests/test_calcfunctions.py
@@ -16,7 +16,9 @@ class GetFuncDefs(ast.NodeVisitor):
     Return information about each function defined in the functions.py file.
     """
     def __init__(self):
-        """class constructor"""
+        """
+        GetFuncDefs class constructor
+        """
         self.fname = ''
         self.fnames = list()  # function name (fname) list
         self.fargs = dict()  # lists of function arguments indexed by fname
@@ -24,12 +26,16 @@ class GetFuncDefs(ast.NodeVisitor):
         self.rvars = dict()  # lists of function return vars indexed by fname
 
     def visit_Module(self, node):  # pylint: disable=invalid-name
-        """visit the one Module node"""
+        """
+        visit the specified Module node
+        """
         self.generic_visit(node)
         return (self.fnames, self.fargs, self.cvars, self.rvars)
 
     def visit_FunctionDef(self, node):  # pylint: disable=invalid-name
-        """visit FunctionDef node"""
+        """
+        visit the specified FunctionDef node
+        """
         self.fname = node.name
         self.fnames.append(self.fname)
         self.fargs[self.fname] = list()
@@ -47,7 +53,9 @@ class GetFuncDefs(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Return(self, node):  # pylint: disable=invalid-name
-        """visit Return node"""
+        """
+        visit the specified Return node
+        """
         if isinstance(node.value, ast.Tuple):
             self.rvars[self.fname] = [r_v.id for r_v in node.value.elts]
         elif isinstance(node.value, ast.BinOp):


### PR DESCRIPTION
This pull request adds to the Makefile `cstest` target another directory to look in for JSON files that need to be tested with `pycodestyle`.  This change is being made in anticipation of the addition of the `PSL_catalog.json` file to the top-level Tax-Calculator directory.