### PR TITLE
Allow Records constructor to accept a Pandas DataFrame as an adjust_ratios argument

### DIFF
--- a/taxcalc/growfactors.py
+++ b/taxcalc/growfactors.py
@@ -53,12 +53,13 @@ class GrowFactors():
         # read grow factors from specified growfactors_filename
         gfdf = pd.DataFrame()
         if isinstance(growfactors_filename, str):
+            assert os.path.isabs(growfactors_filename)
             if os.path.isfile(growfactors_filename):
                 gfdf = pd.read_csv(growfactors_filename,
                                    index_col='YEAR')
             else:
                 # cannot call read_egg_ function in unit tests
-                gfdf = read_egg_csv(GrowFactors.FILENAME,
+                gfdf = read_egg_csv(os.path.basename(growfactors_filename),
                                     index_col='YEAR')  # pragma: no cover
         else:
             raise ValueError('growfactors_filename is not a string')

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -37,11 +37,13 @@ def test_correct_Records_instantiation(cps_subsample):
     assert sum_e00200_in_cps_year_plus_one == sum_e00200_in_cps_year
     wghts_path = os.path.join(Records.CUR_PATH, Records.CPS_WEIGHTS_FILENAME)
     wghts_df = pd.read_csv(wghts_path)
+    ratios_path = os.path.join(Records.CUR_PATH, Records.PUF_RATIOS_FILENAME)
+    ratios_df = pd.read_csv(ratios_path, index_col=0).transpose()
     rec2 = Records(data=cps_subsample,
                    exact_calculations=False,
                    gfactors=GrowFactors(),
                    weights=wghts_df,
-                   adjust_ratios=None,
+                   adjust_ratios=ratios_df,
                    start_year=Records.CPSCSV_YEAR)
     assert rec2
     assert np.all(rec2.MARS != 0)


### PR DESCRIPTION
This pull request resolves a problem reported by @andersonfrailey in issue #2120 by allowing the Records class constructor to accept a Pandas DataFrame as its `adjust_ratios` argument.  This brings the `adjust_ratios` argument into line with the other arguments of the Records class constructor.  The problem reported in #2120 stems from the fact that for the growfactors, weights, and ratios, filenames must be expressed as an absolute (not a relative) path.  By allowing `adjust_ratios` to be specified as a DataFrame, the Pandas.read_csv() method (which does allow the use of relative paths) can be used to simplify Python code.  The alternative is to specify the absolute path of the file containing the adjustment ratios as shown in this [issue 2120 comment](https://github.com/open-source-economics/Tax-Calculator/issues/2120#issuecomment-440081423).
