### PR TITLE
Simplify constructor of classes that inherit from the Parameters class

### DIFF
--- a/taxcalc/calculator.py
+++ b/taxcalc/calculator.py
@@ -114,7 +114,7 @@ class Calculator():
         if self.__policy.current_year < self.__records.data_year:
             self.__policy.set_year(self.__records.data_year)
         if consumption is None:
-            self.__consumption = Consumption(start_year=policy.start_year)
+            self.__consumption = Consumption()
         elif isinstance(consumption, Consumption):
             self.__consumption = copy.deepcopy(consumption)
         else:

--- a/taxcalc/consumption.py
+++ b/taxcalc/consumption.py
@@ -19,18 +19,7 @@ class Consumption(Parameters):
 
     Parameters
     ----------
-    start_year: integer
-        first calendar year for consumption parameters.
-
-    num_years: integer
-        number of calendar years for which to specify parameter
-        values beginning with start_year.
-
-    Raises
-    ------
-    ValueError:
-        if start_year is less than Policy.JSON_START_YEAR.
-        if num_years is less than one.
+    none
 
     Returns
     -------
@@ -41,15 +30,11 @@ class Consumption(Parameters):
     DEFAULTS_FILENAME = 'consumption.json'
     DEFAULT_NUM_YEARS = Policy.DEFAULT_NUM_YEARS
 
-    def __init__(self,
-                 start_year=JSON_START_YEAR,
-                 num_years=DEFAULT_NUM_YEARS):
+    def __init__(self):
         super(Consumption, self).__init__()
         self._vals = self._params_dict_from_json_file()
-        if start_year < Policy.JSON_START_YEAR:
-            raise ValueError('start_year < Policy.JSON_START_YEAR')
-        if num_years < 1:
-            raise ValueError('num_years < 1')
+        start_year = Consumption.JSON_START_YEAR
+        num_years = Consumption.DEFAULT_NUM_YEARS
         self.initialize(start_year, num_years)
         self.parameter_errors = ''
 

--- a/taxcalc/growdiff.py
+++ b/taxcalc/growdiff.py
@@ -18,18 +18,7 @@ class GrowDiff(Parameters):
 
     Parameters
     ----------
-    start_year: integer
-        first calendar year for growth difference parameters.
-
-    num_years: integer
-        number of calendar years for which to specify parameter
-        values beginning with start_year.
-
-    Raises
-    ------
-    ValueError:
-        if start_year is less than 2013
-        if num_years is less than one.
+    none
 
     Returns
     -------
@@ -40,15 +29,11 @@ class GrowDiff(Parameters):
     DEFAULTS_FILENAME = 'growdiff.json'
     DEFAULT_NUM_YEARS = 15  # must be same as Policy.DEFAULT_NUM_YEARS
 
-    def __init__(self,
-                 start_year=JSON_START_YEAR,
-                 num_years=DEFAULT_NUM_YEARS):
+    def __init__(self):
         super(GrowDiff, self).__init__()
         self._vals = self._params_dict_from_json_file()
-        if start_year < GrowDiff.JSON_START_YEAR:
-            raise ValueError('start_year < GrowDiff.JSON_START_YEAR')
-        if num_years < 1:
-            raise ValueError('num_years < 1')
+        start_year = GrowDiff.JSON_START_YEAR
+        num_years = GrowDiff.DEFAULT_NUM_YEARS
         self.initialize(start_year, num_years)
         self.parameter_errors = ''
 

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -22,7 +22,7 @@ class Parameters():
     DEFAULTS_FILENAME = None
 
     @classmethod
-    def default_data(cls, metadata=False, start_year=None):
+    def default_data(cls, metadata=False):
         """
         Return parameter data read from the subclass's json file.
 
@@ -30,22 +30,12 @@ class Parameters():
         ----------
         metadata: boolean
 
-        start_year: int or None
-
         Returns
         -------
         params: dictionary of data
         """
-        # extract different data from DEFAULT_FILENAME depending on start_year
-        if start_year is None:
-            params = cls._params_dict_from_json_file()
-        else:
-            nyrs = start_year - cls.JSON_START_YEAR + 1
-            ppo = cls(num_years=nyrs)
-            ppo.set_year(start_year)
-            params = getattr(ppo, '_vals')
-            params = Parameters._revised_default_data(params, start_year,
-                                                      nyrs, ppo)
+        # extract data from DEFAULT_FILENAME
+        params = cls._params_dict_from_json_file()
         # return different data from params dict depending on metadata value
         if metadata:
             return params
@@ -315,54 +305,6 @@ class Parameters():
                                                    vvalue[idx]) + '\n'
                         )
         del parameters
-
-    @staticmethod
-    def _revised_default_data(params, start_year, nyrs, ppo):
-        """
-        Return revised default parameter data.
-
-        Parameters
-        ----------
-        params: dictionary of NAME:DATA pairs for each parameter
-            as defined in calling default_data staticmethod.
-
-        start_year: int
-            as defined in calling default_data staticmethod.
-
-        nyrs: int
-            as defined in calling default_data staticmethod.
-
-        ppo: Policy object
-            as defined in calling default_data staticmethod.
-
-        Returns
-        -------
-        params: dictionary of revised parameter data
-
-        Notes
-        -----
-        This staticmethod is called from default_data staticmethod in
-        order to reduce the complexity of the default_data staticmethod.
-        """
-        start_year_str = '{}'.format(start_year)
-        for name, data in params.items():
-            data['start_year'] = start_year
-            values = data['value']
-            num_values = len(values)
-            if num_values <= nyrs:
-                # val should be the single start_year value
-                rawval = getattr(ppo, name[1:])
-                if isinstance(rawval, np.ndarray):
-                    val = rawval.tolist()
-                else:
-                    val = rawval
-                data['value'] = [val]
-                data['row_label'] = [start_year_str]
-            else:  # if num_values > nyrs
-                # val should extend beyond the start_year value
-                data['value'] = data['value'][(nyrs - 1):]
-                data['row_label'] = data['row_label'][(nyrs - 1):]
-        return params
 
     @classmethod
     def _params_dict_from_json_file(cls):

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -23,19 +23,10 @@ class Policy(Parameters):
     gfactors: GrowFactors class instance
         containing price inflation rates and wage growth rates
 
-    start_year: integer
-        first calendar year for historical policy parameters.
-
-    num_years: integer
-        number of calendar years for which to specify policy parameter
-        values beginning with start_year.
-
     Raises
     ------
     ValueError:
-        if gfactors is not a GrowFactors class instance.
-        if start_year is less than JSON_START_YEAR.
-        if num_years is less than one.
+        if gfactors is not a GrowFactors class instance or None.
 
     Returns
     -------
@@ -50,10 +41,7 @@ class Policy(Parameters):
     # should increase LAST_BUDGET_YEAR by one every calendar year
     DEFAULT_NUM_YEARS = LAST_BUDGET_YEAR - JSON_START_YEAR + 1
 
-    def __init__(self,
-                 gfactors=None,
-                 start_year=JSON_START_YEAR,
-                 num_years=DEFAULT_NUM_YEARS):
+    def __init__(self, gfactors=None):
         super(Policy, self).__init__()
 
         if gfactors is None:
@@ -63,21 +51,15 @@ class Policy(Parameters):
         else:
             raise ValueError('gfactors is not None or a GrowFactors instance')
 
-        # read default parameters
+        # read default parameters and initialize
         self._vals = self._params_dict_from_json_file()
-
-        if start_year < Policy.JSON_START_YEAR:
-            raise ValueError('start_year cannot be less than JSON_START_YEAR')
-        if num_years < 1:
-            raise ValueError('num_years cannot be less than one')
-
-        syr = start_year
-        lyr = start_year + num_years - 1
+        syr = Policy.JSON_START_YEAR
+        lyr = Policy.LAST_BUDGET_YEAR
+        nyrs = Policy.DEFAULT_NUM_YEARS
         self._inflation_rates = self._gfactors.price_inflation_rates(syr, lyr)
-        self._apply_clp_cpi_offset(self._vals['_cpi_offset'], num_years)
+        self._apply_clp_cpi_offset(self._vals['_cpi_offset'], nyrs)
         self._wage_growth_rates = self._gfactors.wage_growth_rates(syr, lyr)
-
-        self.initialize(start_year, num_years)
+        self.initialize(syr, nyrs)
 
         self.parameter_warnings = ''
         self.parameter_errors = ''

--- a/taxcalc/tests/test_calculator.py
+++ b/taxcalc/tests/test_calculator.py
@@ -56,17 +56,18 @@ def fixture_policyfile():
 
 
 def test_make_calculator(cps_subsample):
-    syr = 2014
-    pol = Policy(start_year=syr, num_years=9)
-    assert pol.current_year == syr
+    start_year = Policy.JSON_START_YEAR
+    sim_year = 2018
+    pol = Policy()
+    assert pol.current_year == start_year
     rec = Records.cps_constructor(data=cps_subsample)
     consump = Consumption()
-    consump.update_consumption({syr: {'_MPC_e20400': [0.05]}})
-    assert consump.current_year == Consumption.JSON_START_YEAR
+    consump.update_consumption({sim_year: {'_MPC_e20400': [0.05]}})
+    assert consump.current_year == start_year
     calc = Calculator(policy=pol, records=rec,
                       consumption=consump, behavior=Behavior())
-    assert calc.current_year == syr
-    assert calc.records_current_year() == syr
+    assert calc.current_year == Records.CPSCSV_YEAR
+    assert calc.records_current_year() == Records.CPSCSV_YEAR
     # test incorrect Calculator instantiation:
     with pytest.raises(ValueError):
         Calculator(policy=None, records=rec)
@@ -224,8 +225,7 @@ def test_calculator_mtr_when_PT_rates_differ():
 
 def test_make_calculator_increment_years_first(cps_subsample):
     # create Policy object with policy reform
-    syr = 2013
-    pol = Policy(start_year=syr)
+    pol = Policy()
     reform = {2015: {}, 2016: {}}
     std5 = 2000
     reform[2015]['_STD_Aged'] = [[std5, std5, std5, std5, std5]]
@@ -238,6 +238,7 @@ def test_make_calculator_increment_years_first(cps_subsample):
     calc = Calculator(policy=pol, records=rec)
     # compare expected policy parameter values with those embedded in calc
     irates = pol.inflation_rates()
+    syr = Policy.JSON_START_YEAR
     irate2015 = irates[2015 - syr]
     irate2016 = irates[2016 - syr]
     std6 = std5 * (1.0 + irate2015)

--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -7,6 +7,11 @@ import copy
 from taxcalc import Policy, Records, Calculator, Consumption
 
 
+def test_year_consistency():
+    assert Consumption.JSON_START_YEAR == Policy.JSON_START_YEAR
+    assert Consumption.DEFAULT_NUM_YEARS == Policy.DEFAULT_NUM_YEARS
+
+
 def test_validity_of_consumption_vars_set():
     assert Consumption.RESPONSE_VARS.issubset(Records.USABLE_READ_VARS)
     useable_vars = set(['housing', 'snap', 'tanf', 'vet', 'wic',

--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -7,13 +7,6 @@ import copy
 from taxcalc import Policy, Records, Calculator, Consumption
 
 
-def test_incorrect_Consumption_instantiation():
-    with pytest.raises(ValueError):
-        consump = Consumption(start_year=2000)
-    with pytest.raises(ValueError):
-        consump = Consumption(num_years=0)
-
-
 def test_validity_of_consumption_vars_set():
     assert Consumption.RESPONSE_VARS.issubset(Records.USABLE_READ_VARS)
     useable_vars = set(['housing', 'snap', 'tanf', 'vet', 'wic',
@@ -22,7 +15,7 @@ def test_validity_of_consumption_vars_set():
 
 
 def test_update_consumption():
-    consump = Consumption(start_year=2013)
+    consump = Consumption()
     consump.update_consumption({})
     consump.update_consumption({2014: {'_MPC_e20400': [0.05],
                                        '_BEN_mcare_value': [0.75]},


### PR DESCRIPTION
This pull request simplifies the creation of objects for Parameters-based classes (Policy, Consumption, and GrowDiff) by removing the `start_year` and `num_years` arguments.  These changes do not affect the standard use of the these Tax-Calculator classes, but do reduce the chance that the constructors will be misused.
