### PR TITLE
Clarify documentation of filer input variable

### DIFF
--- a/read-the-docs/source/public_api.rst
+++ b/read-the-docs/source/public_api.rst
@@ -70,16 +70,10 @@ taxcalc.Growfactors
 .. autoclass:: taxcalc.Growfactors
    :members:
 
-taxcalc.macro_elasticity
-------------------------
+taxcalc.Parameters
+------------------
 
-.. automodule:: taxcalc.macro_elasticity
-   :members:
-
-taxcalc.ParametersBase
-----------------------
-
-.. autoclass:: taxcalc.ParametersBase
+.. autoclass:: taxcalc.Parameters
    :members:
    :exclude-members: _update, _indexing_rates_for_update
 

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -479,12 +479,6 @@
       "form": {"2013-2016": "sample construction info"},
       "availability": "taxdata_cps"
     },
-    "filer": {
-      "type": "int",
-      "desc": "Input variable not used in tax-calculation logic; in puf.csv data, filer=1 indicates record is from IRS/SOI PUF and filer=0 indicates record is from CPS",
-      "form": {"2013-2016": "sample construction info"},
-      "availability": "taxdata_puf, taxdata_cps"
-    },
     "fips": {
       "type": "int",
       "desc": "FIPS state code (not used in tax-calculation logic)",

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -481,7 +481,7 @@
     },
     "filer": {
       "type": "int",
-      "desc": "Input variable not used in tax-calculation logic.  In puf.csv data, filer=1 indicates record is from IRS/SOI PUF and filer=0 indicates record is from CPS.",
+      "desc": "Input variable not used in tax-calculation logic; in puf.csv data, filer=1 indicates record is from IRS/SOI PUF and filer=0 indicates record is from CPS",
       "form": {"2013-2016": "sample construction info"},
       "availability": "taxdata_puf, taxdata_cps"
     },

--- a/taxcalc/records_variables.json
+++ b/taxcalc/records_variables.json
@@ -481,7 +481,7 @@
     },
     "filer": {
       "type": "int",
-      "desc": "1 if unit files an income tax return; 0 if not (not used in tax-calculation logic); in the puf.csv file a value of 1 indicates record is from IRS/SOI PUF and 0 indicates record is from CPS",
+      "desc": "Input variable not used in tax-calculation logic.  In puf.csv data, filer=1 indicates record is from IRS/SOI PUF and filer=0 indicates record is from CPS.",
       "form": {"2013-2016": "sample construction info"},
       "availability": "taxdata_puf, taxdata_cps"
     },

--- a/taxcalc/tests/test_cpscsv.py
+++ b/taxcalc/tests/test_cpscsv.py
@@ -107,7 +107,7 @@ def test_cps_availability(tests_path, cps_path):
         if 'taxdata_cps' in vdict.get('availability', ''):
             recvars.add(vname)
     # check that cpsvars and recvars sets are the same
-    assert (cpsvars - recvars) == set()
+    assert (cpsvars - recvars) == set(['filer'])  # TODO: remove filer
     assert (recvars - cpsvars) == set()
 
 

--- a/taxcalc/tests/test_pufcsv.py
+++ b/taxcalc/tests/test_pufcsv.py
@@ -331,7 +331,7 @@ def test_puf_availability(tests_path, puf_path):
         if 'taxdata_puf' in vdict.get('availability', ''):
             recvars.add(vname)
     # check that pufvars and recvars sets are the same
-    assert (pufvars - recvars) == set()
+    assert (pufvars - recvars) == set(['filer'])  # TODO: remove filer
     assert (recvars - pufvars) == set()
 
 


### PR DESCRIPTION
The name of the input variable, `filer`, is misleading because some might think a variable with that name is an output variable that indicates whether or not the unit filed an income tax return in the Tax-Calculator simulation.  This would appear to be what happened in issue #2099, which was raised by one of our most advanced users.

Do people think we should change this variable name in the taxdata and Tax-Calculator repositories?  If so, what should the new variable name be?  Something like `data_source`?  Other ideas?

Can people suggest better `records_variables.json` documentation text than what is proposed in this pull request?

The focus of this pull request has changed as described [here](https://github.com/open-source-economics/Tax-Calculator/pull/2102#issuecomment-436361073) and [here](https://github.com/open-source-economics/taxdata/issues/288).

@MattHJensen @andersonfrailey @hdoupe @evtedeschi3 