### PR TITLE
Use package version style from conda cheat sheet

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,18 +8,18 @@ build:
 
 requirements:
   build:
-    - python >=3.6.5,<3.7
-    - numpy >=1.12.1
-    - pandas >=0.22.0
-    - bokeh >=0.12.3
+    - python=3.6
+    - "numpy>=1.13"
+    - "pandas>=0.22"
+    - "bokeh>=1.0"
     - numba
     - toolz
 
   run:
-    - python >=3.6.5,<3.7
-    - numpy >=1.12.1
-    - pandas >=0.22.0
-    - bokeh >=0.12.3
+    - python=3.6
+    - "numpy>=1.13"
+    - "pandas>=0.22"
+    - "bokeh>=1.0"
     - numba
     - toolz
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
 name: taxcalc-dev
 dependencies:
-- python >=3.6.5,<3.7
-- numpy >=1.12.1
-- pandas >=0.22.0
-- bokeh >=0.12.3
+- python=3.6
+- "numpy>=1.13"
+- "pandas>=0.22"
+- "bokeh>=1.0"
 - numba
 - toolz
 - pytest


### PR DESCRIPTION
This pull request changes the style of specifying package version requirements (in the `environment.yml` and `conda.recipe/meta.yaml` files) to be the same as the style specified in the [conda cheat sheet](https://conda.io/docs/_downloads/conda-cheatsheet.pdf). 