### PR TITLE
Add deprecated warning to Behavior class constructor and documentation

### DIFF
--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -18,6 +18,10 @@ class Behavior(Parameters):
 
     Constructor for elasticity-based behavioral-response class.
 
+    WARNING: the Behavior class is deprecated and will be removed soon.
+    FUTURE: use the Behavioral-Responses behresp package OR
+            use the Tax-Calculator quantity_response function.
+
     Parameters
     ----------
     start_year: integer
@@ -45,6 +49,10 @@ class Behavior(Parameters):
     def __init__(self,
                  start_year=JSON_START_YEAR,
                  num_years=DEFAULT_NUM_YEARS):
+        print(('WARNING: the Behavior class is deprecated '
+               'and will be removed soon.'))
+        print('FUTURE: use the Behavioral-Responses behresp package OR')
+        print('        use the Tax-Calculator quantity_response function.')
         super(Behavior, self).__init__()
         self._vals = self._params_dict_from_json_file()
         if start_year < Policy.JSON_START_YEAR:


### PR DESCRIPTION
This pull request adds a warning message about the future removal of the Tax-Calculator `Behavior` class to the API documentation and to the class constructor.  The message suggests using either the [Behavioral-Responses](https://github.com/open-source-economics/Behavioral-Responses) `behresp` package (for the exact same capabilities) or the Tax-Calculator `quantity_response` utility function (for the ability to assume that elasticities vary across groups).