### PR TITLE
Fix bug introduced in pull request 1542

### DIFF
--- a/taxcalc/calcfunctions.py
+++ b/taxcalc/calcfunctions.py
@@ -486,10 +486,8 @@ def ItemDedCap(e17500, e18400, e18500, e19200, e19800, e20100, e20400, g20500,
         gross_ded_amt += e20400
     if ID_AmountCap_Switch[5]:  # interest
         gross_ded_amt += e19200
-    if ID_AmountCap_Switch[6]:  # charitycash
+    if ID_AmountCap_Switch[6]:  # charity
         gross_ded_amt += e19800 + e20100
-    if ID_AmountCap_Switch[7]:  # charitynoncash
-        gross_ded_amt += e20100
 
     overage = max(0., gross_ded_amt - cap)
 


### PR DESCRIPTION
This pull request fixes a bug introduced in PR #1542, which was merged into the master branch on 2017-Sep-07.  Bugs get introduced all the time when developers add new reform capabilities (as #1542 did).  But usually these bugs are detected immediately by the test suite.  But that did not happen in this case.  The apparent reason is that the complex decorator logic applied to most of the `calcfunctions.py` code suppressed this bug (referencing `ID_AmountCap_Switch[7]` when it is not defined).  It was discovered immediately (by a Python interpreter crash) when I tried to use the Python debugger and deactivated the `jit_iterate` decorator by setting `DO_JIT = False` in the `decorators.py` code.  This is a worrisome discovery.  Apparently, the decorator logic used on many of the `calcfunctions.py` functions in order to make function execution fast also suppresses errors.