### PR TITLE
Add Records.read_cps_data() static method

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -292,6 +292,19 @@ class Records(object):
     CHANGING_CALCULATED_VARS = None
     INTEGER_VARS = None
 
+    @staticmethod
+    def read_cps_data():
+        """
+        Return data in cps.csv.gz as a Pandas DataFrame.
+        """
+        fname = os.path.join(Records.CUR_PATH, 'cps.csv.gz')
+        if os.path.isfile(fname):
+            cpsdf = pd.read_csv(fname)
+        else:
+            # cannot call read_egg_ function in unit tests
+            cpsdf = read_egg_csv(fname)  # pragma: no cover
+        return cpsdf
+
     # ----- begin private methods of Records class -----
 
     def _extrapolate(self, year):

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -48,6 +48,11 @@ def test_correct_Records_instantiation(cps_subsample):
     assert rec2.current_year == rec2.data_year
 
 
+def test_read_cps_data(cps_fullsample):
+    data = Records.read_cps_data()
+    assert data.equals(cps_fullsample)
+
+
 @pytest.mark.parametrize("csv", [
     (
         u'RECID,MARS,e00200,e00200p,e00200s\n'


### PR DESCRIPTION
This pull request adds a Records method that is useful in testing other models in the Policy Simulation Library collection of USA tax models.