### PR TITLE
Add Makefile target that runs no-jit test of calcfunctions.py functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ help:
 	@echo "             pytest -m ''"
 	@echo "tctest     : generate report for and cleanup after"
 	@echo "             tc --test"
+	@echo "tctest-jit : generate report for and cleanup after"
+	@echo "             tc --test when environment var NOTAXCALCJIT is set"
 	@echo "cstest     : generate coding-style errors using the"
 	@echo "             pycodestyle (nee pep8) and pylint tools"
 	@echo "coverage   : generate test coverage report"
@@ -67,7 +69,11 @@ endef
 tctest: package
 	tc --test
 	@$(tctest-cleanup)
-	@echo "validation tests using tc will be added in the future"
+
+.PHONY=tctest-jit
+tctest-jit:
+	@./tctest-nojit.sh
+	@$(tctest-cleanup)
 
 TOPLEVEL_JSON_FILES := $(shell ls -l ./*json | awk '{print $$9}')
 TAXCALC_JSON_FILES := $(shell ls -l ./taxcalc/*json | awk '{print $$9}')

--- a/tctest-nojit.sh
+++ b/tctest-nojit.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export NOTAXCALCJIT="NOJIT"
+make tctest

--- a/tctest-nojit.sh
+++ b/tctest-nojit.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 export NOTAXCALCJIT="NOJIT"
 make tctest
+make clean


### PR DESCRIPTION
This pull request adds a test of `calcfunctions.py` functions when the JIT decorator logic is turned off.  This new high-level test is executed with `make tctest-jit` which does the same thing as `make tctest` except that the `taxcalc` package containing the `tc` command-line interface is constructed with the JIT decorator logic turned off.  As discussed in #2139 and #2143, the JIT decorator logic masks bugs in the `calcfunctions.py` functions.  The new test has been added to expose those bugs.

Here are some results that demonstrate the behavior of `make tctest` and `make tctest-jit` in the presence of a bug in one of the `calcfunctions.py` functions: the `tc --test` command **passes** when the JIT decorator logic masks the bug while the `tc --test` command **fails** when the JIT decorator logic is turned off.
```
$ make tctest
STARTING : Mon Dec  3 11:46:04 EST 2018
BUILD-PREP...
BUILD START: ['taxcalc-0.0.0-py36_0.tar.bz2']
TEST START: /Users/mrh/anaconda3/conda-bld/osx-64/taxcalc-0.0.0-py36_0.tar.bz2
TEST END: /Users/mrh/anaconda3/conda-bld/osx-64/taxcalc-0.0.0-py36_0.tar.bz2
INSTALLATION...
CLEAN-UP...
FINISHED : Mon Dec  3 11:48:06 EST 2018
tc --test
WARNING: the Behavior class is deprecated and will be removed soon.
FUTURE: use the Behavioral-Responses behresp package OR
        use the Tax-Calculator quantity_response function.
WARNING: the Behavior class is deprecated and will be removed soon.
FUTURE: use the Behavioral-Responses behresp package OR
        use the Tax-Calculator quantity_response function.
PASSED TEST

$ make tctest-jit
STARTING : Mon Dec  3 11:48:49 EST 2018
BUILD-PREP...
BUILD START: ['taxcalc-0.0.0-py36_0.tar.bz2']
TEST START: /Users/mrh/anaconda3/conda-bld/osx-64/taxcalc-0.0.0-py36_0.tar.bz2
TEST END: /Users/mrh/anaconda3/conda-bld/osx-64/taxcalc-0.0.0-py36_0.tar.bz2
INSTALLATION...
CLEAN-UP...
FINISHED : Mon Dec  3 11:50:25 EST 2018
tc --test
WARNING: the Behavior class is deprecated and will be removed soon.
FUTURE: use the Behavioral-Responses behresp package OR
        use the Tax-Calculator quantity_response function.
WARNING: the Behavior class is deprecated and will be removed soon.
FUTURE: use the Behavioral-Responses behresp package OR
        use the Tax-Calculator quantity_response function.
Traceback (most recent call last):
  File "/Users/mrh/anaconda3/bin/tc", line 11, in <module>
    sys.exit(cli_tc_main())
  File "/Users/mrh/anaconda3/lib/python3.6/site-packages/taxcalc/cli/tc.py", line 203, in cli_tc_main
    output_sqldb=args.sqldb)
  File "/Users/mrh/anaconda3/lib/python3.6/site-packages/taxcalc/taxcalcio.py", line 470, in analyze
    self.calc.calc_all()
  File "/Users/mrh/anaconda3/lib/python3.6/site-packages/taxcalc/calculator.py", line 184, in calc_all
    self._calc_one_year(zero_out_calc_vars)
  File "/Users/mrh/anaconda3/lib/python3.6/site-packages/taxcalc/calculator.py", line 1490, in _calc_one_year
    ItemDedCap(self.__policy, self.__records)
  File "/Users/mrh/anaconda3/lib/python3.6/site-packages/taxcalc/decorators.py", line 314, in wrapper
    ans = high_level_fn(*args, **kwargs)
  File "<string>", line 12, in hl_func
  File "/Users/mrh/anaconda3/lib/python3.6/site-packages/taxcalc/decorators.py", line 38, in wrapped_f
    return fnc(*args, **kwargs)
  File "<string>", line 3, in ap_func
  File "/Users/mrh/anaconda3/lib/python3.6/site-packages/taxcalc/decorators.py", line 38, in wrapped_f
    return fnc(*args, **kwargs)
  File "/Users/mrh/anaconda3/lib/python3.6/site-packages/taxcalc/calcfunctions.py", line 491, in ItemDedCap
    if ID_AmountCap_Switch[7]:  # charitynoncash
IndexError: index 7 is out of bounds for axis 0 with size 7
make[1]: *** [tctest] Error 1
make: *** [tctest-jit] Error 2
```
