### PR TITLE
Add taxcalc/validation/taxsim/taxdiffs4one.sh bash script

### DIFF
--- a/taxcalc/validation/taxsim/taxcalc.sh
+++ b/taxcalc/validation/taxsim/taxcalc.sh
@@ -8,7 +8,7 @@
 # ... check command-line arguments
 if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
     echo "ERROR: number of command-line arguments not in 1-to-2 range"
-    echo "USAGE: /taxcalc.sh LYY_FILENAME [save]"
+    echo "USAGE: ./taxcalc.sh LYY_FILENAME [save]"
     echo "       WHERE L is a letter that is valid taxsim_input.py L input and"
     echo "             YY is valid taxsim_input.py YEAR (20YY) input;"
     echo "       WHERE the 'save' option skips the deletion of intermediate"

--- a/taxcalc/validation/taxsim/taxdiffs4one.sh
+++ b/taxcalc/validation/taxsim/taxdiffs4one.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Compute tax differences for a single filing unit.
+#
+# USAGE: ./taxdiffs4one.sh RECID OUT-TAXCALC OUT-TAXSIM
+#
+# check command-line arguments
+if [[ "$#" -ne 3 ]]; then
+    echo "ERROR: number of command-line arguments not equal to three"
+    echo "USAGE: ./taxdiffs4one.sh RECID OUT-TAXCALC OUT-TAXSIM"
+    exit 1
+fi
+awk -v ID=$1 '$1==ID' $2 > tmpfile1
+echo
+cat tmpfile1
+awk -v ID=$1 '$1==ID' $3 > tmpfile2
+echo
+cat tmpfile2
+echo
+tclsh taxdiffs.tcl tmpfile1 tmpfile2
+rm tmpfile1 tmpfile2
+exit 0


### PR DESCRIPTION
Helpful utility allows quick checking of Tax-Calculator versus TAXSIM-27 differences for a single filing unit.