### PR TITLE
Remove toolz dependency using basic Python code

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,7 +13,6 @@ requirements:
     - "pandas>=0.23"
     - "bokeh>=0.13"
     - numba
-    - toolz
 
   run:
     - python=3.6
@@ -21,7 +20,6 @@ requirements:
     - "pandas>=0.23"
     - "bokeh>=0.13"
     - numba
-    - toolz
 
 test:
   commands:

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ dependencies:
 - "pandas>=0.23"
 - "bokeh>=0.13"
 - numba
-- toolz
 - pytest
 - pytest-pep8
 - pytest-xdist

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -11,7 +11,6 @@ import io
 import ast
 import inspect
 import numba
-import toolz
 from taxcalc.policy import Policy
 
 
@@ -249,11 +248,15 @@ def iterate_jit(parameters=None, **kwargs):
         make_wrapper function nested in iterate_jit decorator
         wraps specified func using apply_jit.
         """
+        # pylint: disable=too-many-locals
         # Get the input arguments from the function
         in_args = inspect.getfullargspec(func).args
         # Get the numba.jit arguments
-        jit_args = inspect.getfullargspec(JIT).args + ['nopython']
-        kwargs_for_jit = toolz.keyfilter(jit_args.__contains__, kwargs)
+        jit_args_list = inspect.getfullargspec(JIT).args + ['nopython']
+        kwargs_for_jit = dict()
+        for key, val in kwargs.items():
+            if key in jit_args_list:
+                kwargs_for_jit[key] = val
 
         # Any name that is a parameter
         # Boolean flag is given special treatment.


### PR DESCRIPTION
This pull request eliminates the Tax-Calculator dependency on the `toolz` package by replacing the one call to a `toolz` function with a few lines of basic Python code.