### PR TITLE
Allow use of Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.7"
+  - "3.6"
 
 install:
   # Install conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
 
 install:
   # Install conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "3.6"
-  - "3.7"
 
 install:
   # Install conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.6"
+  - "3.7"
 
 install:
   # Install conda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,19 +11,19 @@ environment:
 
   matrix:
     # Since appveyor is quite slow, we only use a single configuration
-    - PYTHON: "3.6"
+    - PYTHON: "3.7"
       ARCH: "64"
       CONDA_ENV: taxcalc-dev
 
 init:
   # Use AppVeyor's provided Miniconda, which is available from
   # https://www.appveyor.com/docs/installed-software#python
-  - if "%ARCH%" == "64" set MINICONDA=C:\Miniconda36-x64
-  - if "%ARCH%" == "32" set MINICONDA=C:\Miniconda36
+  - if "%ARCH%" == "64" set MINICONDA=C:\Miniconda37-x64
+  - if "%ARCH%" == "32" set MINICONDA=C:\Miniconda37
   - set PATH=%MINICONDA%;%MINICONDA%/Scripts;%MINICONDA%/Library/bin;%PATH%
 
 install:
-  # Update to a recent version of conda that is consistent with Python 3.6
+  # Update to a recent version of conda that is consistent with Python 3.6+
   - conda install -q -y conda>=4.3.0
   - continuous_integration\\setup_conda_environment.cmd
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,14 +8,14 @@ build:
 
 requirements:
   build:
-    - python=3.6
+    - "python>=3.6"
     - "numpy>=1.13"
     - "pandas>=0.23"
     - "bokeh>=0.13"
     - numba
 
   run:
-    - python=3.6
+    - "python>=3.6"
     - "numpy>=1.13"
     - "pandas>=0.23"
     - "bokeh>=0.13"

--- a/docs/cookbook.html
+++ b/docs/cookbook.html
@@ -15,8 +15,8 @@ Tax-Calculator</h1>
 <p>This document tells you how to use Tax-Calculator, an open-source
 federal income and payroll tax simulation model, in Python scripts
 that you can run on your own computer.  Note that these recipes
-require Tax-Calculator release 0.23.2 or higher running on Python 3.6.
-For other ways of using Tax-Calculator, see the
+require Tax-Calculator release 0.23.2 or higher running on Python 3.7
+(or 3.6).  For other ways of using Tax-Calculator, see the
 <a href="https://open-source-economics.github.io/Tax-Calculator/">
 user documentation</a>, which this Cookbook assumes you have read.</p>
 

--- a/docs/index.htmx
+++ b/docs/index.htmx
@@ -216,10 +216,10 @@ files to TaxBrain.</p>
 <p>Installation of tc CLI involves several steps:</p>
 
 <p><b>Install the free Anaconda Python distribution</b> by going to
-the <a href="https://www.continuum.io/downloads">Continuum Analytics
-download page</a> and selecting a version of Python.  You should install
-Python 3.6 because we will be forced to discontinue support for Python
-2.7 at the end of 2018.  You must do this installation even if you already
+the <a href="https://www.anaconda.com/download/">Anaconda download
+page</a> and selecting a version of Python.  You should install Python
+3.7 (or 3.6) because we have discontinued support for Python 2.7.  You
+must do this installation even if you already
 have Python installed on your computer because the Anaconda
 distribution contains all the additional Python packages that
 Tax-Calculator uses to conduct tax calculations (many of which are not
@@ -236,7 +236,7 @@ in any directory:
 <pre>$ conda --version</pre>
 Expected output is something like <kbd>conda 4.4.7</kbd>
 <pre>$ python --version</pre>
-Expected output should contain the <kbd>Python 3.6</kbd> phrase as
+Expected output should contain the <kbd>Python 3.7</kbd> phrase as
 well as the <kbd>Anaconda</kbd> phrase, the presence of which confirm
 that the installation went smoothly.</p>
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: taxcalc-dev
 dependencies:
-- python=3.6
+- "python>=3.6"
 - "numpy>=1.13"
 - "pandas>=0.23"
 - "bokeh>=0.13"

--- a/read-the-docs/requirements-docs.txt
+++ b/read-the-docs/requirements-docs.txt
@@ -4,9 +4,8 @@
 mock  # used to mock numba dependency
 numpy
 pandas
+bokeh
 numba
-six
-toolz
 
 # for ReadTheDocs
 sphinx>=1.3

--- a/read-the-docs/source/contributor_guide.rst
+++ b/read-the-docs/source/contributor_guide.rst
@@ -18,8 +18,8 @@ Setup Python
 -------------
 
 The Tax-Calculator is written in the Python programming language.
-Download and install the free Anaconda distribution of Python 3.6 from
-`Continuum Analytics`_.  You must do this even if you already have
+Download and install the free Anaconda distribution of Python 3.7 (or
+3.6) from `Anaconda`_.  You must do this even if you already have
 Python installed on your computer because the Anaconda distribution
 contains all the additional Python packages that we use to conduct tax
 calculations (many of which are not included in other Python
@@ -270,8 +270,8 @@ interpreter or imported into a Python notebook for interactive execution.
 .. _`Github Flow`:
    https://guides.github.com/introduction/flow/
 
-.. _`Continuum Analytics`:
-   http://www.continuum.io/downloads
+.. _`Anaconda`:
+   https://www.anaconda.com/download/
 
 .. _`remote`:
    https://help.github.com/articles/github-glossary/#remote

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ config = {
     'packages': ['taxcalc', 'taxcalc.tbi', 'taxcalc.cli'],
     'include_package_data': True,
     'name': 'taxcalc',
-    'install_requires': ['numpy', 'pandas', 'bokeh', 'numba', 'toolz'],
+    'install_requires': ['numpy', 'pandas', 'bokeh', 'numba'],
     'classifiers': [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -29,6 +29,7 @@ config = {
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules'],
     'tests_require': ['pytest']
 }


### PR DESCRIPTION
This pull request makes configuration and documentation changes that have the goal of allowing Tax-Calculator to run under Python 3.7 as well as Python 3.6.