### PR TITLE
Replace Parameters.default_data(...) with Policy.metadata()

### DIFF
--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -256,9 +256,9 @@ def iterate_jit(parameters=None, **kwargs):
         # Any name that is a parameter
         # Boolean flag is given special treatment.
         # Identify those names here
-        dd_key_list = list(Policy.default_data(metadata=True).keys())
-        allowed_parameters = dd_key_list
-        allowed_parameters += list(arg[1:] for arg in dd_key_list)
+        param_list = Policy.parameter_list()
+        allowed_parameters = param_list
+        allowed_parameters += list(arg[1:] for arg in param_list)
         additional_parameters = [arg for arg in in_args if
                                  arg in allowed_parameters]
         additional_parameters += parameters

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -13,34 +13,13 @@ from taxcalc.utils import read_egg_json, json_to_dict
 
 class Parameters():
     """
-    Inherit from this class for Policy, Behavior, Consumption, GrowDiff, and
+    Inherit from this class for Policy, Consumption, GrowDiff, and
     other groups of parameters that need to have a set_year method.
     Override this __init__ method and DEFAULTS_FILENAME.
     """
     __metaclass__ = abc.ABCMeta
 
     DEFAULTS_FILENAME = None
-
-    @classmethod
-    def default_data(cls, metadata=False):
-        """
-        Return parameter data read from the subclass's json file.
-
-        Parameters
-        ----------
-        metadata: boolean
-
-        Returns
-        -------
-        params: dictionary of data
-        """
-        # extract data from DEFAULT_FILENAME
-        params = cls._params_dict_from_json_file()
-        # return different data from params dict depending on metadata value
-        if metadata:
-            return params
-        else:
-            return {name: data['value'] for name, data in params.items()}
 
     def __init__(self):
         pass
@@ -150,9 +129,9 @@ class Parameters():
         -----
         To increment the current year, use the following statement::
 
-            behavior.set_year(behavior.current_year + 1)
+            policy.set_year(policy.current_year + 1)
 
-        where, in this example, behavior is a Behavior object.
+        where, in this example, policy is a Policy class object.
         """
         if year < self.start_year or year > self.end_year:
             msg = 'year {} passed to set_year() must be in [{},{}] range.'

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -5,6 +5,7 @@ Tax-Calculator federal tax policy Policy class.
 # pycodestyle policy.py
 # pylint --disable=locally-disabled policy.py
 
+import collections
 import numpy as np
 from taxcalc.parameters import Parameters
 from taxcalc.growfactors import GrowFactors
@@ -333,6 +334,37 @@ class Policy(Parameters):
         Sets self._ignore_errors to True.
         """
         self._ignore_errors = True
+
+    def metadata(self):
+        """
+        Returns ordered dictionary of parameter information based on
+        the contents of the policy_current_law.json file with updates
+        to each parameter's 'start_year', 'row_label', and 'value' key
+        values so that the updated values contain just the current_year
+        information for this instance of the Policy class.
+        """
+        mdata = collections.OrderedDict()
+        for pname, pdata in self._vals.items():
+            mdata[pname] = pdata
+            mdata[pname]['row_label'] = ['{}'.format(self.current_year)]
+            mdata[pname]['start_year'] = '{}'.format(self.current_year)
+            valraw = getattr(self, pname[1:])
+            if isinstance(valraw, np.ndarray):
+                val = valraw.tolist()
+            else:
+                val = valraw
+            mdata[pname]['value'] = [val]
+        return mdata
+
+    @staticmethod
+    def parameter_list():
+        """
+        Returns list of parameter names in the policy_current_law.json file.
+        """
+        pdict = Policy._params_dict_from_json_file()
+        plist = pdict.keys()
+        del pdict
+        return plist
 
     # ----- begin private methods of Policy class -----
 

--- a/taxcalc/policy.py
+++ b/taxcalc/policy.py
@@ -362,7 +362,7 @@ class Policy(Parameters):
         Returns list of parameter names in the policy_current_law.json file.
         """
         pdict = Policy._params_dict_from_json_file()
-        plist = pdict.keys()
+        plist = list(pdict.keys())
         del pdict
         return plist
 

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -173,13 +173,6 @@ def test_future_update_behavior():
     assert behv.has_any_response() is True
 
 
-def test_behavior_default_data():
-    paramdata = Behavior.default_data()
-    assert paramdata['_BE_inc'] == [0.0]
-    assert paramdata['_BE_sub'] == [0.0]
-    assert paramdata['_BE_cg'] == [0.0]
-
-
 def test_boolean_value_infomation(tests_path):
     """
     Check consistency of boolean_value in behavior.json file.

--- a/taxcalc/tests/test_compatible_data.py
+++ b/taxcalc/tests/test_compatible_data.py
@@ -18,9 +18,10 @@ from taxcalc import Policy, Records, Calculator  # pylint: disable=import-error
 @pytest.fixture(scope='module', name='allparams')
 def fixture_allparams():
     """
-    Return metadata for current law parameters
+    Return metadata for current-law policy parameters.
     """
-    return Policy.default_data(metadata=True)
+    clp = Policy()
+    return clp.metadata()
 
 
 def test_compatible_data_presence(allparams):
@@ -135,7 +136,7 @@ def fixture_sorted_param_names(allparams):
     return sorted(list(allparams.keys()))
 
 
-NPARAMS = len(Policy.default_data())
+NPARAMS = 218  # hard-code NPARAMS to len(allparams)
 BATCHSIZE = 10
 BATCHES = int(np.floor(NPARAMS / BATCHSIZE)) + 1
 
@@ -229,6 +230,9 @@ def test_compatible_data(cps_subsample, puf_subsample,
     """
     # pylint: disable=too-many-arguments,too-many-locals
     # pylint: disable=too-many-statements,too-many-branches
+
+    # Check NPARAMS value
+    assert NPARAMS == len(allparams)
 
     # Get taxcalc objects from tc_objs fixture
     rec_xx, c_xx, puftest = tc_objs

--- a/taxcalc/tests/test_consumption.py
+++ b/taxcalc/tests/test_consumption.py
@@ -91,12 +91,13 @@ def test_future_update_consumption():
 
 
 def test_consumption_default_data():
-    paramdata = Consumption.default_data()
-    for param in paramdata:
-        if param.startswith('_MPC'):
-            assert paramdata[param] == [0.0]
-        elif param.startswith('_BEN'):
-            assert paramdata[param] == [1.0]
+    consump = Consumption()
+    pdata = consump._vals
+    for pname in pdata.keys():
+        if pname.startswith('_MPC'):
+            assert pdata[pname]['value'] == [0.0]
+        elif pname.startswith('_BEN'):
+            assert pdata[pname]['value'] == [1.0]
 
 
 def test_consumption_response(cps_subsample):

--- a/taxcalc/tests/test_growmodel.py
+++ b/taxcalc/tests/test_growmodel.py
@@ -98,11 +98,6 @@ def test_future_update_growmodel():
 """
 
 
-def test_growmodel_default_data():
-    paramdata = GrowModel.default_data()
-    assert paramdata['_active'] == [False]
-
-
 def test_boolean_value_infomation(tests_path):
     """
     Check consistency of boolean_value in growmodel.json file.

--- a/taxcalc/tests/test_policy.py
+++ b/taxcalc/tests/test_policy.py
@@ -366,9 +366,10 @@ def test_create_parameters_from_file(monkeypatch, defaultpolicyfile):
                        atol=0.01, rtol=0.0)
 
 
-def test_parameters_get_default():
-    paramdata = Policy.default_data()
-    assert paramdata['_CDCC_ps'] == [15000]
+def test_policy_metadata():
+    clp = Policy()
+    mdata = clp.metadata()
+    assert mdata['_CDCC_ps']['value'] == [15000]
 
 
 def test_implement_reform_Policy_raises_on_no_year():
@@ -422,31 +423,6 @@ def test_Policy_reform_makes_no_changes_before_year():
     assert np.allclose(ppo._II_em[:3], np.array([3900, 3950, 4400]),
                        atol=0.01, rtol=0.0)
     assert ppo.II_em == 4400
-
-
-def test_parameters_get_default_data():
-    paramdata = Policy.default_data(metadata=True)
-    # 1D data, has 2013+ values
-    meta_II_em = paramdata['_II_em']
-    assert meta_II_em['start_year'] == 2013
-    assert meta_II_em['row_label'] == [str(cyr) for cyr in range(2013, 2027)]
-    expval = [3900, 3950, 4000, 4050, 4050] + [0] * 8 + [4883]
-    assert meta_II_em['value'] == expval
-    # 2D data, has 2013+ values
-    meta_std_aged = paramdata['_STD_Aged']
-    assert meta_std_aged['start_year'] == 2013
-    explabels = ['2013', '2014', '2015', '2016', '2017']
-    assert meta_std_aged['row_label'] == explabels
-    assert meta_std_aged['value'] == [[1500, 1200, 1200, 1500, 1500],
-                                      [1550, 1200, 1200, 1550, 1550],
-                                      [1550, 1250, 1250, 1550, 1550],
-                                      [1550, 1250, 1250, 1550, 1550],
-                                      [1550, 1250, 1250, 1550, 1550]]
-    # 1D data, has only 2013 values because is not CPI inflated
-    meta_kt_c_age = paramdata['_AMT_KT_c_Age']
-    assert meta_kt_c_age['start_year'] == 2013
-    assert meta_kt_c_age['row_label'] == ['2013']
-    assert meta_kt_c_age['value'] == [24]
 
 
 REFORM_CONTENTS = """


### PR DESCRIPTION
This pull request removes the `Parameters.default_data` static method because in the discussion of issue #2115 that method was found to return misleading data.  See that [issue discussion](https://github.com/open-source-economics/Tax-Calculator/issues/2115#issuecomment-439651960) for more details on the problems with the old `Parameters.default_data` static method.

This pull request also adds a new `Policy.metadata()` method that avoids these problems.  Using the new method is easy.  Consider the example of getting a dictionary of metadata for policy parameters in 2017.  Using the old `Parameters.default_data` static method involved doing this:
```
mdata_old = Policy.default_data(metadata=True, start_year=2017)
```
Using the new code introduced in this pull request involves doing this:
```
clp = Policy()
clp.set_year(2017)
mdata_new = clp.metadata()
```
The information in `mdata_new` is the same as in `mdata_old` except that the problems with the values of the `row_label` and `value` keys in `mdata_old` are fixed in `mdata_new`.

The Tax-Calculator developers are aware of no sensible use of policy parameter metadata except by TaxBrain, the Tax-Calculator webapp.  So, the API changes in this pull request are of interest only to TaxBrain developers.

@MattHJensen @hdoupe 

